### PR TITLE
feat: implement validate, add element, add relationship commands (#26, #27, #28)

### DIFF
--- a/cmd/bausteinsicht/add.go
+++ b/cmd/bausteinsicht/add.go
@@ -1,0 +1,15 @@
+package main
+
+import "github.com/spf13/cobra"
+
+func newAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Add elements or relationships to the model",
+	}
+
+	cmd.AddCommand(newAddElementCmd())
+	cmd.AddCommand(newAddRelationshipCmd())
+
+	return cmd
+}

--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newAddElementCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "element",
+		Short: "Add an element to the model",
+		RunE:  runAddElement,
+	}
+
+	cmd.Flags().String("id", "", "Unique identifier for the element (required)")
+	cmd.Flags().String("kind", "", "Element kind as defined in specification (required)")
+	cmd.Flags().String("title", "", "Display title (required)")
+	cmd.Flags().String("parent", "", "Parent element ID (dot notation)")
+	cmd.Flags().String("technology", "", "Technology description")
+	cmd.Flags().String("description", "", "Element description")
+
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("kind")
+	_ = cmd.MarkFlagRequired("title")
+
+	return cmd
+}
+
+func runAddElement(cmd *cobra.Command, args []string) error {
+	id, _ := cmd.Flags().GetString("id")
+	kind, _ := cmd.Flags().GetString("kind")
+	title, _ := cmd.Flags().GetString("title")
+	parent, _ := cmd.Flags().GetString("parent")
+	technology, _ := cmd.Flags().GetString("technology")
+	description, _ := cmd.Flags().GetString("description")
+
+	modelPath, _ := cmd.Flags().GetString("model")
+	format, _ := cmd.Flags().GetString("format")
+
+	// Load model
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	// Validate kind
+	if _, ok := m.Specification.Elements[kind]; !ok {
+		return exitWithCode(
+			fmt.Errorf("unknown element kind %q; valid kinds: %s", kind, validKinds(m)),
+			1,
+		)
+	}
+
+	// Build element
+	elem := model.Element{
+		Kind:        kind,
+		Title:       title,
+		Technology:  technology,
+		Description: description,
+	}
+
+	fullID := id
+
+	if parent != "" {
+		// Validate parent exists
+		parentElem, err := model.Resolve(m, parent)
+		if err != nil {
+			return exitWithCode(fmt.Errorf("parent %q not found: %w", parent, err), 1)
+		}
+
+		// Check duplicate within parent's children
+		if parentElem.Children != nil {
+			if _, exists := parentElem.Children[id]; exists {
+				return exitWithCode(fmt.Errorf("element %q already exists under %q", id, parent), 1)
+			}
+		}
+
+		// Add to parent's children — need to update in-place through the model
+		if err := addChildToParent(m, parent, id, elem); err != nil {
+			return exitWithCode(err, 1)
+		}
+
+		fullID = parent + "." + id
+	} else {
+		// Check duplicate at top level
+		if _, exists := m.Model[id]; exists {
+			return exitWithCode(fmt.Errorf("element %q already exists at top level", id), 1)
+		}
+
+		if m.Model == nil {
+			m.Model = make(map[string]model.Element)
+		}
+		m.Model[id] = elem
+	}
+
+	// Save model
+	if err := model.Save(modelPath, m); err != nil {
+		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+	}
+
+	// Output
+	if format == "json" {
+		out := map[string]string{
+			"id":    fullID,
+			"kind":  kind,
+			"title": title,
+		}
+		data, _ := json.Marshal(out)
+		fmt.Println(string(data))
+	} else {
+		fmt.Printf("Added element '%s' (kind: %s) to model.\n", fullID, kind)
+	}
+
+	return nil
+}
+
+// addChildToParent traverses the model to the parent and adds the child element.
+func addChildToParent(m *model.BausteinsichtModel, parentPath, childID string, child model.Element) error {
+	parts := splitDotPath(parentPath)
+
+	// Get root element
+	root, ok := m.Model[parts[0]]
+	if !ok {
+		return fmt.Errorf("element %q not found", parts[0])
+	}
+
+	if len(parts) == 1 {
+		if root.Children == nil {
+			root.Children = make(map[string]model.Element)
+		}
+		root.Children[childID] = child
+		m.Model[parts[0]] = root
+		return nil
+	}
+
+	// Traverse to parent, building a stack of elements to update
+	stack := []model.Element{root}
+	current := root
+	for _, part := range parts[1:] {
+		if current.Children == nil {
+			return fmt.Errorf("no children at %q", part)
+		}
+		next, ok := current.Children[part]
+		if !ok {
+			return fmt.Errorf("element %q not found", part)
+		}
+		stack = append(stack, next)
+		current = next
+	}
+
+	// Add child to the deepest parent
+	if current.Children == nil {
+		current.Children = make(map[string]model.Element)
+	}
+	current.Children[childID] = child
+	stack[len(stack)-1] = current
+
+	// Walk back up the stack updating parents
+	for i := len(stack) - 1; i > 0; i-- {
+		parentElem := stack[i-1]
+		if parentElem.Children == nil {
+			parentElem.Children = make(map[string]model.Element)
+		}
+		parentElem.Children[parts[i]] = stack[i]
+		stack[i-1] = parentElem
+	}
+
+	m.Model[parts[0]] = stack[0]
+	return nil
+}
+
+func splitDotPath(path string) []string {
+	result := []string{}
+	current := ""
+	for _, c := range path {
+		if c == '.' {
+			if current != "" {
+				result = append(result, current)
+			}
+			current = ""
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		result = append(result, current)
+	}
+	return result
+}
+
+func validKinds(m *model.BausteinsichtModel) string {
+	kinds := ""
+	for k := range m.Specification.Elements {
+		if kinds != "" {
+			kinds += ", "
+		}
+		kinds += k
+	}
+	return kinds
+}

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func writeSampleModel(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "architecture.jsonc")
+	content := `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "box"},
+      "container": {"notation": "box", "container": true}
+    }
+  },
+  "model": {
+    "webshop": {
+      "kind": "system",
+      "title": "Webshop",
+      "children": {
+        "api": {
+          "kind": "container",
+          "title": "API"
+        }
+      }
+    }
+  },
+  "relationships": [],
+  "views": {}
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestAddElementTopLevel(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elem, ok := m.Model["payments"]
+	if !ok {
+		t.Fatal("expected element 'payments' in model")
+	}
+	if elem.Kind != "system" {
+		t.Errorf("expected kind 'system', got %q", elem.Kind)
+	}
+	if elem.Title != "Payment Service" {
+		t.Errorf("expected title 'Payment Service', got %q", elem.Title)
+	}
+}
+
+func TestAddElementNested(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "db",
+		"--kind", "container",
+		"--title", "Database",
+		"--parent", "webshop",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, ok := m.Model["webshop"]
+	if !ok {
+		t.Fatal("expected 'webshop' in model")
+	}
+	child, ok := ws.Children["db"]
+	if !ok {
+		t.Fatal("expected child 'db' under webshop")
+	}
+	if child.Title != "Database" {
+		t.Errorf("expected title 'Database', got %q", child.Title)
+	}
+}
+
+func TestAddElementInvalidKind(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "foo",
+		"--kind", "nonexistent",
+		"--title", "Foo",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid kind")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementDuplicateID(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "webshop",
+		"--kind", "system",
+		"--title", "Duplicate",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for duplicate ID")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementDuplicateNestedID(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "api",
+		"--kind", "container",
+		"--title", "Duplicate API",
+		"--parent", "webshop",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for duplicate nested ID")
+	}
+}
+
+func TestAddElementNonExistentParent(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "foo",
+		"--kind", "system",
+		"--title", "Foo",
+		"--parent", "nonexistent",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent parent")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	}
+}
+
+func TestAddElementJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--format", "json",
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+	})
+
+	err := cmd.Execute()
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["id"] != "payments" {
+		t.Errorf("expected id 'payments', got %q", result["id"])
+	}
+	if result["kind"] != "system" {
+		t.Errorf("expected kind 'system', got %q", result["kind"])
+	}
+}
+
+func TestAddElementWithOptionalFlags(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+		"--technology", "Go",
+		"--description", "Handles payments",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	elem := m.Model["payments"]
+	if elem.Technology != "Go" {
+		t.Errorf("expected technology 'Go', got %q", elem.Technology)
+	}
+	if elem.Description != "Handles payments" {
+		t.Errorf("expected description 'Handles payments', got %q", elem.Description)
+	}
+}

--- a/cmd/bausteinsicht/add_relationship.go
+++ b/cmd/bausteinsicht/add_relationship.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newAddRelationshipCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "relationship",
+		Short: "Add a relationship between two elements",
+		Long:  "Adds a new relationship to the architecture model. Both --from and --to must reference existing elements.",
+		RunE:  runAddRelationship,
+	}
+
+	cmd.Flags().String("from", "", "Source element (dot-notation path, e.g. webshop.api)")
+	cmd.Flags().String("to", "", "Target element (dot-notation path, e.g. webshop.db)")
+	cmd.Flags().String("label", "", "Relationship label")
+	cmd.Flags().String("kind", "", "Relationship kind (must be defined in specification)")
+	cmd.Flags().String("description", "", "Relationship description")
+
+	_ = cmd.MarkFlagRequired("from")
+	_ = cmd.MarkFlagRequired("to")
+
+	return cmd
+}
+
+func runAddRelationship(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	label, _ := cmd.Flags().GetString("label")
+	kind, _ := cmd.Flags().GetString("kind")
+	description, _ := cmd.Flags().GetString("description")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	if _, err := model.Resolve(m, from); err != nil {
+		return exitWithCode(fmt.Errorf("--from: element %q not found", from), 1)
+	}
+
+	if _, err := model.Resolve(m, to); err != nil {
+		return exitWithCode(fmt.Errorf("--to: element %q not found", to), 1)
+	}
+
+	if kind != "" {
+		if m.Specification.Relationships == nil {
+			return exitWithCode(fmt.Errorf("--kind: %q not defined (no relationship kinds in specification)", kind), 1)
+		}
+		if _, ok := m.Specification.Relationships[kind]; !ok {
+			return exitWithCode(fmt.Errorf("--kind: %q not defined in specification", kind), 1)
+		}
+	}
+
+	for _, r := range m.Relationships {
+		if r.From == from && r.To == to {
+			fmt.Fprintf(os.Stderr, "Warning: relationship %s -> %s already exists\n", from, to)
+			break
+		}
+	}
+
+	rel := model.Relationship{
+		From:        from,
+		To:          to,
+		Label:       label,
+		Kind:        kind,
+		Description: description,
+	}
+	m.Relationships = append(m.Relationships, rel)
+
+	if err := model.Save(modelPath, m); err != nil {
+		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+	}
+
+	if format == "json" {
+		return printRelationshipJSON(rel)
+	}
+	printRelationshipText(rel)
+	return nil
+}
+
+func printRelationshipText(r model.Relationship) {
+	if r.Label != "" {
+		fmt.Printf("Added relationship: %s -> %s (%s)\n", r.From, r.To, r.Label)
+	} else {
+		fmt.Printf("Added relationship: %s -> %s\n", r.From, r.To)
+	}
+}
+
+func printRelationshipJSON(r model.Relationship) error {
+	out := struct {
+		From        string `json:"from"`
+		To          string `json:"to"`
+		Label       string `json:"label,omitempty"`
+		Kind        string `json:"kind,omitempty"`
+		Description string `json:"description,omitempty"`
+	}{
+		From:        r.From,
+		To:          r.To,
+		Label:       r.Label,
+		Kind:        r.Kind,
+		Description: r.Description,
+	}
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling JSON: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}

--- a/cmd/bausteinsicht/add_relationship_test.go
+++ b/cmd/bausteinsicht/add_relationship_test.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func writeRelTestModel(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "architecture.jsonc")
+	content := `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "box"},
+      "container": {"notation": "box", "container": true}
+    },
+    "relationships": {
+      "uses": {"notation": "->"},
+      "depends_on": {"notation": "-->", "dashed": true}
+    }
+  },
+  "model": {
+    "webshop": {
+      "kind": "system",
+      "title": "Webshop",
+      "children": {
+        "api": {
+          "kind": "container",
+          "title": "API"
+        },
+        "db": {
+          "kind": "container",
+          "title": "Database"
+        }
+      }
+    },
+    "payments": {
+      "kind": "system",
+      "title": "Payment Service"
+    }
+  },
+  "relationships": [],
+  "views": {}
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestAddRelationshipValid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--label", "reads from",
+		"--kind", "uses",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	r := m.Relationships[0]
+	if r.From != "webshop.api" {
+		t.Errorf("expected from 'webshop.api', got %q", r.From)
+	}
+	if r.To != "webshop.db" {
+		t.Errorf("expected to 'webshop.db', got %q", r.To)
+	}
+	if r.Label != "reads from" {
+		t.Errorf("expected label 'reads from', got %q", r.Label)
+	}
+	if r.Kind != "uses" {
+		t.Errorf("expected kind 'uses', got %q", r.Kind)
+	}
+}
+
+func TestAddRelationshipNonExistentFrom(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "nonexistent",
+		"--to", "webshop.db",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent --from")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipNonExistentTo(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "nonexistent",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent --to")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipInvalidKind(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--kind", "nonexistent_kind",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid --kind")
+	}
+	if e, ok := err.(*exitError); ok {
+		if e.code != 1 {
+			t.Errorf("expected exit code 1, got %d", e.code)
+		}
+	} else {
+		t.Errorf("expected *exitError, got %T", err)
+	}
+}
+
+func TestAddRelationshipDuplicateWarning(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd1 := NewRootCmd()
+	cmd1.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--label", "also reads",
+	})
+	err := cmd2.Execute()
+	_ = w.Close()
+	os.Stderr = oldStderr
+
+	if err != nil {
+		t.Fatalf("second add should succeed with warning: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	if !strings.Contains(buf.String(), "already exists") {
+		t.Errorf("expected duplicate warning, got: %q", buf.String())
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 2 {
+		t.Errorf("expected 2 relationships, got %d", len(m.Relationships))
+	}
+}
+
+func TestAddRelationshipJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--format", "json",
+		"--from", "webshop.api",
+		"--to", "payments",
+		"--label", "calls",
+		"--kind", "uses",
+	})
+
+	err := cmd.Execute()
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	output := buf.String()
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["from"] != "webshop.api" {
+		t.Errorf("expected from 'webshop.api', got %q", result["from"])
+	}
+	if result["to"] != "payments" {
+		t.Errorf("expected to 'payments', got %q", result["to"])
+	}
+	if result["label"] != "calls" {
+		t.Errorf("expected label 'calls', got %q", result["label"])
+	}
+	if result["kind"] != "uses" {
+		t.Errorf("expected kind 'uses', got %q", result["kind"])
+	}
+}
+
+func TestAddRelationshipWithDescription(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop",
+		"--to", "payments",
+		"--label", "delegates to",
+		"--description", "Payment processing delegation",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	r := m.Relationships[0]
+	if r.Description != "Payment processing delegation" {
+		t.Errorf("expected description 'Payment processing delegation', got %q", r.Description)
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -16,6 +16,8 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().Bool("verbose", false, "Enable verbose output")
 
 	rootCmd.AddCommand(newInitCmd())
+	rootCmd.AddCommand(newValidateCmd())
+	rootCmd.AddCommand(newAddCmd())
 
 	return rootCmd
 }

--- a/cmd/bausteinsicht/validate.go
+++ b/cmd/bausteinsicht/validate.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+type validateResult struct {
+	Valid  bool              `json:"valid"`
+	Errors []validateErrJSON `json:"errors"`
+}
+
+type validateErrJSON struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+func newValidateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "validate",
+		Short:         "Validate the architecture model",
+		Long:          "Validates the architecture model file for consistency and reports any errors.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runValidate,
+	}
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(err, 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(err, 2)
+	}
+
+	errs := model.Validate(m)
+
+	if format == "json" {
+		return outputJSON(cmd, errs)
+	}
+	return outputText(cmd, errs)
+}
+
+func outputJSON(cmd *cobra.Command, errs []model.ValidationError) error {
+	result := validateResult{
+		Valid:  len(errs) == 0,
+		Errors: make([]validateErrJSON, len(errs)),
+	}
+	for i, e := range errs {
+		result.Errors[i] = validateErrJSON{Path: e.Path, Message: e.Message}
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+		return err
+	}
+	if !result.Valid {
+		return exitWithCode(fmt.Errorf("validation failed"), 1)
+	}
+	return nil
+}
+
+func outputText(cmd *cobra.Command, errs []model.ValidationError) error {
+	if len(errs) == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "Model is valid.")
+		return err
+	}
+	for _, e := range errs {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "ERROR: [%s] %s\n", e.Path, e.Message); err != nil {
+			return err
+		}
+	}
+	return exitWithCode(fmt.Errorf("validation failed"), 1)
+}

--- a/cmd/bausteinsicht/validate_test.go
+++ b/cmd/bausteinsicht/validate_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/templates"
+)
+
+func executeValidateCmd(args ...string) (string, error) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestValidate_ValidModel(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(out, "Model is valid.") {
+		t.Errorf("expected 'Model is valid.' in output, got %q", out)
+	}
+}
+
+func TestValidate_InvalidModel_MissingTitle(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	invalidModel := `{
+		"specification": {
+			"elements": {
+				"system": {"notation": "System"}
+			}
+		},
+		"model": {
+			"mySystem": {
+				"kind": "system",
+				"title": ""
+			}
+		},
+		"relationships": [],
+		"views": {
+			"main": {"title": "Main View"}
+		}
+	}`
+	if err := os.WriteFile(modelPath, []byte(invalidModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath)
+	if err == nil {
+		t.Fatal("expected an error for invalid model")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+	if !strings.Contains(out, "ERROR:") {
+		t.Errorf("expected ERROR in output, got %q", out)
+	}
+}
+
+func TestValidate_NonExistentFile(t *testing.T) {
+	_, err := executeValidateCmd("validate", "--model", "/nonexistent/model.jsonc")
+	if err == nil {
+		t.Fatal("expected an error for non-existent file")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 2 {
+		t.Errorf("expected exit code 2, got %d", ee.code)
+	}
+}
+
+func TestValidate_JSONOutput_Valid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var result validateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, out)
+	}
+	if !result.Valid {
+		t.Errorf("expected valid=true, got false")
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %d", len(result.Errors))
+	}
+}
+
+func TestValidate_JSONOutput_Invalid(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	invalidModel := `{
+		"specification": {
+			"elements": {
+				"system": {"notation": "System"}
+			}
+		},
+		"model": {
+			"mySystem": {
+				"kind": "system",
+				"title": ""
+			}
+		},
+		"relationships": [],
+		"views": {
+			"main": {"title": "Main View"}
+		}
+	}`
+	if err := os.WriteFile(modelPath, []byte(invalidModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeValidateCmd("validate", "--model", modelPath, "--format", "json")
+	if err == nil {
+		t.Fatal("expected an error for invalid model")
+	}
+
+	var result validateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, out)
+	}
+	if result.Valid {
+		t.Errorf("expected valid=false, got true")
+	}
+	if len(result.Errors) == 0 {
+		t.Errorf("expected errors, got none")
+	}
+}
+
+func TestValidate_AutoDetect(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	out, cmdErr := executeValidateCmd("validate")
+	if cmdErr != nil {
+		t.Fatalf("expected no error, got %v", cmdErr)
+	}
+	if !strings.Contains(out, "Model is valid.") {
+		t.Errorf("expected 'Model is valid.' in output, got %q", out)
+	}
+}
+
+func TestValidate_AutoDetect_NoFile(t *testing.T) {
+	dir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	_, cmdErr := executeValidateCmd("validate")
+	if cmdErr == nil {
+		t.Fatal("expected an error when no .jsonc file exists")
+	}
+	ee, ok := cmdErr.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", cmdErr, cmdErr)
+	}
+	if ee.code != 2 {
+		t.Errorf("expected exit code 2, got %d", ee.code)
+	}
+}


### PR DESCRIPTION
## Summary
- Integrates work from PRs #53, #54, #55 (which had merge conflicts with root.go from #56)
- **validate command**: thin wrapper around `model.Validate()`, text/JSON output, exit codes
- **add element command**: `--id`, `--kind`, `--title`, `--parent`, `--technology`, `--description` flags, validates kind and parent, duplicate detection
- **add relationship command**: `--from`, `--to`, `--label`, `--kind`, `--description` flags, validates endpoints, duplicate warning
- All commands use shared `root.go` with `NewRootCmd()` pattern and global flags
- 22 new tests across all three commands

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go build ./...` — compiles cleanly
- [ ] CI lint + build-and-test

Closes #26, closes #27, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)