### PR TITLE
feat: implement ID resolver with dot notation and wildcard matching (#8)

### DIFF
--- a/internal/model/resolve.go
+++ b/internal/model/resolve.go
@@ -1,0 +1,105 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Resolve traverses the model hierarchy using dot notation (e.g., "webshop.api.auth").
+func Resolve(m *BausteinsichtModel, id string) (*Element, error) {
+	parts := strings.Split(id, ".")
+	root := parts[0]
+
+	elem, ok := m.Model[root]
+	if !ok {
+		return nil, fmt.Errorf("element %q not found", id)
+	}
+
+	for _, part := range parts[1:] {
+		if elem.Children == nil {
+			return nil, fmt.Errorf("element %q not found: no children at this level", id)
+		}
+		child, ok := elem.Children[part]
+		if !ok {
+			return nil, fmt.Errorf("element %q not found", id)
+		}
+		elem = child
+	}
+
+	return &elem, nil
+}
+
+// flattenInto recursively adds elements to the map with their full dot-notation path.
+func flattenInto(children map[string]Element, prefix string, result map[string]*Element) {
+	for key, elem := range children {
+		fullID := prefix + key
+		e := elem
+		result[fullID] = &e
+		if elem.Children != nil {
+			flattenInto(elem.Children, fullID+".", result)
+		}
+	}
+}
+
+// FlattenElements returns all elements keyed by full dot-notation ID path.
+func FlattenElements(m *BausteinsichtModel) map[string]*Element {
+	result := make(map[string]*Element)
+	flattenInto(m.Model, "", result)
+	return result
+}
+
+// MatchPattern matches elements in the flat map against a pattern.
+// A trailing ".*" matches direct children only (one level deep).
+// A plain ID matches exactly that element.
+func MatchPattern(flatMap map[string]*Element, pattern string) []string {
+	var matches []string
+
+	if strings.HasSuffix(pattern, ".*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		depth := strings.Count(prefix, ".")
+		for id := range flatMap {
+			if !strings.HasPrefix(id, prefix) {
+				continue
+			}
+			rest := id[len(prefix):]
+			if !strings.Contains(rest, ".") && strings.Count(id, ".") == depth {
+				matches = append(matches, id)
+			}
+		}
+	} else {
+		if _, ok := flatMap[pattern]; ok {
+			matches = append(matches, pattern)
+		}
+	}
+
+	return matches
+}
+
+// ResolveView resolves view includes/excludes to a list of element IDs.
+// Starts with include patterns, then removes exclude patterns.
+func ResolveView(m *BausteinsichtModel, view *View) ([]string, error) {
+	if len(view.Include) == 0 {
+		return []string{}, nil
+	}
+
+	flatMap := FlattenElements(m)
+
+	included := make(map[string]bool)
+	for _, pattern := range view.Include {
+		for _, id := range MatchPattern(flatMap, pattern) {
+			included[id] = true
+		}
+	}
+
+	for _, pattern := range view.Exclude {
+		for _, id := range MatchPattern(flatMap, pattern) {
+			delete(included, id)
+		}
+	}
+
+	result := make([]string, 0, len(included))
+	for id := range included {
+		result = append(result, id)
+	}
+	return result, nil
+}

--- a/internal/model/resolve_test.go
+++ b/internal/model/resolve_test.go
@@ -1,0 +1,235 @@
+package model
+
+import (
+	"testing"
+)
+
+func buildTestModel() *BausteinsichtModel {
+	return &BausteinsichtModel{
+		Model: map[string]Element{
+			"customer": {
+				Kind:  "actor",
+				Title: "Customer",
+			},
+			"onlineshop": {
+				Kind:  "system",
+				Title: "Online Shop",
+				Children: map[string]Element{
+					"frontend": {
+						Kind:  "container",
+						Title: "Frontend",
+					},
+					"api": {
+						Kind:  "container",
+						Title: "API",
+						Children: map[string]Element{
+							"catalog": {
+								Kind:  "component",
+								Title: "Catalog",
+							},
+							"orders": {
+								Kind:  "component",
+								Title: "Orders",
+							},
+						},
+					},
+					"db": {
+						Kind:  "container",
+						Title: "Database",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolve_SimpleID(t *testing.T) {
+	m := buildTestModel()
+	elem, err := Resolve(m, "customer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elem.Kind != "actor" {
+		t.Errorf("expected kind 'actor', got %q", elem.Kind)
+	}
+}
+
+func TestResolve_NestedID(t *testing.T) {
+	m := buildTestModel()
+	tests := []struct {
+		id        string
+		wantKind  string
+		wantTitle string
+	}{
+		{"onlineshop", "system", "Online Shop"},
+		{"onlineshop.api", "container", "API"},
+		{"onlineshop.api.catalog", "component", "Catalog"},
+		{"onlineshop.api.orders", "component", "Orders"},
+		{"onlineshop.db", "container", "Database"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			elem, err := Resolve(m, tt.id)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if elem.Kind != tt.wantKind {
+				t.Errorf("expected kind %q, got %q", tt.wantKind, elem.Kind)
+			}
+			if elem.Title != tt.wantTitle {
+				t.Errorf("expected title %q, got %q", tt.wantTitle, elem.Title)
+			}
+		})
+	}
+}
+
+func TestResolve_NonExistent(t *testing.T) {
+	m := buildTestModel()
+	tests := []string{
+		"nonexistent",
+		"onlineshop.nonexistent",
+		"onlineshop.api.nonexistent",
+	}
+	for _, id := range tests {
+		t.Run(id, func(t *testing.T) {
+			_, err := Resolve(m, id)
+			if err == nil {
+				t.Errorf("expected error for id %q, got nil", id)
+			}
+		})
+	}
+}
+
+func TestFlattenElements(t *testing.T) {
+	m := buildTestModel()
+	flat := FlattenElements(m)
+
+	expected := []string{
+		"customer",
+		"onlineshop",
+		"onlineshop.frontend",
+		"onlineshop.api",
+		"onlineshop.api.catalog",
+		"onlineshop.api.orders",
+		"onlineshop.db",
+	}
+
+	if len(flat) != len(expected) {
+		t.Errorf("expected %d elements, got %d", len(expected), len(flat))
+	}
+
+	for _, id := range expected {
+		if _, ok := flat[id]; !ok {
+			t.Errorf("expected element %q not found in flat map", id)
+		}
+	}
+}
+
+func TestMatchPattern_Wildcard(t *testing.T) {
+	m := buildTestModel()
+	flat := FlattenElements(m)
+
+	tests := []struct {
+		pattern  string
+		wantIDs  []string
+		notWant  []string
+	}{
+		{
+			pattern: "onlineshop.*",
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api", "onlineshop.db"},
+			notWant: []string{"onlineshop.api.catalog", "onlineshop.api.orders", "customer"},
+		},
+		{
+			pattern: "onlineshop.api.*",
+			wantIDs: []string{"onlineshop.api.catalog", "onlineshop.api.orders"},
+			notWant: []string{"onlineshop.api", "onlineshop.frontend"},
+		},
+		{
+			pattern: "customer",
+			wantIDs: []string{"customer"},
+			notWant: []string{"onlineshop"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			matches := MatchPattern(flat, tt.pattern)
+			matchSet := make(map[string]bool)
+			for _, m := range matches {
+				matchSet[m] = true
+			}
+			for _, want := range tt.wantIDs {
+				if !matchSet[want] {
+					t.Errorf("pattern %q: expected match %q not found", tt.pattern, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if matchSet[notWant] {
+					t.Errorf("pattern %q: unexpected match %q found", tt.pattern, notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveView(t *testing.T) {
+	m := buildTestModel()
+
+	tests := []struct {
+		name    string
+		view    View
+		wantIDs []string
+		notWant []string
+	}{
+		{
+			name: "include all onlineshop children",
+			view: View{
+				Title:   "Shop View",
+				Include: []string{"onlineshop.*"},
+			},
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api", "onlineshop.db"},
+			notWant: []string{"onlineshop.api.catalog"},
+		},
+		{
+			name: "include with exclude",
+			view: View{
+				Title:   "Shop No DB",
+				Include: []string{"onlineshop.*"},
+				Exclude: []string{"onlineshop.db"},
+			},
+			wantIDs: []string{"onlineshop.frontend", "onlineshop.api"},
+			notWant: []string{"onlineshop.db", "onlineshop.api.catalog"},
+		},
+		{
+			name: "empty include returns empty",
+			view: View{
+				Title:   "Empty View",
+				Include: []string{},
+			},
+			wantIDs: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids, err := ResolveView(m, &tt.view)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			idSet := make(map[string]bool)
+			for _, id := range ids {
+				idSet[id] = true
+			}
+			for _, want := range tt.wantIDs {
+				if !idSet[want] {
+					t.Errorf("expected ID %q not found in result", want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if idSet[notWant] {
+					t.Errorf("unexpected ID %q found in result", notWant)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `Resolve`: traverse model hierarchy using dot notation (e.g., `webshop.api.auth`)
- `FlattenElements`: return all elements keyed by full dot-notation path
- `MatchPattern`: support `*` wildcard for direct children only (e.g., `webshop.*` matches `webshop.api` but not `webshop.api.auth`)
- `ResolveView`: resolve view includes/excludes to a list of element IDs

## Test plan
- [x] Simple ID resolution: `customer` → customer element
- [x] Nested ID: `onlineshop.api.catalog` → catalog element
- [x] Non-existent ID → error
- [x] FlattenElements returns all 7 elements with full paths
- [x] Wildcard `onlineshop.*` matches frontend, api, db (not api.catalog)
- [x] View resolution with include and exclude patterns
- [x] Empty include returns empty result
- [x] `go build ./...` and `go test ./...` pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)