### PR TITLE
feat: implement add relationship command (#28)

### DIFF
--- a/cmd/bausteinsicht/add.go
+++ b/cmd/bausteinsicht/add.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add elements or relationships to the model",
+	}
+
+	cmd.AddCommand(newAddRelationshipCmd())
+
+	return cmd
+}

--- a/cmd/bausteinsicht/add_relationship.go
+++ b/cmd/bausteinsicht/add_relationship.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newAddRelationshipCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relationship",
+		Short: "Add a relationship between two elements",
+		Long:  "Adds a new relationship to the architecture model. Both --from and --to must reference existing elements.",
+		RunE:  runAddRelationship,
+	}
+
+	cmd.Flags().String("from", "", "Source element (dot-notation path, e.g. webshop.api)")
+	cmd.Flags().String("to", "", "Target element (dot-notation path, e.g. webshop.db)")
+	cmd.Flags().String("label", "", "Relationship label")
+	cmd.Flags().String("kind", "", "Relationship kind (must be defined in specification)")
+	cmd.Flags().String("description", "", "Relationship description")
+
+	_ = cmd.MarkFlagRequired("from")
+	_ = cmd.MarkFlagRequired("to")
+
+	return cmd
+}
+
+func runAddRelationship(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	label, _ := cmd.Flags().GetString("label")
+	kind, _ := cmd.Flags().GetString("kind")
+	description, _ := cmd.Flags().GetString("description")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	if _, err := model.Resolve(m, from); err != nil {
+		return exitWithCode(fmt.Errorf("--from: element %q not found", from), 1)
+	}
+
+	if _, err := model.Resolve(m, to); err != nil {
+		return exitWithCode(fmt.Errorf("--to: element %q not found", to), 1)
+	}
+
+	if kind != "" {
+		if m.Specification.Relationships == nil {
+			return exitWithCode(fmt.Errorf("--kind: %q not defined (no relationship kinds in specification)", kind), 1)
+		}
+		if _, ok := m.Specification.Relationships[kind]; !ok {
+			return exitWithCode(fmt.Errorf("--kind: %q not defined in specification", kind), 1)
+		}
+	}
+
+	for _, r := range m.Relationships {
+		if r.From == from && r.To == to {
+			fmt.Fprintf(os.Stderr, "Warning: relationship %s -> %s already exists\n", from, to)
+			break
+		}
+	}
+
+	rel := model.Relationship{
+		From:        from,
+		To:          to,
+		Label:       label,
+		Kind:        kind,
+		Description: description,
+	}
+	m.Relationships = append(m.Relationships, rel)
+
+	if err := model.Save(modelPath, m); err != nil {
+		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+	}
+
+	if format == "json" {
+		return printRelationshipJSON(rel)
+	}
+	printRelationshipText(rel)
+	return nil
+}
+
+func printRelationshipText(r model.Relationship) {
+	if r.Label != "" {
+		fmt.Printf("Added relationship: %s -> %s (%s)\n", r.From, r.To, r.Label)
+	} else {
+		fmt.Printf("Added relationship: %s -> %s\n", r.From, r.To)
+	}
+}
+
+func printRelationshipJSON(r model.Relationship) error {
+	out := struct {
+		From        string `json:"from"`
+		To          string `json:"to"`
+		Label       string `json:"label,omitempty"`
+		Kind        string `json:"kind,omitempty"`
+		Description string `json:"description,omitempty"`
+	}{
+		From:        r.From,
+		To:          r.To,
+		Label:       r.Label,
+		Kind:        r.Kind,
+		Description: r.Description,
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling JSON: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/cmd/bausteinsicht/add_relationship_test.go
+++ b/cmd/bausteinsicht/add_relationship_test.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func writeRelTestModel(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "architecture.jsonc")
+	content := `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "box"},
+      "container": {"notation": "box", "container": true}
+    },
+    "relationships": {
+      "uses": {"notation": "->"},
+      "depends_on": {"notation": "-->", "dashed": true}
+    }
+  },
+  "model": {
+    "webshop": {
+      "kind": "system",
+      "title": "Webshop",
+      "children": {
+        "api": {
+          "kind": "container",
+          "title": "API"
+        },
+        "db": {
+          "kind": "container",
+          "title": "Database"
+        }
+      }
+    },
+    "payments": {
+      "kind": "system",
+      "title": "Payment Service"
+    }
+  },
+  "relationships": [],
+  "views": {}
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestAddRelationshipValid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--label", "reads from",
+		"--kind", "uses",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	r := m.Relationships[0]
+	if r.From != "webshop.api" {
+		t.Errorf("expected from 'webshop.api', got %q", r.From)
+	}
+	if r.To != "webshop.db" {
+		t.Errorf("expected to 'webshop.db', got %q", r.To)
+	}
+	if r.Label != "reads from" {
+		t.Errorf("expected label 'reads from', got %q", r.Label)
+	}
+	if r.Kind != "uses" {
+		t.Errorf("expected kind 'uses', got %q", r.Kind)
+	}
+}
+
+func TestAddRelationshipNonExistentFrom(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "nonexistent",
+		"--to", "webshop.db",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent --from")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipNonExistentTo(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "nonexistent",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent --to")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipInvalidKind(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--kind", "nonexistent_kind",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid --kind")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipDuplicateWarning(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd1 := NewRootCmd()
+	cmd1.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--label", "also reads",
+	})
+	err := cmd2.Execute()
+	w.Close()
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Fatalf("second add should succeed with warning: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "already exists") {
+		t.Errorf("expected duplicate warning, got: %q", buf.String())
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 2 {
+		t.Errorf("expected 2 relationships, got %d", len(m.Relationships))
+	}
+}
+
+func TestAddRelationshipJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--format", "json",
+		"--from", "webshop.api",
+		"--to", "payments",
+		"--label", "calls",
+		"--kind", "uses",
+	})
+
+	err := cmd.Execute()
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["from"] != "webshop.api" {
+		t.Errorf("expected from 'webshop.api', got %q", result["from"])
+	}
+	if result["to"] != "payments" {
+		t.Errorf("expected to 'payments', got %q", result["to"])
+	}
+	if result["label"] != "calls" {
+		t.Errorf("expected label 'calls', got %q", result["label"])
+	}
+	if result["kind"] != "uses" {
+		t.Errorf("expected kind 'uses', got %q", result["kind"])
+	}
+}
+
+func TestAddRelationshipWithDescription(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop",
+		"--to", "payments",
+		"--label", "delegates to",
+		"--description", "Payment processing delegation",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	r := m.Relationships[0]
+	if r.Description != "Payment processing delegation" {
+		t.Errorf("expected description 'Payment processing delegation', got %q", r.Description)
+	}
+}

--- a/cmd/bausteinsicht/add_relationship_test.go
+++ b/cmd/bausteinsicht/add_relationship_test.go
@@ -192,7 +192,7 @@ func TestAddRelationshipDuplicateWarning(t *testing.T) {
 		"--label", "also reads",
 	})
 	err := cmd2.Execute()
-	w.Close()
+	_ = w.Close()
 	os.Stderr = oldStderr
 
 	if err != nil {
@@ -200,7 +200,7 @@ func TestAddRelationshipDuplicateWarning(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	if !strings.Contains(buf.String(), "already exists") {
 		t.Errorf("expected duplicate warning, got: %q", buf.String())
 	}
@@ -233,7 +233,7 @@ func TestAddRelationshipJSONOutput(t *testing.T) {
 	})
 
 	err := cmd.Execute()
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	if err != nil {
@@ -241,7 +241,7 @@ func TestAddRelationshipJSONOutput(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 	output := buf.String()
 
 	var result map[string]string

--- a/cmd/bausteinsicht/main.go
+++ b/cmd/bausteinsicht/main.go
@@ -3,20 +3,18 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var version = "dev"
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:     "bausteinsicht",
-		Short:   "Architecture-as-code with draw.io synchronization",
-		Version: version,
-	}
+	rootCmd := NewRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
+		if ee, ok := err.(*exitError); ok {
+			fmt.Fprintln(os.Stderr, ee.Error())
+			os.Exit(ee.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -1,0 +1,33 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// NewRootCmd creates and returns the root cobra command with global flags.
+func NewRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "bausteinsicht",
+		Short:   "Architecture-as-code with draw.io synchronization",
+		Version: version,
+	}
+
+	rootCmd.PersistentFlags().String("format", "text", "Output format: text or json")
+	rootCmd.PersistentFlags().String("model", "", "Path to model file (.jsonc)")
+	rootCmd.PersistentFlags().String("template", "", "Path to draw.io template file")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+	rootCmd.AddCommand(newAddCmd())
+
+	return rootCmd
+}
+
+// exitError wraps an error with an exit code for structured error handling.
+type exitError struct {
+	err  error
+	code int
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+
+func exitWithCode(err error, code int) *exitError {
+	return &exitError{err: err, code: code}
+}


### PR DESCRIPTION
## Summary
- Add `bausteinsicht add relationship` command with `--from`, `--to` (required), `--label`, `--kind`, `--description` (optional) flags
- Validates that both `--from` and `--to` resolve to existing elements using `model.Resolve()`
- Validates `--kind` against `specification.relationships` if provided
- Warns on duplicate from+to pairs but still adds the relationship
- Supports `--format json` output
- Includes `root.go` refactor with `NewRootCmd()` pattern and global persistent flags (`--format`, `--model`, `--template`, `--verbose`)
- Exit codes: 0=success, 1=validation error, 2=I/O error

## Test plan
- [x] Test add valid relationship with all flags
- [x] Test non-existent `--from` → exit code 1
- [x] Test non-existent `--to` → exit code 1
- [x] Test invalid `--kind` → exit code 1
- [x] Test duplicate from+to pair → warning on stderr, both added
- [x] Test JSON output format
- [x] Test relationship with description
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)