### PR TITLE
feat: implement sync engine orchestrator (issue #22)

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1,0 +1,94 @@
+package sync
+
+import (
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// SyncResult contains the comprehensive result of a sync cycle.
+type SyncResult struct {
+	Forward   *ForwardResult
+	Reverse   *ReverseResult
+	Conflicts []ResolvedConflict
+	Warnings  []string
+}
+
+// Run executes one full bidirectional sync cycle.
+// It is a pure function — no file I/O. All data is passed as parameters.
+//
+// Sequence (Chapter 6 - Runtime View):
+//  1. DetectChanges → ChangeSet
+//  2. Resolve conflicts (model wins)
+//  3. Remove conflicting fields from DrawioElementChanges
+//  4. ApplyForward → ForwardResult
+//  5. ApplyReverse → ReverseResult
+//  6. Collect all warnings
+func Run(
+	m *model.BausteinsichtModel,
+	doc *drawio.Document,
+	lastState *SyncState,
+	templates *drawio.TemplateSet,
+) *SyncResult {
+	result := &SyncResult{}
+
+	// Step 1: Detect changes from both sides.
+	changes := DetectChanges(m, doc, lastState)
+
+	// Step 2: Resolve conflicts.
+	if len(changes.Conflicts) > 0 {
+		resolved := NewModelWinsResolver().Resolve(changes.Conflicts)
+		result.Conflicts = resolved
+
+		// Step 3: For model-wins conflicts, drop the draw.io change so that
+		// ApplyReverse does not overwrite the model value.
+		changes.DrawioElementChanges = filterConflictingDrawioChanges(
+			changes.DrawioElementChanges, resolved,
+		)
+	}
+
+	// Step 4: Forward sync (model → draw.io).
+	result.Forward = ApplyForward(changes, doc, templates, m)
+
+	// Step 5: Reverse sync (draw.io → model).
+	result.Reverse = ApplyReverse(changes, m)
+
+	// Step 6: Collect all warnings.
+	result.Warnings = append(result.Warnings, result.Forward.Warnings...)
+	result.Warnings = append(result.Warnings, result.Reverse.Warnings...)
+	for _, rc := range result.Conflicts {
+		result.Warnings = append(result.Warnings, rc.Warning)
+	}
+
+	return result
+}
+
+// filterConflictingDrawioChanges removes draw.io element changes for fields
+// that were resolved in favour of the model (Winner == "model").
+func filterConflictingDrawioChanges(
+	drawioChanges []ElementChange,
+	resolved []ResolvedConflict,
+) []ElementChange {
+	// Build a set of (elementID, field) pairs that model won.
+	type conflictKey struct {
+		id    string
+		field string
+	}
+	modelWins := make(map[conflictKey]struct{}, len(resolved))
+	for _, rc := range resolved {
+		if rc.Winner == "model" {
+			modelWins[conflictKey{rc.ElementID, rc.Field}] = struct{}{}
+		}
+	}
+
+	if len(modelWins) == 0 {
+		return drawioChanges
+	}
+
+	filtered := make([]ElementChange, 0, len(drawioChanges))
+	for _, ch := range drawioChanges {
+		if _, skip := modelWins[conflictKey{ch.ID, ch.Field}]; !skip {
+			filtered = append(filtered, ch)
+		}
+	}
+	return filtered
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1,0 +1,179 @@
+package sync
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Test 1: Empty sync (no changes) → zero counts ---
+
+func TestRun_NoChanges(t *testing.T) {
+	m := simpleModel("api", "API", "A service", "Go")
+	doc := docWithElem("api", "API", "Go", "A service")
+	state := stateWithElem("api", "API", "A service", "Go")
+	ts := minimalTemplates(t)
+
+	result := Run(m, doc, state, ts)
+
+	if result.Forward.ElementsCreated != 0 {
+		t.Errorf("expected 0 elements created, got %d", result.Forward.ElementsCreated)
+	}
+	if result.Forward.ElementsUpdated != 0 {
+		t.Errorf("expected 0 elements updated, got %d", result.Forward.ElementsUpdated)
+	}
+	if result.Reverse.ElementsUpdated != 0 {
+		t.Errorf("expected 0 elements updated in reverse, got %d", result.Reverse.ElementsUpdated)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %d", len(result.Conflicts))
+	}
+}
+
+// --- Test 2: Model added element → forward creates it in doc ---
+
+func TestRun_ModelAddedElement(t *testing.T) {
+	m := modelWithElem("svc", "container", "Service")
+	doc := emptyDoc()
+	state := emptyState()
+	ts := minimalTemplates(t)
+
+	result := Run(m, doc, state, ts)
+
+	if result.Forward.ElementsCreated != 1 {
+		t.Errorf("expected 1 element created, got %d", result.Forward.ElementsCreated)
+	}
+	if result.Reverse.ElementsCreated != 0 {
+		t.Errorf("expected no reverse creates, got %d", result.Reverse.ElementsCreated)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %d", len(result.Conflicts))
+	}
+
+	// Verify element exists in doc
+	pages := doc.Pages()
+	if len(pages) == 0 {
+		t.Fatal("expected at least one page in doc")
+	}
+	elems := pages[0].FindAllElements()
+	found := false
+	for _, e := range elems {
+		if e.SelectAttrValue("bausteinsicht_id", "") == "svc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("element 'svc' not found in doc after forward sync")
+	}
+}
+
+// --- Test 3: draw.io modified title → reverse updates model ---
+
+func TestRun_DrawioModifiedTitle(t *testing.T) {
+	// Model and state agree; draw.io has a different title.
+	m := simpleModel("api", "Old Title", "", "")
+	doc := docWithElem("api", "New Title", "", "")
+	state := stateWithElem("api", "Old Title", "", "")
+	ts := minimalTemplates(t)
+
+	result := Run(m, doc, state, ts)
+
+	if result.Reverse.ElementsUpdated != 1 {
+		t.Errorf("expected 1 element updated in reverse, got %d", result.Reverse.ElementsUpdated)
+	}
+	if result.Forward.ElementsUpdated != 0 {
+		t.Errorf("expected 0 forward updates (no model change), got %d", result.Forward.ElementsUpdated)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %d", len(result.Conflicts))
+	}
+
+	// Model should now have the updated title.
+	elem := m.Model["api"]
+	if elem.Title != "New Title" {
+		t.Errorf("expected model title 'New Title', got %q", elem.Title)
+	}
+}
+
+// --- Test 4: Conflict → model wins, warning generated ---
+
+func TestRun_ConflictModelWins(t *testing.T) {
+	// Both model and draw.io changed title compared to last sync.
+	m := simpleModel("api", "Model Title", "", "")
+	doc := docWithElem("api", "DrawIO Title", "", "")
+	state := stateWithElem("api", "Old Title", "", "")
+	ts := minimalTemplates(t)
+
+	result := Run(m, doc, state, ts)
+
+	if len(result.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d", len(result.Conflicts))
+	}
+	if result.Conflicts[0].Winner != "model" {
+		t.Errorf("expected model to win, got %q", result.Conflicts[0].Winner)
+	}
+
+	// Warning must be present.
+	if len(result.Warnings) == 0 {
+		t.Error("expected at least one warning for conflict")
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "Conflict") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected conflict warning message, got %v", result.Warnings)
+	}
+
+	// draw.io change for that field must NOT have been applied to model.
+	elem := m.Model["api"]
+	if elem.Title != "Model Title" {
+		t.Errorf("expected model title to remain 'Model Title', got %q", elem.Title)
+	}
+}
+
+// --- Test 5: Full round-trip ---
+//
+// Round 1: model has one element, doc is empty, state is empty → forward populates doc.
+// Build new state manually.
+// Round 2: modify model title → second sync detects change and applies it forward.
+
+func TestRun_FullRoundTrip(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	// Round 1: first sync populates an empty doc.
+	m := modelWithElem("svc", "container", "Service v1")
+	doc := emptyDoc()
+	state := emptyState()
+
+	r1 := Run(m, doc, state, ts)
+	if r1.Forward.ElementsCreated != 1 {
+		t.Fatalf("round 1: expected 1 element created, got %d", r1.Forward.ElementsCreated)
+	}
+
+	// Build state after round 1 (in-memory, without file I/O).
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"svc": {Title: "Service v1", Kind: "container"},
+		},
+		Relationships: []RelationshipState{},
+	}
+
+	// Round 2: modify model title → forward update expected.
+	m.Model["svc"] = m.Model["svc"] // ensure map has the element
+	updated := m.Model["svc"]
+	updated.Title = "Service v2"
+	m.Model["svc"] = updated
+
+	r2 := Run(m, doc, state1, ts)
+	if r2.Forward.ElementsUpdated != 1 {
+		t.Errorf("round 2: expected 1 element updated, got %d", r2.Forward.ElementsUpdated)
+	}
+	if r2.Forward.ElementsCreated != 0 {
+		t.Errorf("round 2: expected no new elements, got %d", r2.Forward.ElementsCreated)
+	}
+	if len(r2.Conflicts) != 0 {
+		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
+	}
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -161,7 +161,6 @@ func TestRun_FullRoundTrip(t *testing.T) {
 	}
 
 	// Round 2: modify model title → forward update expected.
-	m.Model["svc"] = m.Model["svc"] // ensure map has the element
 	updated := m.Model["svc"]
 	updated.Title = "Service v2"
 	m.Model["svc"] = updated


### PR DESCRIPTION
## Summary
- Adds `internal/sync/engine.go` with `Run()` — a pure bidirectional sync orchestrator (no I/O)
- `Run()` executes the full sync cycle: detect changes → resolve conflicts (model wins) → forward sync → reverse sync → aggregate warnings
- Adds `internal/sync/engine_test.go` with 5 integration-style tests covering all major scenarios

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 5 engine tests + existing tests green)
- [x] No-change sync produces zero counts
- [x] Model-added element is created in draw.io via forward sync
- [x] draw.io title change is propagated back to model via reverse sync
- [x] Conflict resolves to model value with warning generated
- [x] Full two-round round-trip: empty doc populated in round 1, title change detected in round 2

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)