### PR TITLE
feat: implement HTML label generator and parser for draw.io elements (#15)

### DIFF
--- a/internal/drawio/label.go
+++ b/internal/drawio/label.go
@@ -1,0 +1,96 @@
+package drawio
+
+import (
+	"strings"
+)
+
+// GenerateLabel creates an HTML label for draw.io elements.
+// Format: <b>Title</b><br><font color="#666666">Technology</font>
+// If technology is empty, just: <b>Title</b>
+// The returned string is unescaped HTML; etree handles XML attribute escaping.
+func GenerateLabel(title, technology string) string {
+	escaped := escapeHTML(title)
+	if technology == "" {
+		return "<b>" + escaped + "</b>"
+	}
+	escapedTech := escapeHTML(technology)
+	return "<b>" + escaped + "</b><br><font color=\"#666666\">" + escapedTech + "</font>"
+}
+
+// GenerateActorLabel creates a label for actor elements (just the title, no technology line).
+func GenerateActorLabel(title string) string {
+	return "<b>" + escapeHTML(title) + "</b>"
+}
+
+// ParseLabel extracts title and technology from an HTML label.
+// Expected format: <b>Title</b><br><font color="#666666">Technology</font>
+// If the label doesn't match, return the full text as title with empty technology.
+func ParseLabel(html string) (title, technology string) {
+	// Try to match <b>...</b><br><font ...>...</font>
+	if strings.HasPrefix(html, "<b>") {
+		rest := html[len("<b>"):]
+		closeB := strings.Index(rest, "</b>")
+		if closeB >= 0 {
+			titlePart := rest[:closeB]
+			after := rest[closeB+len("</b>"):]
+
+			if after == "" {
+				return unescapeHTML(titlePart), ""
+			}
+
+			// Check for <br><font ...>...</font>
+			if strings.HasPrefix(after, "<br>") {
+				fontPart := after[len("<br>"):]
+				if strings.HasPrefix(fontPart, "<font") {
+					fontClose := strings.Index(fontPart, ">")
+					if fontClose >= 0 {
+						techRest := fontPart[fontClose+1:]
+						endFont := strings.Index(techRest, "</font>")
+						if endFont >= 0 {
+							tech := techRest[:endFont]
+							return unescapeHTML(titlePart), unescapeHTML(tech)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: strip all HTML tags and return plain text as title
+	return stripTags(html), ""
+}
+
+// escapeHTML escapes special HTML characters in text content.
+func escapeHTML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	return s
+}
+
+// unescapeHTML reverses HTML entity escaping.
+func unescapeHTML(s string) string {
+	s = strings.ReplaceAll(s, "&quot;", "\"")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	return s
+}
+
+// stripTags removes all HTML tags from a string.
+func stripTags(s string) string {
+	var b strings.Builder
+	inTag := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+		case !inTag:
+			b.WriteRune(r)
+		}
+	}
+	return unescapeHTML(b.String())
+}

--- a/internal/drawio/label_test.go
+++ b/internal/drawio/label_test.go
@@ -1,0 +1,177 @@
+package drawio
+
+import (
+	"testing"
+)
+
+func TestGenerateLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		title      string
+		technology string
+		want       string
+	}{
+		{
+			name:       "standard label with title and technology",
+			title:      "REST API",
+			technology: "Spring Boot",
+			want:       `<b>REST API</b><br><font color="#666666">Spring Boot</font>`,
+		},
+		{
+			name:       "title only, no technology",
+			title:      "My Service",
+			technology: "",
+			want:       `<b>My Service</b>`,
+		},
+		{
+			name:       "special characters in title",
+			title:      `A & B < C > D "E"`,
+			technology: "",
+			want:       `<b>A &amp; B &lt; C &gt; D &quot;E&quot;</b>`,
+		},
+		{
+			name:       "special characters in technology",
+			title:      "API",
+			technology: `Go & <fast>`,
+			want:       `<b>API</b><br><font color="#666666">Go &amp; &lt;fast&gt;</font>`,
+		},
+		{
+			name:       "empty title and technology",
+			title:      "",
+			technology: "",
+			want:       `<b></b>`,
+		},
+		{
+			name:       "empty title with technology",
+			title:      "",
+			technology: "Java",
+			want:       `<b></b><br><font color="#666666">Java</font>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateLabel(tt.title, tt.technology)
+			if got != tt.want {
+				t.Errorf("GenerateLabel(%q, %q)\n  got:  %q\n  want: %q", tt.title, tt.technology, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateActorLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{
+			name:  "simple actor label",
+			title: "User",
+			want:  `<b>User</b>`,
+		},
+		{
+			name:  "actor with special chars",
+			title: `Admin & <Root>`,
+			want:  `<b>Admin &amp; &lt;Root&gt;</b>`,
+		},
+		{
+			name:  "empty title",
+			title: "",
+			want:  `<b></b>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateActorLabel(tt.title)
+			if got != tt.want {
+				t.Errorf("GenerateActorLabel(%q)\n  got:  %q\n  want: %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		html       string
+		wantTitle  string
+		wantTech   string
+	}{
+		{
+			name:      "standard label with title and technology",
+			html:      `<b>REST API</b><br><font color="#666666">Spring Boot</font>`,
+			wantTitle: "REST API",
+			wantTech:  "Spring Boot",
+		},
+		{
+			name:      "title only, no technology",
+			html:      `<b>My Service</b>`,
+			wantTitle: "My Service",
+			wantTech:  "",
+		},
+		{
+			name:      "non-standard format fallback",
+			html:      "Plain text label",
+			wantTitle: "Plain text label",
+			wantTech:  "",
+		},
+		{
+			name:      "non-standard HTML fallback strips tags",
+			html:      "<div>Some label</div>",
+			wantTitle: "Some label",
+			wantTech:  "",
+		},
+		{
+			name:      "escaped chars in title",
+			html:      `<b>A &amp; B &lt;C&gt;</b>`,
+			wantTitle: "A & B <C>",
+			wantTech:  "",
+		},
+		{
+			name:      "escaped chars in technology",
+			html:      `<b>API</b><br><font color="#666666">Go &amp; &lt;fast&gt;</font>`,
+			wantTitle: "API",
+			wantTech:  "Go & <fast>",
+		},
+		{
+			name:      "empty label",
+			html:      "",
+			wantTitle: "",
+			wantTech:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTitle, gotTech := ParseLabel(tt.html)
+			if gotTitle != tt.wantTitle || gotTech != tt.wantTech {
+				t.Errorf("ParseLabel(%q)\n  got:  (%q, %q)\n  want: (%q, %q)",
+					tt.html, gotTitle, gotTech, tt.wantTitle, tt.wantTech)
+			}
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		title string
+		tech  string
+	}{
+		{"REST API", "Spring Boot"},
+		{"My Service", ""},
+		{`A & B < C > D "E"`, "Go"},
+		{"", "Java"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		label := GenerateLabel(tt.title, tt.tech)
+		gotTitle, gotTech := ParseLabel(label)
+		if gotTitle != tt.title || gotTech != tt.tech {
+			t.Errorf("round-trip GenerateLabel(%q, %q) -> ParseLabel:\n  got:  (%q, %q)\n  want: (%q, %q)",
+				tt.title, tt.tech, gotTitle, gotTech, tt.title, tt.tech)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GenerateLabel(title, technology string) string` — creates HTML labels for draw.io elements with bold title and grey technology line
- Add `GenerateActorLabel(title string) string` — actor labels with title only  
- Add `ParseLabel(html string) (title, technology string)` — parses HTML labels back to components with fallback for non-standard formats
- Full HTML entity escaping/unescaping for special characters (`& < > "`)
- Table-driven tests including round-trip verification

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)