### PR TITLE
feat: implement file watcher with debounce (#30)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require github.com/spf13/cobra v1.10.2
 
 require (
 	github.com/beevik/etree v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/beevik/etree v1.6.0 h1:u8Kwy8pp9D9XeITj2Z0XtA5qqZEmtJtuXZRQi+j03eE=
 github.com/beevik/etree v1.6.0/go.mod h1:bh4zJxiIr62SOf9pRzN7UUYaEDa9HEKafK25+sLc0Gc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -9,4 +11,6 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,116 @@
+// Package watcher monitors file system changes for watch mode operation.
+package watcher
+
+import (
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// DefaultDebounce is the default debounce duration.
+const DefaultDebounce = 300 * time.Millisecond
+
+// OnChange is the callback type invoked when a watched file changes.
+type OnChange func(changedFile string)
+
+// Watcher monitors specific files for write changes with debounce support.
+type Watcher struct {
+	fsWatcher *fsnotify.Watcher
+	debounce  time.Duration
+	onChange  OnChange
+	done      chan struct{}
+	syncing   bool
+	mu        sync.Mutex
+}
+
+// New creates a Watcher that monitors the given files. The onChange callback
+// is invoked after the debounce duration elapses following a write event.
+func New(files []string, debounce time.Duration, onChange OnChange) (*Watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range files {
+		if err := fsw.Add(f); err != nil {
+			fsw.Close()
+			return nil, err
+		}
+	}
+
+	return &Watcher{
+		fsWatcher: fsw,
+		debounce:  debounce,
+		onChange:  onChange,
+		done:      make(chan struct{}),
+	}, nil
+}
+
+// Start begins listening for file change events in a background goroutine.
+func (w *Watcher) Start() error {
+	go w.loop()
+	return nil
+}
+
+// Stop signals the watcher to shut down and closes the underlying fsnotify watcher.
+func (w *Watcher) Stop() {
+	close(w.done)
+	w.fsWatcher.Close()
+}
+
+// SetSyncing sets the syncing flag. While true, file change events are ignored
+// to prevent re-triggering from the watcher's own writes.
+func (w *Watcher) SetSyncing(v bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.syncing = v
+}
+
+func (w *Watcher) isSyncing() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.syncing
+}
+
+func (w *Watcher) loop() {
+	var timer *time.Timer
+	var lastFile string
+
+	for {
+		select {
+		case <-w.done:
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+
+		case event, ok := <-w.fsWatcher.Events:
+			if !ok {
+				return
+			}
+			if !event.Has(fsnotify.Write) {
+				continue
+			}
+			if w.isSyncing() {
+				continue
+			}
+
+			lastFile = event.Name
+
+			if timer != nil {
+				timer.Stop()
+			}
+			timer = time.AfterFunc(w.debounce, func() {
+				if !w.isSyncing() {
+					w.onChange(lastFile)
+				}
+			})
+
+		case _, ok := <-w.fsWatcher.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -34,7 +34,7 @@ func New(files []string, debounce time.Duration, onChange OnChange) (*Watcher, e
 
 	for _, f := range files {
 		if err := fsw.Add(f); err != nil {
-			fsw.Close()
+			_ = fsw.Close()
 			return nil, err
 		}
 	}
@@ -56,7 +56,7 @@ func (w *Watcher) Start() error {
 // Stop signals the watcher to shut down and closes the underlying fsnotify watcher.
 func (w *Watcher) Stop() {
 	close(w.done)
-	w.fsWatcher.Close()
+	_ = w.fsWatcher.Close()
 }
 
 // SetSyncing sets the syncing flag. While true, file change events are ignored

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -7,20 +7,31 @@ import (
 	"time"
 )
 
-func TestSingleFileChangeTriggers(t *testing.T) {
+func createTempFile(t *testing.T) string {
+	t.Helper()
 	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString("initial")
-	tmp.Close()
+	name := tmp.Name()
+	if _, err := tmp.WriteString("initial"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(name) })
+	return name
+}
+
+func TestSingleFileChangeTriggers(t *testing.T) {
+	path := createTempFile(t)
 
 	var mu sync.Mutex
 	var called int
 	var lastFile string
 
-	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {
+	w, err := New([]string{path}, 100*time.Millisecond, func(changedFile string) {
 		mu.Lock()
 		defer mu.Unlock()
 		called++
@@ -35,12 +46,10 @@ func TestSingleFileChangeTriggers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Trigger a write event
-	if err := os.WriteFile(tmp.Name(), []byte("changed"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("changed"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Wait for debounce + processing
 	time.Sleep(300 * time.Millisecond)
 
 	mu.Lock()
@@ -48,24 +57,18 @@ func TestSingleFileChangeTriggers(t *testing.T) {
 	if called != 1 {
 		t.Errorf("expected callback called once, got %d", called)
 	}
-	if lastFile != tmp.Name() {
-		t.Errorf("expected file %s, got %s", tmp.Name(), lastFile)
+	if lastFile != path {
+		t.Errorf("expected file %s, got %s", path, lastFile)
 	}
 }
 
 func TestRapidChangesDebounce(t *testing.T) {
-	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString("initial")
-	tmp.Close()
+	path := createTempFile(t)
 
 	var mu sync.Mutex
 	var called int
 
-	w, err := New([]string{tmp.Name()}, 200*time.Millisecond, func(changedFile string) {
+	w, err := New([]string{path}, 200*time.Millisecond, func(changedFile string) {
 		mu.Lock()
 		defer mu.Unlock()
 		called++
@@ -79,15 +82,13 @@ func TestRapidChangesDebounce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Rapid writes within debounce window
 	for i := 0; i < 5; i++ {
-		if err := os.WriteFile(tmp.Name(), []byte("change"+string(rune('0'+i))), 0644); err != nil {
+		if err := os.WriteFile(path, []byte("change"+string(rune('0'+i))), 0644); err != nil {
 			t.Fatal(err)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Wait for debounce to settle
 	time.Sleep(400 * time.Millisecond)
 
 	mu.Lock()
@@ -98,15 +99,9 @@ func TestRapidChangesDebounce(t *testing.T) {
 }
 
 func TestStopWorksCleanly(t *testing.T) {
-	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString("initial")
-	tmp.Close()
+	path := createTempFile(t)
 
-	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {})
+	w, err := New([]string{path}, 100*time.Millisecond, func(changedFile string) {})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,27 +110,22 @@ func TestStopWorksCleanly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Stop should not block or panic
 	w.Stop()
 
 	// Writing after stop should not trigger callback or panic
-	os.WriteFile(tmp.Name(), []byte("after-stop"), 0644)
+	if err := os.WriteFile(path, []byte("after-stop"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	time.Sleep(200 * time.Millisecond)
 }
 
 func TestSyncingFlagPreventsCallback(t *testing.T) {
-	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmp.Name())
-	tmp.WriteString("initial")
-	tmp.Close()
+	path := createTempFile(t)
 
 	var mu sync.Mutex
 	var called int
 
-	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {
+	w, err := New([]string{path}, 100*time.Millisecond, func(changedFile string) {
 		mu.Lock()
 		defer mu.Unlock()
 		called++
@@ -149,14 +139,12 @@ func TestSyncingFlagPreventsCallback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set syncing flag before writing
 	w.SetSyncing(true)
 
-	if err := os.WriteFile(tmp.Name(), []byte("syncing-write"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("syncing-write"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	// Wait for potential debounce
 	time.Sleep(300 * time.Millisecond)
 
 	mu.Lock()
@@ -166,10 +154,9 @@ func TestSyncingFlagPreventsCallback(t *testing.T) {
 		t.Errorf("expected no callback while syncing, got %d", c)
 	}
 
-	// Disable syncing, write again — should trigger
 	w.SetSyncing(false)
 
-	if err := os.WriteFile(tmp.Name(), []byte("after-sync"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("after-sync"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,183 @@
+package watcher
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSingleFileChangeTriggers(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("initial")
+	tmp.Close()
+
+	var mu sync.Mutex
+	var called int
+	var lastFile string
+
+	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {
+		mu.Lock()
+		defer mu.Unlock()
+		called++
+		lastFile = changedFile
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	if err := w.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger a write event
+	if err := os.WriteFile(tmp.Name(), []byte("changed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for debounce + processing
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Errorf("expected callback called once, got %d", called)
+	}
+	if lastFile != tmp.Name() {
+		t.Errorf("expected file %s, got %s", tmp.Name(), lastFile)
+	}
+}
+
+func TestRapidChangesDebounce(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("initial")
+	tmp.Close()
+
+	var mu sync.Mutex
+	var called int
+
+	w, err := New([]string{tmp.Name()}, 200*time.Millisecond, func(changedFile string) {
+		mu.Lock()
+		defer mu.Unlock()
+		called++
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	if err := w.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rapid writes within debounce window
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(tmp.Name(), []byte("change"+string(rune('0'+i))), 0644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for debounce to settle
+	time.Sleep(400 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Errorf("expected callback called once after debounce, got %d", called)
+	}
+}
+
+func TestStopWorksCleanly(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("initial")
+	tmp.Close()
+
+	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stop should not block or panic
+	w.Stop()
+
+	// Writing after stop should not trigger callback or panic
+	os.WriteFile(tmp.Name(), []byte("after-stop"), 0644)
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestSyncingFlagPreventsCallback(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watcher-test-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.WriteString("initial")
+	tmp.Close()
+
+	var mu sync.Mutex
+	var called int
+
+	w, err := New([]string{tmp.Name()}, 100*time.Millisecond, func(changedFile string) {
+		mu.Lock()
+		defer mu.Unlock()
+		called++
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Stop()
+
+	if err := w.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set syncing flag before writing
+	w.SetSyncing(true)
+
+	if err := os.WriteFile(tmp.Name(), []byte("syncing-write"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for potential debounce
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	c := called
+	mu.Unlock()
+	if c != 0 {
+		t.Errorf("expected no callback while syncing, got %d", c)
+	}
+
+	// Disable syncing, write again — should trigger
+	w.SetSyncing(false)
+
+	if err := os.WriteFile(tmp.Name(), []byte("after-sync"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if called != 1 {
+		t.Errorf("expected callback once after syncing disabled, got %d", called)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/watcher/watcher.go` with fsnotify-based file watcher
- Configurable debounce duration (default 300ms) that resets timer on each new event
- Syncing flag to prevent re-triggering from own writes during sync operations
- Only reacts to fsnotify.Write events; ignores Create, Remove, Rename, Chmod
- Clean shutdown via done channel

## Test plan
- [x] Single file change triggers callback once
- [x] Rapid changes within debounce window produce single callback
- [x] Stop() works cleanly without blocking or panicking
- [x] Syncing flag prevents callback; disabling it re-enables callbacks
- [x] All existing tests still pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)