### PR TITLE
feat: implement model validator (#9)

### DIFF
--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -1,17 +1,137 @@
 package model
 
-// ValidationError represents a single validation error.
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidationError describes a single validation problem with its model path.
 type ValidationError struct {
 	Path    string
-	Field   string
 	Message string
 }
 
 func (e ValidationError) Error() string {
-	return e.Field + ": " + e.Message
+	return fmt.Sprintf("%s: %s", e.Path, e.Message)
 }
 
-// Validate checks model consistency and returns a list of validation errors.
+// Validate checks the model for consistency and returns all found errors.
 func Validate(m *BausteinsichtModel) []ValidationError {
-	panic("not implemented")
+	var errs []ValidationError
+	errs = append(errs, validateElements(m)...)
+	errs = append(errs, validateRelationships(m)...)
+	errs = append(errs, validateViews(m)...)
+	return errs
+}
+
+func validateElements(m *BausteinsichtModel) []ValidationError {
+	var errs []ValidationError
+	for id, elem := range m.Model {
+		errs = append(errs, validateElement(m, "model."+id, elem)...)
+	}
+	return errs
+}
+
+func validateElement(m *BausteinsichtModel, path string, elem Element) []ValidationError {
+	var errs []ValidationError
+
+	if elem.Kind == "" {
+		errs = append(errs, ValidationError{Path: path, Message: "missing required field \"kind\""})
+	} else {
+		kindDef, known := m.Specification.Elements[elem.Kind]
+		if !known {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("unknown kind %q", elem.Kind),
+			})
+		} else if len(elem.Children) > 0 && !kindDef.Container {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("kind %q does not allow children (container: false)", elem.Kind),
+			})
+		}
+	}
+
+	if elem.Title == "" {
+		errs = append(errs, ValidationError{Path: path, Message: "missing required field \"title\""})
+	}
+
+	for childID, child := range elem.Children {
+		errs = append(errs, validateElement(m, path+"."+childID, child)...)
+	}
+
+	return errs
+}
+
+func validateRelationships(m *BausteinsichtModel) []ValidationError {
+	var errs []ValidationError
+	for i, rel := range m.Relationships {
+		path := fmt.Sprintf("relationships[%d]", i)
+
+		if _, err := lookupElement(m, rel.From); err != nil {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("from %q does not resolve to an existing element", rel.From),
+			})
+		}
+		if _, err := lookupElement(m, rel.To); err != nil {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("to %q does not resolve to an existing element", rel.To),
+			})
+		}
+		if rel.Kind != "" {
+			if _, known := m.Specification.Relationships[rel.Kind]; !known {
+				errs = append(errs, ValidationError{
+					Path:    path,
+					Message: fmt.Sprintf("unknown relationship kind %q", rel.Kind),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+func validateViews(m *BausteinsichtModel) []ValidationError {
+	var errs []ValidationError
+	for id, view := range m.Views {
+		path := "views." + id
+		if view.Title == "" {
+			errs = append(errs, ValidationError{Path: path, Message: "missing required field \"title\""})
+		}
+		if view.Scope != "" {
+			if _, err := lookupElement(m, view.Scope); err != nil {
+				errs = append(errs, ValidationError{
+					Path:    path,
+					Message: fmt.Sprintf("scope %q does not resolve to an existing element", view.Scope),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// lookupElement resolves a dot-notation path to an Element within the model.
+func lookupElement(m *BausteinsichtModel, path string) (Element, error) {
+	parts := strings.SplitN(path, ".", 2)
+	elem, ok := m.Model[parts[0]]
+	if !ok {
+		return Element{}, fmt.Errorf("element %q not found", parts[0])
+	}
+	if len(parts) == 1 {
+		return elem, nil
+	}
+	return lookupChild(elem, parts[1])
+}
+
+func lookupChild(parent Element, path string) (Element, error) {
+	parts := strings.SplitN(path, ".", 2)
+	child, ok := parent.Children[parts[0]]
+	if !ok {
+		return Element{}, fmt.Errorf("element %q not found", parts[0])
+	}
+	if len(parts) == 1 {
+		return child, nil
+	}
+	return lookupChild(child, parts[1])
 }

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -1,0 +1,192 @@
+package model
+
+import (
+	"testing"
+)
+
+// buildValidModel returns a fully valid model for use as a baseline in tests.
+func buildValidModel() *BausteinsichtModel {
+	return &BausteinsichtModel{
+		Specification: Specification{
+			Elements: map[string]ElementKind{
+				"actor":     {Notation: "Actor", Container: false},
+				"system":    {Notation: "System", Container: true},
+				"container": {Notation: "Container", Container: false},
+			},
+			Relationships: map[string]RelationshipKind{
+				"uses": {Notation: "uses"},
+			},
+		},
+		Model: map[string]Element{
+			"customer": {
+				Kind:  "actor",
+				Title: "Customer",
+			},
+			"shop": {
+				Kind:  "system",
+				Title: "Online Shop",
+				Children: map[string]Element{
+					"api": {
+						Kind:  "container",
+						Title: "API",
+					},
+				},
+			},
+		},
+		Relationships: []Relationship{
+			{From: "customer", To: "shop", Kind: "uses"},
+		},
+		Views: map[string]View{
+			"main": {Title: "Main View", Scope: "shop"},
+		},
+	}
+}
+
+func TestValidate_ValidModel(t *testing.T) {
+	m := buildValidModel()
+	errs := Validate(m)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidate_MissingElementKind(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.Kind = ""
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer") {
+		t.Errorf("expected error for model.customer, got %v", errs)
+	}
+}
+
+func TestValidate_MissingElementTitle(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.Title = ""
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer") {
+		t.Errorf("expected error for model.customer, got %v", errs)
+	}
+}
+
+func TestValidate_UnknownElementKind(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.Kind = "unknownkind"
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer") {
+		t.Errorf("expected error for model.customer, got %v", errs)
+	}
+}
+
+func TestValidate_ChildrenOnNonContainerKind(t *testing.T) {
+	m := buildValidModel()
+	// "actor" has container:false, so children are not allowed
+	elem := m.Model["customer"]
+	elem.Children = map[string]Element{
+		"child": {Kind: "actor", Title: "Child"},
+	}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer") {
+		t.Errorf("expected error for model.customer, got %v", errs)
+	}
+}
+
+func TestValidate_RelationshipFromNonExistent(t *testing.T) {
+	m := buildValidModel()
+	m.Relationships = []Relationship{
+		{From: "nonexistent", To: "shop", Kind: "uses"},
+	}
+
+	errs := Validate(m)
+	if !containsMessage(errs, "nonexistent") {
+		t.Errorf("expected error mentioning 'nonexistent', got %v", errs)
+	}
+}
+
+func TestValidate_RelationshipToNonExistent(t *testing.T) {
+	m := buildValidModel()
+	m.Relationships = []Relationship{
+		{From: "customer", To: "nonexistent", Kind: "uses"},
+	}
+
+	errs := Validate(m)
+	if !containsMessage(errs, "nonexistent") {
+		t.Errorf("expected error mentioning 'nonexistent', got %v", errs)
+	}
+}
+
+func TestValidate_UnknownRelationshipKind(t *testing.T) {
+	m := buildValidModel()
+	m.Relationships = []Relationship{
+		{From: "customer", To: "shop", Kind: "unknownrel"},
+	}
+
+	errs := Validate(m)
+	if !containsMessage(errs, "unknownrel") {
+		t.Errorf("expected error mentioning 'unknownrel', got %v", errs)
+	}
+}
+
+func TestValidate_ViewMissingTitle(t *testing.T) {
+	m := buildValidModel()
+	m.Views["empty"] = View{Title: ""}
+
+	errs := Validate(m)
+	if !containsPath(errs, "views.empty") {
+		t.Errorf("expected error for views.empty, got %v", errs)
+	}
+}
+
+func TestValidate_ViewNonExistentScope(t *testing.T) {
+	m := buildValidModel()
+	m.Views["bad"] = View{Title: "Bad View", Scope: "nonexistent"}
+
+	errs := Validate(m)
+	if !containsPath(errs, "views.bad") {
+		t.Errorf("expected error for views.bad, got %v", errs)
+	}
+}
+
+// containsPath checks whether any error has the given path.
+func containsPath(errs []ValidationError, path string) bool {
+	for _, e := range errs {
+		if e.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// containsMessage checks whether any error message contains the given substring.
+func containsMessage(errs []ValidationError, substr string) bool {
+	for _, e := range errs {
+		if contains(e.Message, substr) || contains(e.Path, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds `ValidationError` struct with `Path` and `Message` fields
- Implements `Validate(*BausteinsichtModel) []ValidationError` function
- Validates: element kind/title presence, known kinds, container rules, relationship from/to resolution, relationship kind, view title, view scope
- Includes own `lookupElement`/`lookupChild` helpers (no dependency on resolve.go)

## Test plan
- [ ] `TestValidate_ValidModel` — valid model returns no errors
- [ ] `TestValidate_MissingElementKind` — missing kind detected
- [ ] `TestValidate_MissingElementTitle` — missing title detected
- [ ] `TestValidate_UnknownElementKind` — unknown kind detected
- [ ] `TestValidate_ChildrenOnNonContainerKind` — children on non-container kind detected
- [ ] `TestValidate_RelationshipFromNonExistent` — bad `from` detected
- [ ] `TestValidate_RelationshipToNonExistent` — bad `to` detected
- [ ] `TestValidate_UnknownRelationshipKind` — unknown relationship kind detected
- [ ] `TestValidate_ViewMissingTitle` — view without title detected
- [ ] `TestValidate_ViewNonExistentScope` — view with bad scope detected

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)