### PR TITLE
feat: implement conflict detection and resolution (#21)

### DIFF
--- a/internal/sync/conflict.go
+++ b/internal/sync/conflict.go
@@ -1,0 +1,55 @@
+package sync
+
+import "fmt"
+
+// Conflict represents a field that was changed on both sides since the last sync.
+type Conflict struct {
+	ElementID     string
+	Field         string // "title", "description", "technology"
+	ModelValue    string
+	DrawioValue   string
+	LastSyncValue string
+}
+
+// ResolvedConflict is a conflict with its resolution decision.
+type ResolvedConflict struct {
+	Conflict
+	Winner  string // "model" or "drawio"
+	Warning string // human-readable warning message
+}
+
+// ConflictResolver resolves conflicts between model and draw.io changes.
+// Designed as an interface for future extension (interactive, merge strategies).
+type ConflictResolver interface {
+	Resolve(conflicts []Conflict) []ResolvedConflict
+}
+
+// ModelWinsResolver always picks the model value (v1 default strategy).
+type ModelWinsResolver struct{}
+
+// NewModelWinsResolver creates a new ModelWinsResolver.
+func NewModelWinsResolver() *ModelWinsResolver {
+	return &ModelWinsResolver{}
+}
+
+// Resolve resolves all conflicts by choosing the model value.
+func (r *ModelWinsResolver) Resolve(conflicts []Conflict) []ResolvedConflict {
+	resolved := make([]ResolvedConflict, 0, len(conflicts))
+	for _, c := range conflicts {
+		warning := fmt.Sprintf(
+			"WARNING: Conflict detected for element %q:\n"+
+				"  Field: %s\n"+
+				"  Model value:   %q\n"+
+				"  draw.io value: %q\n"+
+				"  Last sync:     %q\n"+
+				"  → Keeping model value. Edit draw.io manually if needed.",
+			c.ElementID, c.Field, c.ModelValue, c.DrawioValue, c.LastSyncValue,
+		)
+		resolved = append(resolved, ResolvedConflict{
+			Conflict: c,
+			Winner:   "model",
+			Warning:  warning,
+		})
+	}
+	return resolved
+}

--- a/internal/sync/conflict_test.go
+++ b/internal/sync/conflict_test.go
@@ -1,0 +1,91 @@
+package sync
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestModelWinsResolver_NoConflicts(t *testing.T) {
+	r := NewModelWinsResolver()
+	result := r.Resolve([]Conflict{})
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d items", len(result))
+	}
+}
+
+func TestModelWinsResolver_SingleConflict(t *testing.T) {
+	r := NewModelWinsResolver()
+	conflicts := []Conflict{
+		{
+			ElementID:     "paymentService",
+			Field:         "title",
+			ModelValue:    "Payment Service",
+			DrawioValue:   "Pay Svc",
+			LastSyncValue: "Payment Service",
+		},
+	}
+	result := r.Resolve(conflicts)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+	rc := result[0]
+	if rc.Winner != "model" {
+		t.Errorf("expected winner 'model', got %q", rc.Winner)
+	}
+	if rc.ElementID != "paymentService" {
+		t.Errorf("expected ElementID 'paymentService', got %q", rc.ElementID)
+	}
+}
+
+func TestModelWinsResolver_MultipleConflicts(t *testing.T) {
+	r := NewModelWinsResolver()
+	conflicts := []Conflict{
+		{ElementID: "elem1", Field: "title", ModelValue: "A", DrawioValue: "B", LastSyncValue: "A"},
+		{ElementID: "elem2", Field: "description", ModelValue: "Desc", DrawioValue: "D", LastSyncValue: "Desc"},
+		{ElementID: "elem3", Field: "technology", ModelValue: "Go", DrawioValue: "Java", LastSyncValue: "Go"},
+	}
+	result := r.Resolve(conflicts)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(result))
+	}
+	for i, rc := range result {
+		if rc.Winner != "model" {
+			t.Errorf("result[%d]: expected winner 'model', got %q", i, rc.Winner)
+		}
+	}
+}
+
+func TestModelWinsResolver_WarningFormat(t *testing.T) {
+	r := NewModelWinsResolver()
+	conflicts := []Conflict{
+		{
+			ElementID:     "userService",
+			Field:         "technology",
+			ModelValue:    "Go",
+			DrawioValue:   "Python",
+			LastSyncValue: "Go",
+		},
+	}
+	result := r.Resolve(conflicts)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+	w := result[0].Warning
+	checks := []string{
+		"userService",
+		"technology",
+		"Go",
+		"Python",
+		"Keeping model value",
+	}
+	for _, check := range checks {
+		if !strings.Contains(w, check) {
+			t.Errorf("warning missing %q:\n%s", check, w)
+		}
+	}
+}
+
+func TestConflictResolverInterface(t *testing.T) {
+	// Ensure ModelWinsResolver satisfies the ConflictResolver interface.
+	var _ ConflictResolver = NewModelWinsResolver()
+}

--- a/internal/sync/doc.go
+++ b/internal/sync/doc.go
@@ -1,0 +1,3 @@
+// Package sync provides bidirectional synchronization between the model DSL
+// and draw.io diagram files, including conflict detection and resolution.
+package sync

--- a/internal/sync/state_test.go
+++ b/internal/sync/state_test.go
@@ -194,6 +194,7 @@ func TestBuildState_CorrectSnapshot(t *testing.T) {
 		t.Errorf("expected sha256 drawio hash, got %q", state.DrawioHash)
 	}
 
+	// FlattenElements returns both "webshop" and "webshop.api"
 	if len(state.Elements) != 2 {
 		t.Errorf("expected 2 elements, got %d", len(state.Elements))
 	}


### PR DESCRIPTION
## Summary
- Adds `Conflict` and `ResolvedConflict` types for field-level conflict tracking
- Adds `ConflictResolver` interface for future extension (interactive resolution, etc.)
- Implements `ModelWinsResolver` — v1 default where model always wins
- Restores `doc.go` placeholder to keep `internal/sync` package intact

## Test plan
- [ ] No conflicts → empty result
- [ ] Single conflict → model wins, warning generated
- [ ] Multiple conflicts → all resolved with model winning
- [ ] Warning message contains element ID, field, all three values, and resolution message
- [ ] `ConflictResolver` interface satisfied by `ModelWinsResolver`
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)