### PR TITLE
feat: implement forward sync - model to draw.io (#19)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -1,0 +1,209 @@
+package sync
+
+import (
+	"strconv"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+const (
+	newElementMarker = "strokeColor=#FF0000;dashed=1;"
+	elementGap       = 40.0
+	defaultWidth     = 120.0
+	defaultHeight    = 60.0
+)
+
+// ForwardResult summarises the changes applied to a draw.io document.
+type ForwardResult struct {
+	ElementsCreated   int
+	ElementsUpdated   int
+	ElementsDeleted   int
+	ConnectorsCreated int
+	ConnectorsUpdated int
+	ConnectorsDeleted int
+	Warnings          []string
+}
+
+// ApplyForward applies ModelElementChanges and ModelRelationshipChanges from cs
+// to doc, using templates for styles and m for element data.
+func ApplyForward(
+	cs *ChangeSet,
+	doc *drawio.Document,
+	templates *drawio.TemplateSet,
+	m *model.BausteinsichtModel,
+) *ForwardResult {
+	result := &ForwardResult{}
+	flat := model.FlattenElements(m)
+
+	page := firstPage(doc)
+	if page == nil {
+		result.Warnings = append(result.Warnings, "no page found in document")
+		return result
+	}
+
+	placement := computePlacement(page)
+
+	for _, ch := range cs.ModelElementChanges {
+		switch ch.Type {
+		case Added:
+			applyElementAdded(ch.ID, page, templates, flat, &placement, result)
+		case Modified:
+			applyElementModified(ch, page, flat, result)
+		case Deleted:
+			page.DeleteElement(ch.ID)
+			result.ElementsDeleted++
+		}
+	}
+
+	for _, ch := range cs.ModelRelationshipChanges {
+		switch ch.Type {
+		case Added:
+			applyRelAdded(ch, page, templates, result)
+		case Modified:
+			page.UpdateConnectorLabel(ch.From, ch.To, ch.NewValue)
+			result.ConnectorsUpdated++
+		case Deleted:
+			page.DeleteConnector(ch.From, ch.To)
+			result.ConnectorsDeleted++
+		}
+	}
+
+	return result
+}
+
+// firstPage returns the first page in doc, or nil if there are none.
+func firstPage(doc *drawio.Document) *drawio.Page {
+	pages := doc.Pages()
+	if len(pages) == 0 {
+		return nil
+	}
+	return pages[0]
+}
+
+// placement tracks where the next new element should be placed.
+type placement struct {
+	nextX float64
+	nextY float64
+}
+
+// computePlacement scans existing elements on a page and returns a placement
+// state positioned one row below all existing content.
+func computePlacement(page *drawio.Page) placement {
+	maxY := 0.0
+	for _, obj := range page.FindAllElements() {
+		cell := obj.FindElement("mxCell")
+		if cell == nil {
+			continue
+		}
+		geo := cell.FindElement("mxGeometry")
+		if geo == nil {
+			continue
+		}
+		y, _ := strconv.ParseFloat(geo.SelectAttrValue("y", "0"), 64)
+		h, _ := strconv.ParseFloat(geo.SelectAttrValue("height", "0"), 64)
+		if bottom := y + h; bottom > maxY {
+			maxY = bottom
+		}
+	}
+
+	startY := maxY
+	if maxY > 0 {
+		startY = maxY + elementGap
+	}
+	return placement{nextX: elementGap, nextY: startY}
+}
+
+// applyElementAdded creates a new element on page with a visual new-element marker.
+func applyElementAdded(
+	id string,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	pl *placement,
+	result *ForwardResult,
+) {
+	elem, ok := flat[id]
+	if !ok {
+		result.Warnings = append(result.Warnings, "element not found in model: "+id)
+		return
+	}
+
+	ts, ok := templates.GetStyle(elem.Kind)
+	if !ok {
+		ts = drawio.TemplateStyle{Width: defaultWidth, Height: defaultHeight}
+		result.Warnings = append(result.Warnings, "no template style for kind: "+elem.Kind)
+	}
+
+	style := ts.Style + newElementMarker
+
+	width := ts.Width
+	if width == 0 {
+		width = defaultWidth
+	}
+	height := ts.Height
+	if height == 0 {
+		height = defaultHeight
+	}
+
+	data := drawio.ElementData{
+		ID:          id,
+		Kind:        elem.Kind,
+		Title:       elem.Title,
+		Technology:  elem.Technology,
+		Description: elem.Description,
+		X:           pl.nextX,
+		Y:           pl.nextY,
+		Width:       width,
+		Height:      height,
+	}
+
+	if err := page.CreateElement(data, style); err != nil {
+		result.Warnings = append(result.Warnings, "failed to create element "+id+": "+err.Error())
+		return
+	}
+
+	pl.nextX += width + elementGap
+	result.ElementsCreated++
+}
+
+// applyElementModified updates the changed field of an existing element.
+func applyElementModified(
+	ch ElementChange,
+	page *drawio.Page,
+	flat map[string]*model.Element,
+	result *ForwardResult,
+) {
+	elem, ok := flat[ch.ID]
+	if !ok {
+		result.Warnings = append(result.Warnings, "element not found in model for update: "+ch.ID)
+		return
+	}
+
+	data := drawio.ElementData{
+		ID:          ch.ID,
+		Title:       elem.Title,
+		Technology:  elem.Technology,
+		Description: elem.Description,
+	}
+
+	page.UpdateElement(ch.ID, data)
+	result.ElementsUpdated++
+}
+
+// applyRelAdded creates a new connector on page.
+func applyRelAdded(
+	ch RelationshipChange,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	result *ForwardResult,
+) {
+	style := templates.GetConnectorStyle()
+	data := drawio.ConnectorData{
+		From:  ch.From,
+		To:    ch.To,
+		Label: ch.NewValue,
+	}
+	page.CreateConnector(data, style)
+	result.ConnectorsCreated++
+}

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -1,0 +1,267 @@
+package sync
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// minimalTemplates returns a TemplateSet loaded from a small inline template.
+func minimalTemplates(t *testing.T) *drawio.TemplateSet {
+	t.Helper()
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<mxfile>
+  <diagram id="t1" name="templates">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object bausteinsicht_template="container" label="" id="tpl-container">
+          <mxCell style="shape=mxgraph.c4;c4Type=container;" vertex="1" parent="1">
+            <mxGeometry width="120" height="60" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell bausteinsicht_template="relationship" style="endArrow=block;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`
+	ts, err := drawio.LoadTemplateFromBytes([]byte(xml))
+	if err != nil {
+		t.Fatalf("LoadTemplateFromBytes: %v", err)
+	}
+	return ts
+}
+
+// modelWithElem returns a model containing a single element.
+func modelWithElem(id, kind, title string) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			id: {Kind: kind, Title: title},
+		},
+		Relationships: []model.Relationship{},
+	}
+}
+
+// fwdModelWithRel returns a model with two elements and one relationship.
+func fwdModelWithRel(fromID, toID string) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			fromID: {Kind: "container", Title: "From"},
+			toID:   {Kind: "container", Title: "To"},
+		},
+		Relationships: []model.Relationship{
+			{From: fromID, To: toID, Label: "calls"},
+		},
+	}
+}
+
+// TestApplyForward_NewElement verifies that an Added element change creates the element.
+func TestApplyForward_NewElement(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := modelWithElem("api", "container", "API")
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Added},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsCreated != 1 {
+		t.Fatalf("expected 1 element created, got %d", result.ElementsCreated)
+	}
+
+	page := doc.Pages()[0]
+	obj := page.FindElement("api")
+	if obj == nil {
+		t.Fatal("element 'api' not found in document")
+	}
+	if len(result.Warnings) > 0 {
+		t.Errorf("unexpected warnings: %v", result.Warnings)
+	}
+}
+
+// TestApplyForward_NewElementVisualMarker verifies the new-element style marker is applied.
+func TestApplyForward_NewElementVisualMarker(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := modelWithElem("api", "container", "API")
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{{ID: "api", Type: Added}},
+	}
+	ApplyForward(cs, doc, ts, m)
+
+	page := doc.Pages()[0]
+	obj := page.FindElement("api")
+	if obj == nil {
+		t.Fatal("element 'api' not found")
+	}
+	cell := obj.FindElement("mxCell")
+	if cell == nil {
+		t.Fatal("mxCell not found under element")
+	}
+	style := cell.SelectAttrValue("style", "")
+	if style == "" {
+		t.Fatal("style is empty")
+	}
+	if !strings.Contains(style, "strokeColor=#FF0000") {
+		t.Errorf("expected visual marker in style, got: %s", style)
+	}
+}
+
+// TestApplyForward_UpdatedTitle verifies that a Modified/title change updates the label.
+func TestApplyForward_UpdatedTitle(t *testing.T) {
+	doc := docWithElem("api", "Old Title", "", "")
+	ts := minimalTemplates(t)
+	m := modelWithElem("api", "container", "New Title")
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Modified, Field: "title", OldValue: "Old Title", NewValue: "New Title"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsUpdated != 1 {
+		t.Fatalf("expected 1 element updated, got %d", result.ElementsUpdated)
+	}
+
+	page := doc.Pages()[0]
+	obj := page.FindElement("api")
+	if obj == nil {
+		t.Fatal("element 'api' not found")
+	}
+	label := obj.SelectAttrValue("label", "")
+	if !strings.Contains(label, "New Title") {
+		t.Errorf("expected label to contain 'New Title', got: %s", label)
+	}
+}
+
+// TestApplyForward_DeletedElement verifies that a Deleted change removes the element.
+func TestApplyForward_DeletedElement(t *testing.T) {
+	doc := docWithElem("api", "API", "", "")
+	ts := minimalTemplates(t)
+	m := emptyModel()
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Deleted},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsDeleted != 1 {
+		t.Fatalf("expected 1 element deleted, got %d", result.ElementsDeleted)
+	}
+
+	page := doc.Pages()[0]
+	if page.FindElement("api") != nil {
+		t.Fatal("element 'api' should have been removed")
+	}
+}
+
+// TestApplyForward_NewRelationship verifies that an Added relationship creates a connector.
+func TestApplyForward_NewRelationship(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := fwdModelWithRel("frontend", "backend")
+
+	cs := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "frontend", To: "backend", Type: Added, NewValue: "calls"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ConnectorsCreated != 1 {
+		t.Fatalf("expected 1 connector created, got %d", result.ConnectorsCreated)
+	}
+
+	page := doc.Pages()[0]
+	if page.FindConnector("frontend", "backend") == nil {
+		t.Fatal("connector 'frontend→backend' not found")
+	}
+}
+
+// TestApplyForward_MultipleNewElementsNoOverlap verifies placement doesn't overlap elements.
+func TestApplyForward_MultipleNewElementsNoOverlap(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "a", Type: Added},
+			{ID: "b", Type: Added},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsCreated != 2 {
+		t.Fatalf("expected 2 elements created, got %d", result.ElementsCreated)
+	}
+
+	page := doc.Pages()[0]
+	xA := elementX(page, "a")
+	xB := elementX(page, "b")
+	if xA == xB {
+		t.Errorf("elements 'a' and 'b' have the same X position (%g), expected no overlap", xA)
+	}
+}
+
+// TestApplyForward_NoPageWarning verifies a warning is emitted when the document has no pages.
+func TestApplyForward_NoPageWarning(t *testing.T) {
+	doc := drawio.NewDocument()
+	ts := minimalTemplates(t)
+	m := emptyModel()
+	cs := &ChangeSet{}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if len(result.Warnings) == 0 {
+		t.Fatal("expected a warning for document with no pages")
+	}
+}
+
+// helpers
+
+// elementX returns the X position of an element by bausteinsicht_id, or -1 if not found.
+func elementX(page *drawio.Page, id string) float64 {
+	obj := page.FindElement(id)
+	if obj == nil {
+		return -1
+	}
+	cell := obj.FindElement("mxCell")
+	if cell == nil {
+		return -1
+	}
+	geo := cell.FindElement("mxGeometry")
+	if geo == nil {
+		return -1
+	}
+	val := geo.SelectAttrValue("x", "-1")
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return -1
+	}
+	return f
+}


### PR DESCRIPTION
## Summary

- Implements `ApplyForward(changes, doc, templates, model)` in `internal/sync/forward.go`
- Processes `ModelElementChanges` and `ModelRelationshipChanges` from a `ChangeSet`
- New elements are placed side-by-side below existing content with a visual marker (`strokeColor=#FF0000;dashed=1;`)
- Modified elements update label/tooltip in place; deleted elements/connectors are removed

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestApplyForward_NewElement` — element created in document
- [x] `TestApplyForward_NewElementVisualMarker` — red dashed border on new elements
- [x] `TestApplyForward_UpdatedTitle` — label updated on modification
- [x] `TestApplyForward_DeletedElement` — element removed from document
- [x] `TestApplyForward_NewRelationship` — connector created
- [x] `TestApplyForward_MultipleNewElementsNoOverlap` — placement doesn't overlap
- [x] `TestApplyForward_NoPageWarning` — warning emitted for empty document

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)