### PR TITLE
feat: implement reverse sync (draw.io → model)

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -1,0 +1,183 @@
+package sync
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// ReverseResult summarizes the changes applied back to the model.
+type ReverseResult struct {
+	ElementsCreated      int
+	ElementsUpdated      int
+	ElementsDeleted      int
+	RelationshipsCreated int
+	RelationshipsUpdated int
+	RelationshipsDeleted int
+	Warnings             []string
+}
+
+// ApplyReverse applies draw.io-side changes back to the model.
+func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResult {
+	result := &ReverseResult{}
+
+	for _, ch := range changes.DrawioElementChanges {
+		applyElementChange(ch, m, result)
+	}
+
+	for _, ch := range changes.DrawioRelationshipChanges {
+		applyRelationshipChange(ch, m, result)
+	}
+
+	return result
+}
+
+func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	switch ch.Type {
+	case Modified:
+		err := modifyElement(m, ch.ID, func(e *model.Element) {
+			switch ch.Field {
+			case "title":
+				e.Title = ch.NewValue
+			case "description":
+				e.Description = ch.NewValue
+			case "technology":
+				e.Technology = ch.NewValue
+			}
+		})
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Element %q not found in model: %v", ch.ID, err))
+			return
+		}
+		result.ElementsUpdated++
+
+	case Deleted:
+		err := deleteElement(m, ch.ID)
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Element %q could not be deleted: %v", ch.ID, err))
+			return
+		}
+		result.ElementsDeleted++
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Element %q was deleted in draw.io and removed from model", ch.ID))
+
+	case Added:
+		result.Warnings = append(result.Warnings,
+			"New element detected in draw.io (no bausteinsicht_id). Please add it to the model manually.")
+	}
+}
+
+func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	switch ch.Type {
+	case Modified:
+		updated := false
+		for i, r := range m.Relationships {
+			if r.From == ch.From && r.To == ch.To {
+				if ch.Field == "label" {
+					m.Relationships[i].Label = ch.NewValue
+				}
+				updated = true
+				break
+			}
+		}
+		if updated {
+			result.RelationshipsUpdated++
+		} else {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Relationship %q->%q not found in model", ch.From, ch.To))
+		}
+
+	case Deleted:
+		before := len(m.Relationships)
+		m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
+		if len(m.Relationships) < before {
+			result.RelationshipsDeleted++
+		}
+
+	case Added:
+		m.Relationships = append(m.Relationships, model.Relationship{
+			From:  ch.From,
+			To:    ch.To,
+			Label: ch.NewValue,
+		})
+		result.RelationshipsCreated++
+	}
+}
+
+// filterRelationships returns all relationships except those matching from/to.
+func filterRelationships(rels []model.Relationship, from, to string) []model.Relationship {
+	result := make([]model.Relationship, 0, len(rels))
+	for _, r := range rels {
+		if r.From != from || r.To != to {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// modifyElement finds an element by dot-notation ID and applies fn to it.
+func modifyElement(m *model.BausteinsichtModel, id string, fn func(*model.Element)) error {
+	parts := strings.Split(id, ".")
+	return modifyInMap(m.Model, parts, id, fn)
+}
+
+// modifyInMap recursively walks the map to find and modify the target element.
+func modifyInMap(elems map[string]model.Element, parts []string, fullID string, fn func(*model.Element)) error {
+	if len(parts) == 0 {
+		return fmt.Errorf("empty path")
+	}
+	key := parts[0]
+	elem, ok := elems[key]
+	if !ok {
+		return fmt.Errorf("element %q not found", fullID)
+	}
+	if len(parts) == 1 {
+		fn(&elem)
+		elems[key] = elem
+		return nil
+	}
+	if elem.Children == nil {
+		return fmt.Errorf("element %q not found: no children at this level", fullID)
+	}
+	if err := modifyInMap(elem.Children, parts[1:], fullID, fn); err != nil {
+		return err
+	}
+	elems[key] = elem
+	return nil
+}
+
+// deleteElement removes an element by dot-notation ID from the model hierarchy.
+func deleteElement(m *model.BausteinsichtModel, id string) error {
+	parts := strings.Split(id, ".")
+	return deleteFromMap(m.Model, parts, id)
+}
+
+// deleteFromMap recursively walks to find the parent map and deletes the element.
+func deleteFromMap(elems map[string]model.Element, parts []string, fullID string) error {
+	if len(parts) == 0 {
+		return fmt.Errorf("empty path")
+	}
+	key := parts[0]
+	if len(parts) == 1 {
+		if _, ok := elems[key]; !ok {
+			return fmt.Errorf("element %q not found", fullID)
+		}
+		delete(elems, key)
+		return nil
+	}
+	elem, ok := elems[key]
+	if !ok {
+		return fmt.Errorf("element %q not found", fullID)
+	}
+	if elem.Children == nil {
+		return fmt.Errorf("element %q not found: no children at this level", fullID)
+	}
+	if err := deleteFromMap(elem.Children, parts[1:], fullID); err != nil {
+		return err
+	}
+	elems[key] = elem
+	return nil
+}

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -1,0 +1,210 @@
+package sync
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// modelWithRel builds a model with one element and one relationship.
+func modelWithRel(fromID, toID, label string) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			fromID: {Kind: "container", Title: fromID},
+			toID:   {Kind: "container", Title: toID},
+		},
+		Relationships: []model.Relationship{
+			{From: fromID, To: toID, Label: label},
+		},
+	}
+}
+
+// modelWithChild builds a model with a nested child element.
+func modelWithChild(parentID, childKey string) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			parentID: {
+				Kind:  "container",
+				Title: parentID,
+				Children: map[string]model.Element{
+					childKey: {Kind: "component", Title: "child-title"},
+				},
+			},
+		},
+		Relationships: []model.Relationship{},
+	}
+}
+
+// changeSet builds a ChangeSet with a single DrawioElementChange.
+func elemChangeSet(id string, ct ChangeType, field, oldVal, newVal string) *ChangeSet {
+	return &ChangeSet{
+		DrawioElementChanges: []ElementChange{
+			{ID: id, Type: ct, Field: field, OldValue: oldVal, NewValue: newVal},
+		},
+	}
+}
+
+// relChangeSet builds a ChangeSet with a single DrawioRelationshipChange.
+func relChangeSet(from, to string, ct ChangeType, field, oldVal, newVal string) *ChangeSet {
+	return &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: from, To: to, Type: ct, Field: field, OldValue: oldVal, NewValue: newVal},
+		},
+	}
+}
+
+// --- Element change tests ---
+
+func TestApplyReverse_TitleUpdate(t *testing.T) {
+	m := simpleModel("api", "Old Title", "", "")
+	cs := elemChangeSet("api", Modified, "title", "Old Title", "New Title")
+
+	r := ApplyReverse(cs, m)
+
+	if m.Model["api"].Title != "New Title" {
+		t.Errorf("expected title %q, got %q", "New Title", m.Model["api"].Title)
+	}
+	if r.ElementsUpdated != 1 {
+		t.Errorf("expected ElementsUpdated=1, got %d", r.ElementsUpdated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", r.Warnings)
+	}
+}
+
+func TestApplyReverse_DescriptionUpdate(t *testing.T) {
+	m := simpleModel("api", "Title", "Old Desc", "")
+	cs := elemChangeSet("api", Modified, "description", "Old Desc", "New Desc")
+
+	r := ApplyReverse(cs, m)
+
+	if m.Model["api"].Description != "New Desc" {
+		t.Errorf("expected description %q, got %q", "New Desc", m.Model["api"].Description)
+	}
+	if r.ElementsUpdated != 1 {
+		t.Errorf("expected ElementsUpdated=1, got %d", r.ElementsUpdated)
+	}
+}
+
+func TestApplyReverse_TechnologyUpdate(t *testing.T) {
+	m := simpleModel("api", "Title", "", "Go")
+	cs := elemChangeSet("api", Modified, "technology", "Go", "Rust")
+
+	r := ApplyReverse(cs, m)
+
+	if m.Model["api"].Technology != "Rust" {
+		t.Errorf("expected technology %q, got %q", "Rust", m.Model["api"].Technology)
+	}
+	if r.ElementsUpdated != 1 {
+		t.Errorf("expected ElementsUpdated=1, got %d", r.ElementsUpdated)
+	}
+}
+
+func TestApplyReverse_NestedElementUpdate(t *testing.T) {
+	m := modelWithChild("webshop", "api")
+	cs := elemChangeSet("webshop.api", Modified, "title", "child-title", "Updated API")
+
+	r := ApplyReverse(cs, m)
+
+	child := m.Model["webshop"].Children["api"]
+	if child.Title != "Updated API" {
+		t.Errorf("expected nested title %q, got %q", "Updated API", child.Title)
+	}
+	if r.ElementsUpdated != 1 {
+		t.Errorf("expected ElementsUpdated=1, got %d", r.ElementsUpdated)
+	}
+}
+
+func TestApplyReverse_ElementDeleted(t *testing.T) {
+	m := simpleModel("api", "Title", "", "")
+	cs := elemChangeSet("api", Deleted, "", "", "")
+
+	r := ApplyReverse(cs, m)
+
+	if _, exists := m.Model["api"]; exists {
+		t.Error("expected element to be removed from model")
+	}
+	if r.ElementsDeleted != 1 {
+		t.Errorf("expected ElementsDeleted=1, got %d", r.ElementsDeleted)
+	}
+	if len(r.Warnings) != 1 || !strings.Contains(r.Warnings[0], "deleted in draw.io") {
+		t.Errorf("expected deletion warning, got %v", r.Warnings)
+	}
+}
+
+func TestApplyReverse_AddedElementWarning(t *testing.T) {
+	m := emptyModel()
+	cs := elemChangeSet("unknown", Added, "", "", "")
+
+	r := ApplyReverse(cs, m)
+
+	if len(r.Warnings) != 1 || !strings.Contains(r.Warnings[0], "manually") {
+		t.Errorf("expected manual-add warning, got %v", r.Warnings)
+	}
+	if r.ElementsCreated != 0 {
+		t.Errorf("expected ElementsCreated=0, got %d", r.ElementsCreated)
+	}
+}
+
+func TestApplyReverse_ModifyMissingElement(t *testing.T) {
+	m := emptyModel()
+	cs := elemChangeSet("nonexistent", Modified, "title", "", "New")
+
+	r := ApplyReverse(cs, m)
+
+	if r.ElementsUpdated != 0 {
+		t.Errorf("expected no update, got %d", r.ElementsUpdated)
+	}
+	if len(r.Warnings) == 0 {
+		t.Error("expected warning for missing element")
+	}
+}
+
+// --- Relationship change tests ---
+
+func TestApplyReverse_RelationshipLabelUpdated(t *testing.T) {
+	m := modelWithRel("a", "b", "old label")
+	cs := relChangeSet("a", "b", Modified, "label", "old label", "new label")
+
+	r := ApplyReverse(cs, m)
+
+	if m.Relationships[0].Label != "new label" {
+		t.Errorf("expected label %q, got %q", "new label", m.Relationships[0].Label)
+	}
+	if r.RelationshipsUpdated != 1 {
+		t.Errorf("expected RelationshipsUpdated=1, got %d", r.RelationshipsUpdated)
+	}
+}
+
+func TestApplyReverse_RelationshipDeleted(t *testing.T) {
+	m := modelWithRel("a", "b", "calls")
+	cs := relChangeSet("a", "b", Deleted, "", "", "")
+
+	r := ApplyReverse(cs, m)
+
+	if len(m.Relationships) != 0 {
+		t.Errorf("expected relationship to be removed, got %d remaining", len(m.Relationships))
+	}
+	if r.RelationshipsDeleted != 1 {
+		t.Errorf("expected RelationshipsDeleted=1, got %d", r.RelationshipsDeleted)
+	}
+}
+
+func TestApplyReverse_RelationshipAdded(t *testing.T) {
+	m := emptyModel()
+	cs := relChangeSet("x", "y", Added, "", "", "uses")
+
+	r := ApplyReverse(cs, m)
+
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	rel := m.Relationships[0]
+	if rel.From != "x" || rel.To != "y" {
+		t.Errorf("unexpected relationship: %+v", rel)
+	}
+	if r.RelationshipsCreated != 1 {
+		t.Errorf("expected RelationshipsCreated=1, got %d", r.RelationshipsCreated)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `ApplyReverse` in `internal/sync/reverse.go` that applies draw.io-side changes back to the model
- Handles element field updates (title, description, technology) with dot-notation nested traversal
- Handles element deletion with warning; new elements from draw.io get a manual-add warning
- Handles relationship label updates, deletions, and additions
- 10 new tests covering all scenarios including nested elements

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 10 new tests green)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)