### PR TITLE
feat: implement draw.io document parser with multi-page support (#11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require github.com/spf13/cobra v1.10.2
 
 require (
+	github.com/beevik/etree v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
+github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/drawio/doc.go
+++ b/internal/drawio/doc.go
@@ -1,2 +1,0 @@
-// Package drawio handles reading and writing draw.io XML files.
-package drawio

--- a/internal/drawio/document.go
+++ b/internal/drawio/document.go
@@ -1,0 +1,134 @@
+// Package drawio handles reading and writing draw.io XML files.
+package drawio
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/beevik/etree"
+)
+
+// Document represents a draw.io file (mxfile).
+type Document struct {
+	tree *etree.Document
+}
+
+// Page represents a single page (diagram element) within a Document.
+type Page struct {
+	diagram *etree.Element
+}
+
+// LoadDocument parses a draw.io XML file from disk.
+func LoadDocument(path string) (*Document, error) {
+	tree := etree.NewDocument()
+	if err := tree.ReadFromFile(path); err != nil {
+		return nil, fmt.Errorf("LoadDocument %q: %w", path, err)
+	}
+	return &Document{tree: tree}, nil
+}
+
+// SaveDocument writes a Document to disk using an atomic temp-file + rename.
+func SaveDocument(path string, doc *Document) error {
+	doc.tree.Indent(2)
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".drawio-tmp-*")
+	if err != nil {
+		return fmt.Errorf("SaveDocument create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	if _, err := doc.tree.WriteTo(tmp); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("SaveDocument write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("SaveDocument close: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("SaveDocument rename: %w", err)
+	}
+	return nil
+}
+
+// NewDocument creates an empty mxfile document.
+func NewDocument() *Document {
+	tree := etree.NewDocument()
+	tree.CreateProcInst("xml", `version="1.0" encoding="UTF-8"`)
+	mxfile := tree.CreateElement("mxfile")
+	mxfile.CreateAttr("host", "bausteinsicht")
+	mxfile.CreateAttr("compressed", "false")
+	return &Document{tree: tree}
+}
+
+// Pages returns all pages in the document.
+func (d *Document) Pages() []*Page {
+	root := d.tree.Root()
+	if root == nil {
+		return nil
+	}
+	diagrams := root.SelectElements("diagram")
+	pages := make([]*Page, len(diagrams))
+	for i, el := range diagrams {
+		pages[i] = &Page{diagram: el}
+	}
+	return pages
+}
+
+// GetPage returns the page with the given id, or nil if not found.
+func (d *Document) GetPage(id string) *Page {
+	root := d.tree.Root()
+	if root == nil {
+		return nil
+	}
+	for _, el := range root.SelectElements("diagram") {
+		if el.SelectAttrValue("id", "") == id {
+			return &Page{diagram: el}
+		}
+	}
+	return nil
+}
+
+// AddPage adds a new page with the given id and name, initialised with base cells.
+func (d *Document) AddPage(id, name string) *Page {
+	root := d.tree.Root()
+	if root == nil {
+		root = d.tree.CreateElement("mxfile")
+	}
+
+	diagram := root.CreateElement("diagram")
+	diagram.CreateAttr("id", id)
+	diagram.CreateAttr("name", name)
+
+	model := diagram.CreateElement("mxGraphModel")
+	model.CreateAttr("dx", "1422")
+	model.CreateAttr("dy", "794")
+	model.CreateAttr("grid", "1")
+	model.CreateAttr("gridSize", "10")
+	model.CreateAttr("page", "1")
+	model.CreateAttr("pageWidth", "1169")
+	model.CreateAttr("pageHeight", "827")
+	model.CreateAttr("background", "#ffffff")
+
+	rootEl := model.CreateElement("root")
+	cell0 := rootEl.CreateElement("mxCell")
+	cell0.CreateAttr("id", "0")
+	cell1 := rootEl.CreateElement("mxCell")
+	cell1.CreateAttr("id", "1")
+	cell1.CreateAttr("parent", "0")
+
+	return &Page{diagram: diagram}
+}
+
+// Root returns the <root> element of the page for direct manipulation.
+func (p *Page) Root() *etree.Element {
+	model := p.diagram.FindElement("mxGraphModel")
+	if model == nil {
+		return nil
+	}
+	return model.FindElement("root")
+}

--- a/internal/drawio/document.go
+++ b/internal/drawio/document.go
@@ -40,16 +40,16 @@ func SaveDocument(path string, doc *Document) error {
 	tmpName := tmp.Name()
 
 	if _, err := doc.tree.WriteTo(tmp); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("SaveDocument write: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("SaveDocument close: %w", err)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("SaveDocument rename: %w", err)
 	}
 	return nil

--- a/internal/drawio/document_test.go
+++ b/internal/drawio/document_test.go
@@ -1,0 +1,127 @@
+package drawio_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+)
+
+func TestLoadDocument_Simple(t *testing.T) {
+	doc, err := drawio.LoadDocument("testdata/simple-diagram.drawio")
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	pages := doc.Pages()
+	if len(pages) != 1 {
+		t.Errorf("expected 1 page, got %d", len(pages))
+	}
+}
+
+func TestLoadDocument_MultiPage(t *testing.T) {
+	doc, err := drawio.LoadDocument("testdata/multi-page.drawio")
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	pages := doc.Pages()
+	if len(pages) != 2 {
+		t.Errorf("expected 2 pages, got %d", len(pages))
+	}
+}
+
+func TestGetPage(t *testing.T) {
+	doc, err := drawio.LoadDocument("testdata/multi-page.drawio")
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+	p := doc.GetPage("page2")
+	if p == nil {
+		t.Fatal("expected page2, got nil")
+	}
+	if doc.GetPage("nonexistent") != nil {
+		t.Error("expected nil for nonexistent page")
+	}
+}
+
+func TestSaveDocument_RoundTrip(t *testing.T) {
+	doc, err := drawio.LoadDocument("testdata/simple-diagram.drawio")
+	if err != nil {
+		t.Fatalf("LoadDocument: %v", err)
+	}
+
+	tmp := filepath.Join(t.TempDir(), "out.drawio")
+	if err := drawio.SaveDocument(tmp, doc); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+
+	doc2, err := drawio.LoadDocument(tmp)
+	if err != nil {
+		t.Fatalf("LoadDocument after save: %v", err)
+	}
+	if len(doc2.Pages()) != len(doc.Pages()) {
+		t.Errorf("page count mismatch after round-trip: got %d, want %d", len(doc2.Pages()), len(doc.Pages()))
+	}
+}
+
+func TestNewDocument(t *testing.T) {
+	doc := drawio.NewDocument()
+	if doc == nil {
+		t.Fatal("NewDocument returned nil")
+	}
+	if len(doc.Pages()) != 0 {
+		t.Errorf("expected 0 pages, got %d", len(doc.Pages()))
+	}
+}
+
+func TestAddPage(t *testing.T) {
+	doc := drawio.NewDocument()
+	p := doc.AddPage("mypage", "My Page")
+	if p == nil {
+		t.Fatal("AddPage returned nil")
+	}
+	if len(doc.Pages()) != 1 {
+		t.Errorf("expected 1 page after AddPage, got %d", len(doc.Pages()))
+	}
+	if doc.GetPage("mypage") == nil {
+		t.Error("GetPage could not find the added page")
+	}
+}
+
+func TestAddPage_BaseCells(t *testing.T) {
+	doc := drawio.NewDocument()
+	p := doc.AddPage("p1", "Page 1")
+	root := p.Root()
+	if root == nil {
+		t.Fatal("Root() returned nil")
+	}
+	cells := root.SelectElements("mxCell")
+	if len(cells) < 2 {
+		t.Errorf("expected at least 2 base mxCells, got %d", len(cells))
+	}
+	if cells[0].SelectAttrValue("id", "") != "0" {
+		t.Errorf("first base cell id should be '0', got '%s'", cells[0].SelectAttrValue("id", ""))
+	}
+	if cells[1].SelectAttrValue("id", "") != "1" {
+		t.Errorf("second base cell id should be '1', got '%s'", cells[1].SelectAttrValue("id", ""))
+	}
+}
+
+func TestSaveDocument_Atomic(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("p1", "Page 1")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "atomic.drawio")
+	if err := drawio.SaveDocument(path, doc); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("saved file is empty")
+	}
+}

--- a/internal/drawio/testdata/multi-page.drawio
+++ b/internal/drawio/testdata/multi-page.drawio
@@ -1,0 +1,24 @@
+<mxfile host="bausteinsicht" compressed="false">
+  <diagram id="page1" name="Page-1">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="System A" style="rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="page2" name="Page-2">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="3" value="System B" style="rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="200" y="200" width="120" height="60" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/internal/drawio/testdata/simple-diagram.drawio
+++ b/internal/drawio/testdata/simple-diagram.drawio
@@ -1,0 +1,13 @@
+<mxfile host="bausteinsicht" compressed="false">
+  <diagram id="page1" name="Page-1">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" value="System A" style="rounded=1;" vertex="1" parent="1">
+          <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- Implement `LoadDocument`, `SaveDocument` (atomic temp+rename), `NewDocument`
- Implement `Document.Pages()`, `GetPage()`, `AddPage()` with base mxCell initialization
- Implement `Page.Root()` for direct XML element manipulation
- Add test fixtures (`simple-diagram.drawio`, `multi-page.drawio`) and full test suite

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 8 new tests green)
- [x] Round-trip save/load preserves page count
- [x] Atomic write verified (temp + rename)
- [x] Multi-page fixture tested

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)