### PR TITLE
feat: implement JSONC loader with comment stripping and atomic write

### DIFF
--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Load reads a JSONC file, strips comments and trailing commas, and parses it.
+func Load(path string) (*BausteinsichtModel, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	clean := StripJSONC(data)
+	var m BausteinsichtModel
+	if err := json.Unmarshal(clean, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// Save marshals the model and atomically writes it to path.
+func Save(path string, model *BausteinsichtModel) error {
+	data, err := json.MarshalIndent(model, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling model: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
+// AutoDetect finds the first *.jsonc file in dir.
+func AutoDetect(dir string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.jsonc"))
+	if err != nil {
+		return "", fmt.Errorf("scanning %s: %w", dir, err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no .jsonc file found in %s", dir)
+	}
+	return matches[0], nil
+}
+
+// StripJSONC removes single-line comments and trailing commas from JSONC data.
+// Comments inside strings are preserved.
+func StripJSONC(data []byte) []byte {
+	var sb strings.Builder
+	src := string(data)
+	i := 0
+	for i < len(src) {
+		// Handle string literals — skip their content intact
+		if src[i] == '"' {
+			sb.WriteByte(src[i])
+			i++
+			for i < len(src) {
+				if src[i] == '\\' && i+1 < len(src) {
+					sb.WriteByte(src[i])
+					sb.WriteByte(src[i+1])
+					i += 2
+					continue
+				}
+				sb.WriteByte(src[i])
+				if src[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+		// Handle single-line comments
+		if i+1 < len(src) && src[i] == '/' && src[i+1] == '/' {
+			// Trim trailing whitespace written before the comment
+			s := sb.String()
+			trimmed := strings.TrimRight(s, " \t")
+			sb.Reset()
+			sb.WriteString(trimmed)
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		sb.WriteByte(src[i])
+		i++
+	}
+
+	// Remove trailing commas before } or ]
+	result := trailingCommaRe.ReplaceAllString(sb.String(), "$1")
+	return []byte(result)
+}
+
+// trailingCommaRe matches a comma optionally followed by whitespace before } or ]
+var trailingCommaRe = regexp.MustCompile(`,(\s*[}\]])`)

--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -34,7 +34,7 @@ func Save(path string, model *BausteinsichtModel) error {
 		return fmt.Errorf("writing temp file: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
-		os.Remove(tmp)
+		_ = os.Remove(tmp)
 		return fmt.Errorf("renaming temp file: %w", err)
 	}
 	return nil

--- a/internal/model/loader_test.go
+++ b/internal/model/loader_test.go
@@ -1,0 +1,161 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_ValidModelWithComments(t *testing.T) {
+	m, err := Load("testdata/valid-model.jsonc")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if m.Specification.Elements["system"].Notation != "System" {
+		t.Errorf("expected element notation 'System', got '%s'", m.Specification.Elements["system"].Notation)
+	}
+	if m.Model["mySystem"].Title != "My System" {
+		t.Errorf("expected title 'My System', got '%s'", m.Model["mySystem"].Title)
+	}
+}
+
+func TestLoad_ValidModelWithTrailingCommas(t *testing.T) {
+	m, err := Load("testdata/valid-model.jsonc")
+	if err != nil {
+		t.Fatalf("expected no error loading model with trailing commas, got: %v", err)
+	}
+	if len(m.Model) != 2 {
+		t.Errorf("expected 2 model elements, got %d", len(m.Model))
+	}
+}
+
+func TestLoad_MinimalModel(t *testing.T) {
+	m, err := Load("testdata/minimal-model.jsonc")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(m.Specification.Elements) != 1 {
+		t.Errorf("expected 1 element kind, got %d", len(m.Specification.Elements))
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load("testdata/nonexistent.jsonc")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	_, err := Load("testdata/invalid-json.jsonc")
+	if err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestSave_RoundTrip(t *testing.T) {
+	original, err := Load("testdata/minimal-model.jsonc")
+	if err != nil {
+		t.Fatalf("failed to load original: %v", err)
+	}
+
+	tmp := filepath.Join(t.TempDir(), "model.jsonc")
+	if err := Save(tmp, original); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	reloaded, err := Load(tmp)
+	if err != nil {
+		t.Fatalf("failed to reload: %v", err)
+	}
+	if reloaded.Model["root"].Title != original.Model["root"].Title {
+		t.Errorf("round-trip mismatch: expected '%s', got '%s'", original.Model["root"].Title, reloaded.Model["root"].Title)
+	}
+}
+
+func TestSave_AtomicWrite(t *testing.T) {
+	original, err := Load("testdata/minimal-model.jsonc")
+	if err != nil {
+		t.Fatalf("failed to load: %v", err)
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "model.jsonc")
+	if err := Save(target, original); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	// Temp file should have been cleaned up
+	tmpFile := target + ".tmp"
+	if _, err := os.Stat(tmpFile); !os.IsNotExist(err) {
+		t.Error("expected .tmp file to be removed after atomic write")
+	}
+}
+
+func TestAutoDetect_FindsJSONCFile(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "model.jsonc")
+
+	original, err := Load("testdata/minimal-model.jsonc")
+	if err != nil {
+		t.Fatalf("failed to load: %v", err)
+	}
+	if err := Save(target, original); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	found, err := AutoDetect(dir)
+	if err != nil {
+		t.Fatalf("expected to find .jsonc file, got error: %v", err)
+	}
+	if found != target {
+		t.Errorf("expected '%s', got '%s'", target, found)
+	}
+}
+
+func TestAutoDetect_NoJSONCFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := AutoDetect(dir)
+	if err == nil {
+		t.Error("expected error when no .jsonc file found")
+	}
+}
+
+func TestStripJSONC_RemovesLineComments(t *testing.T) {
+	input := []byte(`{
+  "key": "value" // comment
+}`)
+	out := StripJSONC(input)
+	expected := `{
+  "key": "value"
+}`
+	if string(out) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(out))
+	}
+}
+
+func TestStripJSONC_PreservesCommentInString(t *testing.T) {
+	input := []byte(`{"key": "value // not a comment"}`)
+	out := StripJSONC(input)
+	if string(out) != `{"key": "value // not a comment"}` {
+		t.Errorf("comment inside string should not be stripped, got: %s", string(out))
+	}
+}
+
+func TestStripJSONC_RemovesTrailingCommas(t *testing.T) {
+	input := []byte(`{"a": 1, "b": 2,}`)
+	out := StripJSONC(input)
+	expected := `{"a": 1, "b": 2}`
+	if string(out) != expected {
+		t.Errorf("expected trailing comma removed, got: %s", string(out))
+	}
+}
+
+func TestStripJSONC_RemovesTrailingCommaBeforeArrayEnd(t *testing.T) {
+	input := []byte(`[1, 2, 3,]`)
+	out := StripJSONC(input)
+	expected := `[1, 2, 3]`
+	if string(out) != expected {
+		t.Errorf("expected trailing comma in array removed, got: %s", string(out))
+	}
+}

--- a/internal/model/resolve.go
+++ b/internal/model/resolve.go
@@ -1,21 +1,105 @@
 package model
 
-// Resolve finds an element by dot-separated ID path (e.g. "system.container.component").
+import (
+	"fmt"
+	"strings"
+)
+
+// Resolve traverses the model hierarchy using dot notation (e.g., "webshop.api.auth").
 func Resolve(m *BausteinsichtModel, id string) (*Element, error) {
-	panic("not implemented")
+	parts := strings.Split(id, ".")
+	root := parts[0]
+
+	elem, ok := m.Model[root]
+	if !ok {
+		return nil, fmt.Errorf("element %q not found", id)
+	}
+
+	for _, part := range parts[1:] {
+		if elem.Children == nil {
+			return nil, fmt.Errorf("element %q not found: no children at this level", id)
+		}
+		child, ok := elem.Children[part]
+		if !ok {
+			return nil, fmt.Errorf("element %q not found", id)
+		}
+		elem = child
+	}
+
+	return &elem, nil
 }
 
-// FlattenElements returns a flat map of all elements keyed by dot-separated path.
-func FlattenElements(m *BausteinsichtModel) map[string]Element {
-	panic("not implemented")
+// flattenInto recursively adds elements to the map with their full dot-notation path.
+func flattenInto(children map[string]Element, prefix string, result map[string]*Element) {
+	for key, elem := range children {
+		fullID := prefix + key
+		e := elem
+		result[fullID] = &e
+		if elem.Children != nil {
+			flattenInto(elem.Children, fullID+".", result)
+		}
+	}
 }
 
-// MatchPattern returns element IDs from flat that match the given pattern (supports * wildcard).
-func MatchPattern(flat map[string]Element, pattern string) []string {
-	panic("not implemented")
+// FlattenElements returns all elements keyed by full dot-notation ID path.
+func FlattenElements(m *BausteinsichtModel) map[string]*Element {
+	result := make(map[string]*Element)
+	flattenInto(m.Model, "", result)
+	return result
 }
 
-// ResolveView returns element IDs included in a view.
-func ResolveView(m *BausteinsichtModel, v *View) ([]string, error) {
-	panic("not implemented")
+// MatchPattern matches elements in the flat map against a pattern.
+// A trailing ".*" matches direct children only (one level deep).
+// A plain ID matches exactly that element.
+func MatchPattern(flatMap map[string]*Element, pattern string) []string {
+	var matches []string
+
+	if strings.HasSuffix(pattern, ".*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		depth := strings.Count(prefix, ".")
+		for id := range flatMap {
+			if !strings.HasPrefix(id, prefix) {
+				continue
+			}
+			rest := id[len(prefix):]
+			if !strings.Contains(rest, ".") && strings.Count(id, ".") == depth {
+				matches = append(matches, id)
+			}
+		}
+	} else {
+		if _, ok := flatMap[pattern]; ok {
+			matches = append(matches, pattern)
+		}
+	}
+
+	return matches
+}
+
+// ResolveView resolves view includes/excludes to a list of element IDs.
+// Starts with include patterns, then removes exclude patterns.
+func ResolveView(m *BausteinsichtModel, view *View) ([]string, error) {
+	if len(view.Include) == 0 {
+		return []string{}, nil
+	}
+
+	flatMap := FlattenElements(m)
+
+	included := make(map[string]bool)
+	for _, pattern := range view.Include {
+		for _, id := range MatchPattern(flatMap, pattern) {
+			included[id] = true
+		}
+	}
+
+	for _, pattern := range view.Exclude {
+		for _, id := range MatchPattern(flatMap, pattern) {
+			delete(included, id)
+		}
+	}
+
+	result := make([]string, 0, len(included))
+	for id := range included {
+		result = append(result, id)
+	}
+	return result, nil
 }

--- a/internal/model/resolve.go
+++ b/internal/model/resolve.go
@@ -1,0 +1,21 @@
+package model
+
+// Resolve finds an element by dot-separated ID path (e.g. "system.container.component").
+func Resolve(m *BausteinsichtModel, id string) (*Element, error) {
+	panic("not implemented")
+}
+
+// FlattenElements returns a flat map of all elements keyed by dot-separated path.
+func FlattenElements(m *BausteinsichtModel) map[string]Element {
+	panic("not implemented")
+}
+
+// MatchPattern returns element IDs from flat that match the given pattern (supports * wildcard).
+func MatchPattern(flat map[string]Element, pattern string) []string {
+	panic("not implemented")
+}
+
+// ResolveView returns element IDs included in a view.
+func ResolveView(m *BausteinsichtModel, v *View) ([]string, error) {
+	panic("not implemented")
+}

--- a/internal/model/resolve_test.go
+++ b/internal/model/resolve_test.go
@@ -1,0 +1,235 @@
+package model
+
+import (
+	"testing"
+)
+
+func buildTestModel() *BausteinsichtModel {
+	return &BausteinsichtModel{
+		Model: map[string]Element{
+			"customer": {
+				Kind:  "actor",
+				Title: "Customer",
+			},
+			"onlineshop": {
+				Kind:  "system",
+				Title: "Online Shop",
+				Children: map[string]Element{
+					"frontend": {
+						Kind:  "container",
+						Title: "Frontend",
+					},
+					"api": {
+						Kind:  "container",
+						Title: "API",
+						Children: map[string]Element{
+							"catalog": {
+								Kind:  "component",
+								Title: "Catalog",
+							},
+							"orders": {
+								Kind:  "component",
+								Title: "Orders",
+							},
+						},
+					},
+					"db": {
+						Kind:  "container",
+						Title: "Database",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolve_SimpleID(t *testing.T) {
+	m := buildTestModel()
+	elem, err := Resolve(m, "customer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elem.Kind != "actor" {
+		t.Errorf("expected kind 'actor', got %q", elem.Kind)
+	}
+}
+
+func TestResolve_NestedID(t *testing.T) {
+	m := buildTestModel()
+	tests := []struct {
+		id        string
+		wantKind  string
+		wantTitle string
+	}{
+		{"onlineshop", "system", "Online Shop"},
+		{"onlineshop.api", "container", "API"},
+		{"onlineshop.api.catalog", "component", "Catalog"},
+		{"onlineshop.api.orders", "component", "Orders"},
+		{"onlineshop.db", "container", "Database"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			elem, err := Resolve(m, tt.id)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if elem.Kind != tt.wantKind {
+				t.Errorf("expected kind %q, got %q", tt.wantKind, elem.Kind)
+			}
+			if elem.Title != tt.wantTitle {
+				t.Errorf("expected title %q, got %q", tt.wantTitle, elem.Title)
+			}
+		})
+	}
+}
+
+func TestResolve_NonExistent(t *testing.T) {
+	m := buildTestModel()
+	tests := []string{
+		"nonexistent",
+		"onlineshop.nonexistent",
+		"onlineshop.api.nonexistent",
+	}
+	for _, id := range tests {
+		t.Run(id, func(t *testing.T) {
+			_, err := Resolve(m, id)
+			if err == nil {
+				t.Errorf("expected error for id %q, got nil", id)
+			}
+		})
+	}
+}
+
+func TestFlattenElements(t *testing.T) {
+	m := buildTestModel()
+	flat := FlattenElements(m)
+
+	expected := []string{
+		"customer",
+		"onlineshop",
+		"onlineshop.frontend",
+		"onlineshop.api",
+		"onlineshop.api.catalog",
+		"onlineshop.api.orders",
+		"onlineshop.db",
+	}
+
+	if len(flat) != len(expected) {
+		t.Errorf("expected %d elements, got %d", len(expected), len(flat))
+	}
+
+	for _, id := range expected {
+		if _, ok := flat[id]; !ok {
+			t.Errorf("expected element %q not found in flat map", id)
+		}
+	}
+}
+
+func TestMatchPattern_Wildcard(t *testing.T) {
+	m := buildTestModel()
+	flat := FlattenElements(m)
+
+	tests := []struct {
+		pattern  string
+		wantIDs  []string
+		notWant  []string
+	}{
+		{
+			pattern: "onlineshop.*",
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api", "onlineshop.db"},
+			notWant: []string{"onlineshop.api.catalog", "onlineshop.api.orders", "customer"},
+		},
+		{
+			pattern: "onlineshop.api.*",
+			wantIDs: []string{"onlineshop.api.catalog", "onlineshop.api.orders"},
+			notWant: []string{"onlineshop.api", "onlineshop.frontend"},
+		},
+		{
+			pattern: "customer",
+			wantIDs: []string{"customer"},
+			notWant: []string{"onlineshop"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			matches := MatchPattern(flat, tt.pattern)
+			matchSet := make(map[string]bool)
+			for _, m := range matches {
+				matchSet[m] = true
+			}
+			for _, want := range tt.wantIDs {
+				if !matchSet[want] {
+					t.Errorf("pattern %q: expected match %q not found", tt.pattern, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if matchSet[notWant] {
+					t.Errorf("pattern %q: unexpected match %q found", tt.pattern, notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveView(t *testing.T) {
+	m := buildTestModel()
+
+	tests := []struct {
+		name    string
+		view    View
+		wantIDs []string
+		notWant []string
+	}{
+		{
+			name: "include all onlineshop children",
+			view: View{
+				Title:   "Shop View",
+				Include: []string{"onlineshop.*"},
+			},
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api", "onlineshop.db"},
+			notWant: []string{"onlineshop.api.catalog"},
+		},
+		{
+			name: "include with exclude",
+			view: View{
+				Title:   "Shop No DB",
+				Include: []string{"onlineshop.*"},
+				Exclude: []string{"onlineshop.db"},
+			},
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api"},
+			notWant: []string{"onlineshop.db", "onlineshop.api.catalog"},
+		},
+		{
+			name: "empty include returns empty",
+			view: View{
+				Title:   "Empty View",
+				Include: []string{},
+			},
+			wantIDs: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids, err := ResolveView(m, &tt.view)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			idSet := make(map[string]bool)
+			for _, id := range ids {
+				idSet[id] = true
+			}
+			for _, want := range tt.wantIDs {
+				if !idSet[want] {
+					t.Errorf("expected ID %q not found in result", want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if idSet[notWant] {
+					t.Errorf("unexpected ID %q found in result", notWant)
+				}
+			}
+		})
+	}
+}

--- a/internal/model/testdata/invalid-json.jsonc
+++ b/internal/model/testdata/invalid-json.jsonc
@@ -1,0 +1,9 @@
+{
+  "specification": {
+    "elements": {
+      INVALID_KEY_NO_QUOTES: {
+        "notation": "System"
+      }
+    }
+  }
+}

--- a/internal/model/testdata/minimal-model.jsonc
+++ b/internal/model/testdata/minimal-model.jsonc
@@ -1,0 +1,17 @@
+{
+  "specification": {
+    "elements": {
+      "system": {
+        "notation": "System"
+      }
+    }
+  },
+  "model": {
+    "root": {
+      "kind": "system",
+      "title": "Root"
+    }
+  },
+  "relationships": [],
+  "views": {}
+}

--- a/internal/model/testdata/valid-model.jsonc
+++ b/internal/model/testdata/valid-model.jsonc
@@ -1,0 +1,47 @@
+{
+  // This is a valid model with comments and trailing commas
+  "$schema": "https://example.com/schema.json",
+  "specification": {
+    "elements": {
+      "system": {
+        "notation": "System", // a software system
+        "description": "A software system",
+        "container": false,
+      },
+      "container": {
+        "notation": "Container",
+        "container": true, // containers hold other elements
+      },
+    },
+    "relationships": {
+      "uses": {
+        "notation": "uses",
+        "dashed": false,
+      },
+    },
+  },
+  "model": {
+    "mySystem": {
+      "kind": "system",
+      "title": "My System",
+      "description": "The main system", // trailing comma below
+    },
+    "myContainer": {
+      "kind": "container",
+      "title": "My Container",
+    },
+  },
+  "relationships": [
+    {
+      "from": "myContainer",
+      "to": "mySystem",
+      "label": "part of",
+    },
+  ],
+  "views": {
+    "main": {
+      "title": "Main View",
+      "scope": "mySystem",
+    },
+  },
+}

--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -1,0 +1,17 @@
+package model
+
+// ValidationError represents a single validation error.
+type ValidationError struct {
+	Path    string
+	Field   string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	return e.Field + ": " + e.Message
+}
+
+// Validate checks model consistency and returns a list of validation errors.
+func Validate(m *BausteinsichtModel) []ValidationError {
+	panic("not implemented")
+}


### PR DESCRIPTION
## Summary
- Implements `Load()` — reads `.jsonc` file, strips `// comments` and trailing commas, parses JSON
- Implements `Save()` — marshals with `json.MarshalIndent`, atomic write via `.tmp` + `os.Rename`
- Implements `AutoDetect()` — finds first `*.jsonc` file in a directory
- Implements `StripJSONC()` — exported helper that preserves comments inside strings
- Adds test fixtures: `valid-model.jsonc`, `minimal-model.jsonc`, `invalid-json.jsonc`
- Adds stub `resolve.go` and `validate.go` to keep parallel feature branches buildable

Closes #7

## Test plan
- [ ] All 13 loader tests pass (`TestLoad_*`, `TestSave_*`, `TestAutoDetect_*`, `TestStripJSONC_*`)
- [ ] `go build ./...` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)