### PR TITLE
feat: implement template loader for draw.io (#14)

### DIFF
--- a/internal/drawio/template.go
+++ b/internal/drawio/template.go
@@ -1,0 +1,108 @@
+package drawio
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/beevik/etree"
+)
+
+// TemplateStyle holds the visual style and default dimensions for a draw.io element.
+type TemplateStyle struct {
+	Style  string  // mxCell style string
+	Width  float64 // default width from mxGeometry
+	Height float64 // default height from mxGeometry
+}
+
+// TemplateSet holds all styles parsed from a draw.io template file.
+type TemplateSet struct {
+	elements   map[string]TemplateStyle // keyed by kind (actor, system, container, component)
+	boundaries map[string]TemplateStyle // keyed by kind (system_boundary, container_boundary)
+	connector  string                   // default connector style
+}
+
+// LoadTemplate parses a draw.io template file from disk.
+func LoadTemplate(path string) (*TemplateSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("LoadTemplate %q: %w", path, err)
+	}
+	return LoadTemplateFromBytes(data)
+}
+
+// LoadTemplateFromBytes parses a draw.io template from raw XML bytes.
+func LoadTemplateFromBytes(data []byte) (*TemplateSet, error) {
+	tree := etree.NewDocument()
+	if err := tree.ReadFromBytes(data); err != nil {
+		return nil, fmt.Errorf("LoadTemplateFromBytes: %w", err)
+	}
+
+	ts := &TemplateSet{
+		elements:   make(map[string]TemplateStyle),
+		boundaries: make(map[string]TemplateStyle),
+	}
+
+	// Find all <object> elements with bausteinsicht_template attribute.
+	for _, obj := range tree.FindElements("//object[@bausteinsicht_template]") {
+		kind := obj.SelectAttrValue("bausteinsicht_template", "")
+		if kind == "" {
+			continue
+		}
+
+		cell := obj.FindElement("mxCell")
+		if cell == nil {
+			continue
+		}
+
+		style := cell.SelectAttrValue("style", "")
+		width, height := parseGeometry(cell)
+
+		ts.categorize(kind, TemplateStyle{Style: style, Width: width, Height: height})
+	}
+
+	// Find relationship connector: bare <mxCell bausteinsicht_template="relationship">.
+	for _, cell := range tree.FindElements("//mxCell[@bausteinsicht_template='relationship']") {
+		ts.connector = cell.SelectAttrValue("style", "")
+	}
+
+	return ts, nil
+}
+
+// GetStyle returns the TemplateStyle for a given element kind.
+func (t *TemplateSet) GetStyle(kind string) (TemplateStyle, bool) {
+	s, ok := t.elements[kind]
+	return s, ok
+}
+
+// GetBoundaryStyle returns the TemplateStyle for a given boundary kind.
+func (t *TemplateSet) GetBoundaryStyle(kind string) (TemplateStyle, bool) {
+	s, ok := t.boundaries[kind]
+	return s, ok
+}
+
+// GetConnectorStyle returns the default connector style string.
+func (t *TemplateSet) GetConnectorStyle() string {
+	return t.connector
+}
+
+// categorize places the style into the appropriate map based on its kind.
+func (t *TemplateSet) categorize(kind string, style TemplateStyle) {
+	if strings.HasSuffix(kind, "_boundary") {
+		t.boundaries[kind] = style
+	} else {
+		t.elements[kind] = style
+	}
+}
+
+// parseGeometry extracts width and height from an mxCell's nested mxGeometry element.
+func parseGeometry(cell *etree.Element) (float64, float64) {
+	geo := cell.FindElement("mxGeometry")
+	if geo == nil {
+		return 0, 0
+	}
+	w, _ := strconv.ParseFloat(geo.SelectAttrValue("width", "0"), 64)
+	h, _ := strconv.ParseFloat(geo.SelectAttrValue("height", "0"), 64)
+	return w, h
+}

--- a/internal/drawio/template_test.go
+++ b/internal/drawio/template_test.go
@@ -1,0 +1,108 @@
+package drawio_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+)
+
+const defaultTemplatePath = "../../templates/default.drawio"
+
+func TestLoadTemplate_Success(t *testing.T) {
+	ts, err := drawio.LoadTemplate(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	if ts == nil {
+		t.Fatal("expected non-nil TemplateSet")
+	}
+}
+
+func TestGetStyle_ElementKinds(t *testing.T) {
+	ts, err := drawio.LoadTemplate(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+
+	kinds := []string{"actor", "system", "container", "component"}
+	for _, kind := range kinds {
+		style, ok := ts.GetStyle(kind)
+		if !ok {
+			t.Errorf("GetStyle(%q): expected true, got false", kind)
+			continue
+		}
+		if style.Style == "" {
+			t.Errorf("GetStyle(%q): expected non-empty style string", kind)
+		}
+		if style.Width <= 0 || style.Height <= 0 {
+			t.Errorf("GetStyle(%q): expected positive dimensions, got w=%v h=%v", kind, style.Width, style.Height)
+		}
+	}
+}
+
+func TestGetBoundaryStyle_BoundaryKinds(t *testing.T) {
+	ts, err := drawio.LoadTemplate(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+
+	kinds := []string{"system_boundary", "container_boundary"}
+	for _, kind := range kinds {
+		style, ok := ts.GetBoundaryStyle(kind)
+		if !ok {
+			t.Errorf("GetBoundaryStyle(%q): expected true, got false", kind)
+			continue
+		}
+		if style.Style == "" {
+			t.Errorf("GetBoundaryStyle(%q): expected non-empty style string", kind)
+		}
+		if style.Width <= 0 || style.Height <= 0 {
+			t.Errorf("GetBoundaryStyle(%q): expected positive dimensions, got w=%v h=%v", kind, style.Width, style.Height)
+		}
+	}
+}
+
+func TestGetConnectorStyle(t *testing.T) {
+	ts, err := drawio.LoadTemplate(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+
+	connector := ts.GetConnectorStyle()
+	if connector == "" {
+		t.Error("GetConnectorStyle: expected non-empty connector style")
+	}
+}
+
+func TestGetStyle_UnknownKind(t *testing.T) {
+	ts, err := drawio.LoadTemplate(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+
+	_, ok := ts.GetStyle("nonexistent")
+	if ok {
+		t.Error("GetStyle(nonexistent): expected false, got true")
+	}
+}
+
+func TestLoadTemplateFromBytes(t *testing.T) {
+	data, err := os.ReadFile(defaultTemplatePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	ts, err := drawio.LoadTemplateFromBytes(data)
+	if err != nil {
+		t.Fatalf("LoadTemplateFromBytes: %v", err)
+	}
+
+	style, ok := ts.GetStyle("system")
+	if !ok {
+		t.Fatal("GetStyle(system): expected true, got false")
+	}
+	if style.Style == "" {
+		t.Error("expected non-empty style string")
+	}
+}

--- a/templates/default.drawio
+++ b/templates/default.drawio
@@ -81,6 +81,7 @@
 
         <!-- Relationship connector template -->
         <mxCell id="template-relationship"
+                bausteinsicht_template="relationship"
                 value="label"
                 style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;"
                 edge="1"


### PR DESCRIPTION
## Summary
- Implements `TemplateStyle` and `TemplateSet` types for draw.io template styles
- Adds `LoadTemplate`/`LoadTemplateFromBytes` to parse draw.io template files
- Adds `GetStyle`, `GetBoundaryStyle`, `GetConnectorStyle` accessors
- Updates `templates/default.drawio` to add `bausteinsicht_template="relationship"` to the connector mxCell

## Test plan
- [ ] `TestLoadTemplate_Success` — loads default template without error
- [ ] `TestGetStyle_ElementKinds` — actor, system, container, component styles have non-empty style string and positive dimensions
- [ ] `TestGetBoundaryStyle_BoundaryKinds` — system_boundary, container_boundary styles correct
- [ ] `TestGetConnectorStyle` — relationship connector style non-empty
- [ ] `TestGetStyle_UnknownKind` — returns false for unknown kind
- [ ] `TestLoadTemplateFromBytes` — works with embedded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)