### PR TITLE
feat: implement watch command (#31)

### DIFF
--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -19,6 +19,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newSyncCmd())
 	rootCmd.AddCommand(newValidateCmd())
 	rootCmd.AddCommand(newAddCmd())
+	rootCmd.AddCommand(newWatchCmd())
 
 	return rootCmd
 }

--- a/cmd/bausteinsicht/watch.go
+++ b/cmd/bausteinsicht/watch.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	bsync "github.com/docToolchain/Bauteinsicht/internal/sync"
+	"github.com/docToolchain/Bauteinsicht/internal/watcher"
+	"github.com/docToolchain/Bauteinsicht/templates"
+	"github.com/spf13/cobra"
+)
+
+func newWatchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "watch",
+		Short: "Watch model and diagram for changes and auto-sync",
+		Long:  "Watches the model and draw.io files for changes and automatically runs a sync cycle on each change.",
+		RunE:  runWatch,
+	}
+}
+
+func runWatch(cmd *cobra.Command, _ []string) error {
+	modelPath, _ := cmd.Flags().GetString("model")
+	templatePath, _ := cmd.Flags().GetString("template")
+
+	// Auto-detect model file.
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	// Derive drawio path from model path.
+	dir := filepath.Dir(modelPath)
+	drawioPath := filepath.Join(dir, "architecture.drawio")
+
+	// Verify both files exist before starting the watcher.
+	if _, err := os.Stat(modelPath); err != nil {
+		return exitWithCode(fmt.Errorf("model file not found: %w", err), 2)
+	}
+	if _, err := os.Stat(drawioPath); err != nil {
+		return exitWithCode(fmt.Errorf("draw.io file not found: %w", err), 2)
+	}
+
+	absModel, _ := filepath.Abs(modelPath)
+	absDrawio, _ := filepath.Abs(drawioPath)
+
+	var err error
+
+	fmt.Printf("Watching %s and %s...\n", modelPath, drawioPath)
+
+	// Create the file watcher. Use a variable so the callback can access the watcher.
+	var w *watcher.Watcher
+	w, err = watcher.New(
+		[]string{absModel, absDrawio},
+		watcher.DefaultDebounce,
+		func(changedFile string) {
+			w.SetSyncing(true)
+			defer w.SetSyncing(false)
+			doSync(changedFile, modelPath, drawioPath, templatePath)
+		},
+	)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("creating watcher: %w", err), 2)
+	}
+
+	if err := w.Start(); err != nil {
+		return exitWithCode(fmt.Errorf("starting watcher: %w", err), 2)
+	}
+
+	// Block until SIGINT/SIGTERM.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	w.Stop()
+	fmt.Println("Stopped watching.")
+	return nil
+}
+
+func doSync(changedFile, modelPath, drawioPath, templatePath string) {
+	fmt.Printf("[%s] Sync triggered by %s\n", time.Now().Format("15:04:05"), changedFile)
+
+	dir := filepath.Dir(modelPath)
+	statePath := filepath.Join(dir, ".bausteinsicht-sync")
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading model: %v\n", err)
+		return
+	}
+
+	doc, err := drawio.LoadDocument(drawioPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading draw.io file: %v\n", err)
+		return
+	}
+
+	state, err := bsync.LoadState(statePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading sync state: %v\n", err)
+		return
+	}
+
+	var tmpl *drawio.TemplateSet
+	if templatePath != "" {
+		tmpl, err = drawio.LoadTemplate(templatePath)
+	} else {
+		tmpl, err = drawio.LoadTemplateFromBytes(templates.DefaultTemplate)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading template: %v\n", err)
+		return
+	}
+
+	// Ensure pages exist for all views.
+	for viewID, view := range m.Views {
+		pageID := "view-" + viewID
+		if doc.GetPage(pageID) == nil {
+			doc.AddPage(pageID, view.Title)
+		}
+	}
+
+	result := bsync.Run(m, doc, state, tmpl)
+
+	if err := model.Save(modelPath, m); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR saving model: %v\n", err)
+		return
+	}
+	if err := drawio.SaveDocument(drawioPath, doc); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR saving draw.io file: %v\n", err)
+		return
+	}
+
+	absModel, _ := filepath.Abs(modelPath)
+	absDrawio, _ := filepath.Abs(drawioPath)
+	newState, err := bsync.BuildState(m, doc, absModel, absDrawio)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR building sync state: %v\n", err)
+		return
+	}
+	if err := bsync.SaveState(statePath, newState); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR saving sync state: %v\n", err)
+		return
+	}
+
+	for _, w := range result.Warnings {
+		fmt.Fprintln(os.Stderr, "WARNING:", w)
+	}
+
+	printSyncSummary(buildSyncSummary(result))
+}

--- a/cmd/bausteinsicht/watch_test.go
+++ b/cmd/bausteinsicht/watch_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWatchNoModelFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"watch"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no model file exists")
+	}
+}
+
+func TestWatchCommandRegistered(t *testing.T) {
+	cmd := NewRootCmd()
+	watchCmd, _, err := cmd.Find([]string{"watch"})
+	if err != nil {
+		t.Fatalf("watch command not found: %v", err)
+	}
+	if watchCmd.Use != "watch" {
+		t.Errorf("expected Use='watch', got %q", watchCmd.Use)
+	}
+}
+
+func TestWatchMissingDrawioFile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Create a minimal model file but no drawio file.
+	if err := os.WriteFile("architecture.jsonc", []byte(`{"elements":{},"relationships":[],"views":{}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"watch"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when drawio file does not exist")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `bausteinsicht watch` command that monitors model and draw.io files for changes
- Automatically runs bidirectional sync cycles on file changes with 300ms debounce
- Graceful shutdown on SIGINT/SIGTERM, errors printed to stderr without exiting
- Uses the existing `internal/watcher` package with `SetSyncing` to prevent re-triggering

## Test plan
- [x] `TestWatchCommandRegistered` — verifies command is registered on root
- [x] `TestWatchNoModelFile` — verifies graceful error when no model file exists
- [x] `TestWatchMissingDrawioFile` — verifies error when drawio file is missing
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)