### PR TITLE
feat: implement validate command (#26)

### DIFF
--- a/cmd/bausteinsicht/main.go
+++ b/cmd/bausteinsicht/main.go
@@ -3,20 +3,16 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var version = "dev"
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:     "bausteinsicht",
-		Short:   "Architecture-as-code with draw.io synchronization",
-		Version: version,
-	}
-
-	if err := rootCmd.Execute(); err != nil {
+	if err := NewRootCmd().Execute(); err != nil {
+		if ee, ok := err.(*exitError); ok {
+			fmt.Fprintln(os.Stderr, ee.Error())
+			os.Exit(ee.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// NewRootCmd creates and returns the root cobra command with global flags.
+func NewRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "bausteinsicht",
+		Short:   "Architecture-as-code with draw.io synchronization",
+		Version: version,
+	}
+
+	rootCmd.PersistentFlags().String("format", "text", "Output format: text or json")
+	rootCmd.PersistentFlags().String("model", "", "Path to model file (.jsonc)")
+	rootCmd.PersistentFlags().String("template", "", "Path to draw.io template file")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+	rootCmd.AddCommand(newValidateCmd())
+
+	return rootCmd
+}
+
+// exitError wraps an error with an exit code for structured error handling.
+type exitError struct {
+	err  error
+	code int
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+
+func exitWithCode(err error, code int) *exitError {
+	return &exitError{err: err, code: code}
+}

--- a/cmd/bausteinsicht/validate.go
+++ b/cmd/bausteinsicht/validate.go
@@ -66,7 +66,9 @@ func outputJSON(cmd *cobra.Command, errs []model.ValidationError) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+		return err
+	}
 	if !result.Valid {
 		return exitWithCode(fmt.Errorf("validation failed"), 1)
 	}
@@ -75,11 +77,13 @@ func outputJSON(cmd *cobra.Command, errs []model.ValidationError) error {
 
 func outputText(cmd *cobra.Command, errs []model.ValidationError) error {
 	if len(errs) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "Model is valid.")
-		return nil
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "Model is valid.")
+		return err
 	}
 	for _, e := range errs {
-		fmt.Fprintf(cmd.OutOrStdout(), "ERROR: [%s] %s\n", e.Path, e.Message)
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "ERROR: [%s] %s\n", e.Path, e.Message); err != nil {
+			return err
+		}
 	}
 	return exitWithCode(fmt.Errorf("validation failed"), 1)
 }

--- a/cmd/bausteinsicht/validate.go
+++ b/cmd/bausteinsicht/validate.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+type validateResult struct {
+	Valid  bool              `json:"valid"`
+	Errors []validateErrJSON `json:"errors"`
+}
+
+type validateErrJSON struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "validate",
+		Short:         "Validate the architecture model",
+		Long:          "Validates the architecture model file for consistency and reports any errors.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runValidate,
+	}
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(err, 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(err, 2)
+	}
+
+	errs := model.Validate(m)
+
+	if format == "json" {
+		return outputJSON(cmd, errs)
+	}
+	return outputText(cmd, errs)
+}
+
+func outputJSON(cmd *cobra.Command, errs []model.ValidationError) error {
+	result := validateResult{
+		Valid:  len(errs) == 0,
+		Errors: make([]validateErrJSON, len(errs)),
+	}
+	for i, e := range errs {
+		result.Errors[i] = validateErrJSON{Path: e.Path, Message: e.Message}
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	if !result.Valid {
+		return exitWithCode(fmt.Errorf("validation failed"), 1)
+	}
+	return nil
+}
+
+func outputText(cmd *cobra.Command, errs []model.ValidationError) error {
+	if len(errs) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "Model is valid.")
+		return nil
+	}
+	for _, e := range errs {
+		fmt.Fprintf(cmd.OutOrStdout(), "ERROR: [%s] %s\n", e.Path, e.Message)
+	}
+	return exitWithCode(fmt.Errorf("validation failed"), 1)
+}

--- a/cmd/bausteinsicht/validate_test.go
+++ b/cmd/bausteinsicht/validate_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/templates"
+)
+
+func executeValidateCmd(args ...string) (string, error) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestValidate_ValidModel(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "Model is valid.") {
+		t.Errorf("expected 'Model is valid.' in output, got %q", out)
+	}
+}
+
+func TestValidate_InvalidModel_MissingTitle(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	invalidModel := `{
+		"specification": {
+			"elements": {
+				"system": {"notation": "System"}
+			}
+		},
+		"model": {
+			"mySystem": {
+				"kind": "system",
+				"title": ""
+			}
+		},
+		"relationships": [],
+		"views": {
+			"main": {"title": "Main View"}
+		}
+	}`
+	if err := os.WriteFile(modelPath, []byte(invalidModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath)
+	if err == nil {
+		t.Fatal("expected an error for invalid model")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+	if !strings.Contains(out, "ERROR:") {
+		t.Errorf("expected ERROR in output, got %q", out)
+	}
+}
+
+func TestValidate_NonExistentFile(t *testing.T) {
+	_, err := executeValidateCmd("validate", "--model", "/nonexistent/model.jsonc")
+	if err == nil {
+		t.Fatal("expected an error for non-existent file")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 2 {
+		t.Errorf("expected exit code 2, got %d", ee.code)
+	}
+}
+
+func TestValidate_JSONOutput_Valid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result validateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, out)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid=true, got false")
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %d", len(result.Errors))
+	}
+}
+
+func TestValidate_JSONOutput_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	invalidModel := `{
+		"specification": {
+			"elements": {
+				"system": {"notation": "System"}
+			}
+		},
+		"model": {
+			"mySystem": {
+				"kind": "system",
+				"title": ""
+			}
+		},
+		"relationships": [],
+		"views": {
+			"main": {"title": "Main View"}
+		}
+	}`
+	if err := os.WriteFile(modelPath, []byte(invalidModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath, "--format", "json")
+	if err == nil {
+		t.Fatal("expected an error for invalid model")
+	}
+
+	var result validateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, out)
+	}
+	if result.Valid {
+		t.Errorf("expected valid=false, got true")
+	}
+	if len(result.Errors) == 0 {
+		t.Errorf("expected errors, got none")
+	}
+}
+
+func TestValidate_AutoDetect(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	out, cmdErr := executeValidateCmd("validate")
+	if cmdErr != nil {
+		t.Fatalf("expected no error, got %v", cmdErr)
+	}
+	if !strings.Contains(out, "Model is valid.") {
+		t.Errorf("expected 'Model is valid.' in output, got %q", out)
+	}
+}
+
+func TestValidate_AutoDetect_NoFile(t *testing.T) {
+	dir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	_, cmdErr := executeValidateCmd("validate")
+	if cmdErr == nil {
+		t.Fatal("expected an error when no .jsonc file exists")
+	}
+	ee, ok := cmdErr.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", cmdErr, cmdErr)
+	}
+	if ee.code != 2 {
+		t.Errorf("expected exit code 2, got %d", ee.code)
+	}
+}

--- a/cmd/bausteinsicht/validate_test.go
+++ b/cmd/bausteinsicht/validate_test.go
@@ -170,7 +170,7 @@ func TestValidate_AutoDetect(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chdir(origDir) })
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	out, cmdErr := executeValidateCmd("validate")
 	if cmdErr != nil {
@@ -191,7 +191,7 @@ func TestValidate_AutoDetect_NoFile(t *testing.T) {
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chdir(origDir) })
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	_, cmdErr := executeValidateCmd("validate")
 	if cmdErr == nil {


### PR DESCRIPTION
## Summary
- Adds `bausteinsicht validate` command that validates architecture model files for consistency
- Refactors `main.go` into `root.go` pattern with `NewRootCmd()` and global persistent flags (`--format`, `--model`, `--template`, `--verbose`)
- Supports text output (`ERROR: [path] message`) and JSON output (`{"valid":false,"errors":[...]}`)
- Uses structured exit codes: 0=valid, 1=validation errors, 2=I/O error
- Auto-detects `.jsonc` files in current directory when `--model` is not specified

## Test plan
- [x] Test with valid model (sample model from templates)
- [x] Test with invalid model (missing required fields) — verifies exit code 1
- [x] Test with non-existent file — verifies exit code 2
- [x] Test JSON output format (valid model)
- [x] Test JSON output format (invalid model)
- [x] Test auto-detection of .jsonc files
- [x] Test auto-detection with no .jsonc files — verifies exit code 2
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)