### PR TITLE
feat: implement add element command (#27)

### DIFF
--- a/cmd/bausteinsicht/add.go
+++ b/cmd/bausteinsicht/add.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add elements or relationships to the model",
+	}
+
+	cmd.AddCommand(newAddElementCmd())
+
+	return cmd
+}

--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newAddElementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "element",
+		Short: "Add an element to the model",
+		RunE:  runAddElement,
+	}
+
+	cmd.Flags().String("id", "", "Unique identifier for the element (required)")
+	cmd.Flags().String("kind", "", "Element kind as defined in specification (required)")
+	cmd.Flags().String("title", "", "Display title (required)")
+	cmd.Flags().String("parent", "", "Parent element ID (dot notation)")
+	cmd.Flags().String("technology", "", "Technology description")
+	cmd.Flags().String("description", "", "Element description")
+
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("kind")
+	_ = cmd.MarkFlagRequired("title")
+
+	return cmd
+}
+
+func runAddElement(cmd *cobra.Command, args []string) error {
+	id, _ := cmd.Flags().GetString("id")
+	kind, _ := cmd.Flags().GetString("kind")
+	title, _ := cmd.Flags().GetString("title")
+	parent, _ := cmd.Flags().GetString("parent")
+	technology, _ := cmd.Flags().GetString("technology")
+	description, _ := cmd.Flags().GetString("description")
+
+	modelPath, _ := cmd.Flags().GetString("model")
+	format, _ := cmd.Flags().GetString("format")
+
+	// Load model
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	// Validate kind
+	if _, ok := m.Specification.Elements[kind]; !ok {
+		return exitWithCode(
+			fmt.Errorf("unknown element kind %q; valid kinds: %s", kind, validKinds(m)),
+			1,
+		)
+	}
+
+	// Build element
+	elem := model.Element{
+		Kind:        kind,
+		Title:       title,
+		Technology:  technology,
+		Description: description,
+	}
+
+	fullID := id
+
+	if parent != "" {
+		// Validate parent exists
+		parentElem, err := model.Resolve(m, parent)
+		if err != nil {
+			return exitWithCode(fmt.Errorf("parent %q not found: %w", parent, err), 1)
+		}
+
+		// Check duplicate within parent's children
+		if parentElem.Children != nil {
+			if _, exists := parentElem.Children[id]; exists {
+				return exitWithCode(fmt.Errorf("element %q already exists under %q", id, parent), 1)
+			}
+		}
+
+		// Add to parent's children — need to update in-place through the model
+		if err := addChildToParent(m, parent, id, elem); err != nil {
+			return exitWithCode(err, 1)
+		}
+
+		fullID = parent + "." + id
+	} else {
+		// Check duplicate at top level
+		if _, exists := m.Model[id]; exists {
+			return exitWithCode(fmt.Errorf("element %q already exists at top level", id), 1)
+		}
+
+		if m.Model == nil {
+			m.Model = make(map[string]model.Element)
+		}
+		m.Model[id] = elem
+	}
+
+	// Save model
+	if err := model.Save(modelPath, m); err != nil {
+		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+	}
+
+	// Output
+	if format == "json" {
+		out := map[string]string{
+			"id":    fullID,
+			"kind":  kind,
+			"title": title,
+		}
+		data, _ := json.Marshal(out)
+		fmt.Println(string(data))
+	} else {
+		fmt.Printf("Added element '%s' (kind: %s) to model.\n", fullID, kind)
+	}
+
+	return nil
+}
+
+// addChildToParent traverses the model to the parent and adds the child element.
+func addChildToParent(m *model.BausteinsichtModel, parentPath, childID string, child model.Element) error {
+	parts := splitDotPath(parentPath)
+
+	// Get root element
+	root, ok := m.Model[parts[0]]
+	if !ok {
+		return fmt.Errorf("element %q not found", parts[0])
+	}
+
+	if len(parts) == 1 {
+		if root.Children == nil {
+			root.Children = make(map[string]model.Element)
+		}
+		root.Children[childID] = child
+		m.Model[parts[0]] = root
+		return nil
+	}
+
+	// Traverse to parent, building a stack of elements to update
+	stack := []model.Element{root}
+	current := root
+	for _, part := range parts[1:] {
+		if current.Children == nil {
+			return fmt.Errorf("no children at %q", part)
+		}
+		next, ok := current.Children[part]
+		if !ok {
+			return fmt.Errorf("element %q not found", part)
+		}
+		stack = append(stack, next)
+		current = next
+	}
+
+	// Add child to the deepest parent
+	if current.Children == nil {
+		current.Children = make(map[string]model.Element)
+	}
+	current.Children[childID] = child
+	stack[len(stack)-1] = current
+
+	// Walk back up the stack updating parents
+	for i := len(stack) - 1; i > 0; i-- {
+		parentElem := stack[i-1]
+		if parentElem.Children == nil {
+			parentElem.Children = make(map[string]model.Element)
+		}
+		parentElem.Children[parts[i]] = stack[i]
+		stack[i-1] = parentElem
+	}
+
+	m.Model[parts[0]] = stack[0]
+	return nil
+}
+
+func splitDotPath(path string) []string {
+	result := []string{}
+	current := ""
+	for _, c := range path {
+		if c == '.' {
+			if current != "" {
+				result = append(result, current)
+			}
+			current = ""
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		result = append(result, current)
+	}
+	return result
+}
+
+func validKinds(m *model.BausteinsichtModel) string {
+	kinds := ""
+	for k := range m.Specification.Elements {
+		if kinds != "" {
+			kinds += ", "
+		}
+		kinds += k
+	}
+	return kinds
+}

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func writeSampleModel(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "architecture.jsonc")
+	content := `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "box"},
+      "container": {"notation": "box", "container": true}
+    }
+  },
+  "model": {
+    "webshop": {
+      "kind": "system",
+      "title": "Webshop",
+      "children": {
+        "api": {
+          "kind": "container",
+          "title": "API"
+        }
+      }
+    }
+  },
+  "relationships": [],
+  "views": {}
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestAddElementTopLevel(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elem, ok := m.Model["payments"]
+	if !ok {
+		t.Fatal("expected element 'payments' in model")
+	}
+	if elem.Kind != "system" {
+		t.Errorf("expected kind 'system', got %q", elem.Kind)
+	}
+	if elem.Title != "Payment Service" {
+		t.Errorf("expected title 'Payment Service', got %q", elem.Title)
+	}
+}
+
+func TestAddElementNested(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "db",
+		"--kind", "container",
+		"--title", "Database",
+		"--parent", "webshop",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, ok := m.Model["webshop"]
+	if !ok {
+		t.Fatal("expected 'webshop' in model")
+	}
+	child, ok := ws.Children["db"]
+	if !ok {
+		t.Fatal("expected child 'db' under webshop")
+	}
+	if child.Title != "Database" {
+		t.Errorf("expected title 'Database', got %q", child.Title)
+	}
+}
+
+func TestAddElementInvalidKind(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "foo",
+		"--kind", "nonexistent",
+		"--title", "Foo",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid kind")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementDuplicateID(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "webshop",
+		"--kind", "system",
+		"--title", "Duplicate",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for duplicate ID")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementDuplicateNestedID(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "api",
+		"--kind", "container",
+		"--title", "Duplicate API",
+		"--parent", "webshop",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for duplicate nested ID")
+	}
+}
+
+func TestAddElementNonExistentParent(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "foo",
+		"--kind", "system",
+		"--title", "Foo",
+		"--parent", "nonexistent",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent parent")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--format", "json",
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+	})
+
+	err := cmd.Execute()
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["id"] != "payments" {
+		t.Errorf("expected id 'payments', got %q", result["id"])
+	}
+	if result["kind"] != "system" {
+		t.Errorf("expected kind 'system', got %q", result["kind"])
+	}
+}
+
+func TestAddElementWithOptionalFlags(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+		"--technology", "Go",
+		"--description", "Handles payments",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elem := m.Model["payments"]
+	if elem.Technology != "Go" {
+		t.Errorf("expected technology 'Go', got %q", elem.Technology)
+	}
+	if elem.Description != "Handles payments" {
+		t.Errorf("expected description 'Handles payments', got %q", elem.Description)
+	}
+}

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -213,7 +213,7 @@ func TestAddElementJSONOutput(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	if err != nil {

--- a/cmd/bausteinsicht/main.go
+++ b/cmd/bausteinsicht/main.go
@@ -3,20 +3,18 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var version = "dev"
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:     "bausteinsicht",
-		Short:   "Architecture-as-code with draw.io synchronization",
-		Version: version,
-	}
+	rootCmd := NewRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
+		if e, ok := err.(*exitError); ok {
+			fmt.Fprintln(os.Stderr, e.Error())
+			os.Exit(e.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// NewRootCmd creates and returns the root cobra command with global flags.
+func NewRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "bausteinsicht",
+		Short:   "Architecture-as-code with draw.io synchronization",
+		Version: version,
+	}
+
+	rootCmd.PersistentFlags().String("format", "text", "Output format: text or json")
+	rootCmd.PersistentFlags().String("model", "", "Path to model file (.jsonc)")
+	rootCmd.PersistentFlags().String("template", "", "Path to draw.io template file")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+	rootCmd.AddCommand(newAddCmd())
+
+	return rootCmd
+}
+
+type exitError struct {
+	err  error
+	code int
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+
+func exitWithCode(err error, code int) *exitError {
+	return &exitError{err: err, code: code}
+}


### PR DESCRIPTION
## Summary
- Adds `bausteinsicht add element` CLI command for adding elements to the architecture model
- Refactors `main.go` into `root.go` pattern with `NewRootCmd()` and global persistent flags (`--format`, `--model`, `--template`, `--verbose`)
- Creates `add` parent command group and `add element` subcommand
- Supports required flags (`--id`, `--kind`, `--title`) and optional flags (`--parent`, `--technology`, `--description`)
- Validates kind against model specification, checks for duplicate IDs, resolves parent via dot notation
- Text and JSON output formats; exit codes 0/1/2 for success/validation/I/O errors

## Test plan
- [x] Test add top-level element
- [x] Test add nested element (with `--parent`)
- [x] Test invalid kind → exit 1
- [x] Test duplicate ID → exit 1
- [x] Test duplicate nested ID → exit 1
- [x] Test non-existent parent → exit 1
- [x] Test JSON output format
- [x] Test optional flags (technology, description)
- [x] All existing tests still pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)