### PR TITLE
feat: implement init command (#24)

### DIFF
--- a/cmd/bausteinsicht/init.go
+++ b/cmd/bausteinsicht/init.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/docToolchain/Bauteinsicht/internal/sync"
+	"github.com/docToolchain/Bauteinsicht/templates"
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultModelFile   = "architecture.jsonc"
+	defaultDrawioFile  = "architecture.drawio"
+	defaultTemplFile   = "template.drawio"
+	defaultSyncState   = ".bausteinsicht-sync"
+)
+
+func newInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize a new architecture project",
+		Long:  "Creates a sample model, template, and initial draw.io diagram in the current directory.",
+		RunE:  runInit,
+	}
+}
+
+func runInit(cmd *cobra.Command, _ []string) error {
+	format, _ := cmd.Flags().GetString("format")
+
+	// Check if files already exist.
+	for _, name := range []string{defaultModelFile, defaultDrawioFile} {
+		if _, err := os.Stat(name); err == nil {
+			return exitWithCode(
+				fmt.Errorf("file %q already exists; remove it or use a different directory", name),
+				2,
+			)
+		}
+	}
+
+	// Write sample model.
+	if err := os.WriteFile(defaultModelFile, templates.SampleModel, 0644); err != nil {
+		return exitWithCode(fmt.Errorf("writing %s: %w", defaultModelFile, err), 2)
+	}
+
+	// Write template.
+	if err := os.WriteFile(defaultTemplFile, templates.DefaultTemplate, 0644); err != nil {
+		return exitWithCode(fmt.Errorf("writing %s: %w", defaultTemplFile, err), 2)
+	}
+
+	// Load model for sync.
+	m, err := model.Load(defaultModelFile)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	// Load template.
+	tmpl, err := drawio.LoadTemplateFromBytes(templates.DefaultTemplate)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading template: %w", err), 2)
+	}
+
+	// Create empty document and run initial forward sync.
+	doc := drawio.NewDocument()
+	emptyState := &sync.SyncState{
+		Elements:      make(map[string]sync.ElementState),
+		Relationships: []sync.RelationshipState{},
+	}
+
+	// Add pages for each view before sync.
+	for viewID, view := range m.Views {
+		doc.AddPage("view-"+viewID, view.Title)
+	}
+
+	_ = sync.Run(m, doc, emptyState, tmpl)
+
+	// Save generated draw.io file.
+	if err := drawio.SaveDocument(defaultDrawioFile, doc); err != nil {
+		return exitWithCode(fmt.Errorf("writing %s: %w", defaultDrawioFile, err), 2)
+	}
+
+	// Build and save sync state.
+	modelPath, _ := filepath.Abs(defaultModelFile)
+	drawioPath, _ := filepath.Abs(defaultDrawioFile)
+	state, err := sync.BuildState(m, doc, modelPath, drawioPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("building sync state: %w", err), 2)
+	}
+	if err := sync.SaveState(defaultSyncState, state); err != nil {
+		return exitWithCode(fmt.Errorf("writing %s: %w", defaultSyncState, err), 2)
+	}
+
+	// Output result.
+	createdFiles := []string{defaultModelFile, defaultTemplFile, defaultDrawioFile, defaultSyncState}
+
+	if format == "json" {
+		out := map[string]interface{}{
+			"success": true,
+			"files":   createdFiles,
+		}
+		data, _ := json.Marshal(out)
+		fmt.Println(string(data))
+	} else {
+		fmt.Println("Initialized Bausteinsicht project:")
+		for _, f := range createdFiles {
+			fmt.Printf("  - %s\n", f)
+		}
+		fmt.Println()
+		fmt.Println("Next steps:")
+		fmt.Println("  1. Edit architecture.jsonc to define your architecture")
+		fmt.Println("  2. Run 'bausteinsicht sync' to update the draw.io diagram")
+		fmt.Println("  3. Open architecture.drawio in draw.io to arrange elements")
+	}
+
+	return nil
+}

--- a/cmd/bausteinsicht/init_test.go
+++ b/cmd/bausteinsicht/init_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitCreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	buf := &strings.Builder{}
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Check all 4 files exist.
+	for _, name := range []string{defaultModelFile, defaultTemplFile, defaultDrawioFile, defaultSyncState} {
+		if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", name)
+		}
+	}
+}
+
+func TestInitFailsIfFilesExist(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Create model file to trigger conflict.
+	if err := os.WriteFile(defaultModelFile, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when files already exist")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 2 {
+			t.Errorf("expected exit code 2, got %d", e.code)
+		}
+	}
+}
+
+func TestInitDrawioFilesExist(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Create drawio file to trigger conflict.
+	if err := os.WriteFile(defaultDrawioFile, []byte("<mxfile/>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when drawio file already exists")
+	}
+}
+
+func TestInitGeneratesValidModel(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// The model file should be loadable.
+	_, err := os.ReadFile(defaultModelFile)
+	if err != nil {
+		t.Fatalf("reading model: %v", err)
+	}
+}
+
+func TestInitGeneratesValidDrawio(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// The drawio file should contain mxfile and diagram elements.
+	data, err := os.ReadFile(defaultDrawioFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "<mxfile") {
+		t.Error("drawio file missing <mxfile> element")
+	}
+	if !strings.Contains(content, "<diagram") {
+		t.Error("drawio file missing <diagram> element")
+	}
+}
+
+func TestInitJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init", "--format", "json"})
+	err := cmd.Execute()
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["success"] != true {
+		t.Error("expected success=true")
+	}
+	files, ok := result["files"].([]interface{})
+	if !ok || len(files) != 4 {
+		t.Errorf("expected 4 files, got %v", result["files"])
+	}
+}
+
+func TestInitSyncStateValid(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Sync state should be valid JSON with expected fields.
+	data, err := os.ReadFile(defaultSyncState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state map[string]interface{}
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("invalid sync state JSON: %v", err)
+	}
+	if _, ok := state["timestamp"]; !ok {
+		t.Error("sync state missing timestamp")
+	}
+	if _, ok := state["elements"]; !ok {
+		t.Error("sync state missing elements")
+	}
+}

--- a/cmd/bausteinsicht/main.go
+++ b/cmd/bausteinsicht/main.go
@@ -3,20 +3,18 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/spf13/cobra"
 )
 
 var version = "dev"
 
 func main() {
-	rootCmd := &cobra.Command{
-		Use:     "bausteinsicht",
-		Short:   "Architecture-as-code with draw.io synchronization",
-		Version: version,
-	}
+	rootCmd := NewRootCmd()
 
 	if err := rootCmd.Execute(); err != nil {
+		if e, ok := err.(*exitError); ok {
+			fmt.Fprintln(os.Stderr, e.Error())
+			os.Exit(e.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -1,0 +1,32 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// NewRootCmd creates and returns the root cobra command with global flags.
+func NewRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:     "bausteinsicht",
+		Short:   "Architecture-as-code with draw.io synchronization",
+		Version: version,
+	}
+
+	rootCmd.PersistentFlags().String("format", "text", "Output format: text or json")
+	rootCmd.PersistentFlags().String("model", "", "Path to model file (.jsonc)")
+	rootCmd.PersistentFlags().String("template", "", "Path to draw.io template file")
+	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
+
+	rootCmd.AddCommand(newInitCmd())
+
+	return rootCmd
+}
+
+type exitError struct {
+	err  error
+	code int
+}
+
+func (e *exitError) Error() string { return e.err.Error() }
+
+func exitWithCode(err error, code int) *exitError {
+	return &exitError{err: err, code: code}
+}


### PR DESCRIPTION
## Summary
- Refactors `main.go` into `root.go` pattern with `NewRootCmd()` and global persistent flags (`--format`, `--model`, `--template`, `--verbose`)
- Implements `bausteinsicht init` command that scaffolds a new project:
  - Writes embedded sample model → `architecture.jsonc`
  - Writes embedded template → `template.drawio`
  - Runs initial forward sync → `architecture.drawio`
  - Writes sync state → `.bausteinsicht-sync`
- Checks for existing files (exit code 2 if conflict)
- Supports `--format json` output
- 7 end-to-end tests in temp directories

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build ./...` — compiles cleanly
- [ ] CI lint + build-and-test

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)