### PR TITLE
docs: migrate architecture diagrams to C4-PlantUML (#48)

### DIFF
--- a/src/docs/arc42/chapters/03_context_and_scope.adoc
+++ b/src/docs/arc42/chapters/03_context_and_scope.adoc
@@ -18,28 +18,28 @@ Bausteinsicht sits between the architecture model (JSON files) and draw.io diagr
 [plantuml, business-context, png]
 ....
 @startuml
-skinparam actorStyle awesome
+!include <C4/C4_Context>
 
-actor "Software Architect" as architect
-actor "Developer" as dev
-actor "LLM Agent" as llm
+Person(architect, "Software Architect", "Edits architecture model and diagrams")
+Person(dev, "Developer", "Reads architecture diagrams")
+Person(llm, "LLM Agent", "Modifies model via CLI commands")
 
-rectangle "Bausteinsicht" as bs
+System(bs, "Bausteinsicht", "Architecture-as-code tool with bidirectional draw.io sync")
 
-file "Architecture Model\n(JSONC files)" as model
-file "draw.io Diagrams\n(.drawio XML)" as drawio
-file "Templates\n(.drawio XML)" as templates
+System_Ext(model, "Architecture Model", "JSONC files on filesystem")
+System_Ext(drawio, "draw.io Diagrams", ".drawio XML files")
+System_Ext(templates, "Templates", ".drawio template files")
 
-architect --> drawio : edits visually
-architect --> model : edits DSL
-dev --> drawio : reads diagrams
-llm --> bs : CLI commands
+Rel(architect, drawio, "Edits visually")
+Rel(architect, model, "Edits DSL")
+Rel(dev, drawio, "Reads diagrams")
+Rel(llm, bs, "CLI commands")
 
-bs --> model : reads / writes
-bs --> drawio : generates / reads
-bs --> templates : reads styling
+Rel(bs, model, "Reads / writes")
+Rel(bs, drawio, "Generates / reads")
+Rel(bs, templates, "Reads styling")
 
-model <--> drawio : bidirectional sync\nvia Bausteinsicht
+BiRel(model, drawio, "Bidirectional sync via Bausteinsicht")
 @enduml
 ....
 

--- a/src/docs/arc42/chapters/04_solution_strategy.adoc
+++ b/src/docs/arc42/chapters/04_solution_strategy.adoc
@@ -41,22 +41,31 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 Bausteinsicht follows a **pipes-and-filters** architecture with a clear separation between data formats:
 
+[plantuml, solution-decomposition, png]
 ....
- ┌─────────┐     ┌─────────────┐     ┌───────────┐
- │  JSON   │────▶│  Sync       │────▶│  draw.io  │
- │  Model  │◀────│  Engine     │◀────│  XML      │
- └─────────┘     └─────────────┘     └───────────┘
-       ▲               │                    ▲
-       │               ▼                    │
-       │         ┌───────────┐              │
-       │         │  Sync     │              │
-       │         │  State    │              │
-       │         └───────────┘              │
-       │                                    │
-  ┌─────────┐                        ┌───────────┐
-  │  JSON   │                        │  Template  │
-  │  Schema │                        │  (.drawio) │
-  └─────────┘                        └───────────┘
+@startuml
+!include <C4/C4_Container>
+
+System_Boundary(bs, "Bausteinsicht") {
+  Container(model_pkg, "Model Package", "Go", "Reads/writes JSONC architecture model")
+  Container(sync_pkg, "Sync Engine", "Go", "Bidirectional three-way merge")
+  Container(drawio_pkg, "DrawIO Package", "Go", "Reads/writes mxGraph XML")
+}
+
+ContainerDb(jsonc, "JSON Model", "JSONC", "Architecture model files")
+ContainerDb(drawiofile, "draw.io XML", "mxGraph", "Diagram files")
+ContainerDb(syncstate, "Sync State", "JSON", ".bausteinsicht-sync")
+ContainerDb(template, "Template", ".drawio", "Visual style templates")
+ContainerDb(schema, "JSON Schema", "JSON Schema", "Model validation")
+
+Rel(model_pkg, jsonc, "Reads / writes")
+Rel(drawio_pkg, drawiofile, "Reads / writes")
+Rel(drawio_pkg, template, "Reads")
+Rel(sync_pkg, syncstate, "Reads / writes")
+Rel(sync_pkg, model_pkg, "Reads / writes model")
+Rel(sync_pkg, drawio_pkg, "Reads / writes XML")
+Rel(schema, jsonc, "Validates")
+@enduml
 ....
 
 * **Model package** reads/writes the JSON model. Knows nothing about draw.io XML.

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -15,38 +15,34 @@ ifndef::imagesdir[:imagesdir: ../../images]
 [plantuml, building-blocks-level1, png]
 ....
 @startuml
-skinparam componentStyle rectangle
-skinparam shadowing false
-skinparam defaultFontSize 11
+!include <C4/C4_Container>
 
-package "bausteinsicht CLI" as cli {
-  [cmd] <<Cobra Commands>>
+Person(user, "User", "Architect, Developer, or LLM Agent")
+
+System_Boundary(bs, "Bausteinsicht") {
+  Container(cmd, "cmd", "Cobra", "CLI entry points, argument parsing, output formatting")
+  Container(model, "model", "Go", "JSON model read/write, validation, ID resolution")
+  Container(drawio, "drawio", "Go", "mxGraph XML read/write, templates, labels")
+  Container(sync, "sync", "Go", "Bidirectional sync engine with three-way merge")
+  Container(watcher_c, "watcher", "Go", "File system watcher with debounce")
 }
 
-package "internal" as internal {
-  [model] <<JSON Model>>
-  [drawio] <<mxGraph XML>>
-  [sync] <<Sync Engine>>
-  [watcher] <<File Watcher>>
-}
+ContainerDb(jsonc, "*.jsonc", "JSONC", "Architecture model files")
+ContainerDb(drawiofile, "*.drawio", "mxGraph XML", "draw.io diagram files")
+ContainerDb(syncstate, ".bausteinsicht-sync", "JSON", "Sync state file")
+ContainerDb(template, "template.drawio", "mxGraph XML", "Style templates")
 
-[cmd] --> [sync] : delegates
-[cmd] --> [model] : delegates
-[cmd] --> [watcher] : delegates
-[sync] --> [model] : reads/writes model
-[sync] --> [drawio] : reads/writes XML
-[watcher] --> [sync] : triggers sync
-
-database "*.jsonc" as jsonc
-database "*.drawio" as drawiofile
-database ".bausteinsicht-sync" as syncstate
-database "template.drawio" as template
-
-[model] --> jsonc : reads/writes
-[drawio] --> drawiofile : reads/writes
-[drawio] --> template : reads
-[sync] --> syncstate : reads/writes
-
+Rel(user, cmd, "CLI commands")
+Rel(cmd, sync, "Delegates")
+Rel(cmd, model, "Delegates")
+Rel(cmd, watcher_c, "Delegates")
+Rel(sync, model, "Reads/writes model")
+Rel(sync, drawio, "Reads/writes XML")
+Rel(watcher_c, sync, "Triggers sync")
+Rel(model, jsonc, "Reads/writes")
+Rel(drawio, drawiofile, "Reads/writes")
+Rel(drawio, template, "Reads")
+Rel(sync, syncstate, "Reads/writes")
 @enduml
 ....
 
@@ -115,26 +111,23 @@ The sync engine is the most complex package. It decomposes into five sub-compone
 [plantuml, building-blocks-level2-sync, png]
 ....
 @startuml
-skinparam componentStyle rectangle
-skinparam shadowing false
-skinparam defaultFontSize 11
+!include <C4/C4_Component>
 
-package "sync" {
-  [engine] <<Orchestrator>>
-  [diff] <<Change Detection>>
-  [forward] <<Model → draw.io>>
-  [reverse] <<draw.io → Model>>
-  [state] <<State Management>>
-  [conflict] <<Conflict Resolution>>
+Container_Boundary(sync, "sync") {
+  Component(engine, "engine", "Go", "Main orchestrator: diff, resolve, apply")
+  Component(diff, "diff", "Go", "Three-way change detection")
+  Component(forward, "forward", "Go", "Applies model changes to draw.io")
+  Component(reverse, "reverse", "Go", "Applies draw.io changes to model")
+  Component(state, "state", "Go", "Sync state file I/O and hashing")
+  Component(conflict, "conflict", "Go", "Conflict detection and resolution")
 }
 
-[engine] --> [diff] : detect changes
-[engine] --> [forward] : apply model changes
-[engine] --> [reverse] : apply drawio changes
-[engine] --> [state] : read/write state
-[engine] --> [conflict] : resolve conflicts
-[diff] --> [conflict] : report conflicts
-
+Rel(engine, diff, "Detect changes")
+Rel(engine, forward, "Apply model changes")
+Rel(engine, reverse, "Apply drawio changes")
+Rel(engine, state, "Read/write state")
+Rel(engine, conflict, "Resolve conflicts")
+Rel(diff, conflict, "Report conflicts")
 @enduml
 ....
 
@@ -171,23 +164,20 @@ The draw.io package handles all mxGraph XML concerns.
 [plantuml, building-blocks-level2-drawio, png]
 ....
 @startuml
-skinparam componentStyle rectangle
-skinparam shadowing false
-skinparam defaultFontSize 11
+!include <C4/C4_Component>
 
-package "drawio" {
-  [document] <<XML Document>>
-  [element] <<Element CRUD>>
-  [connector] <<Connector CRUD>>
-  [template] <<Template Loader>>
-  [label] <<HTML Labels>>
+Container_Boundary(drawio, "drawio") {
+  Component(document, "document", "Go", "mxfile/diagram XML parsing and page management")
+  Component(element, "element", "Go", "Element CRUD as <object> + <mxCell>")
+  Component(connector, "connector", "Go", "Connector CRUD with edge routing")
+  Component(template_c, "template", "Go", "Template loading by bausteinsicht_template attribute")
+  Component(label, "label", "Go", "HTML label generation and parsing")
 }
 
-[document] --> [element] : manages
-[document] --> [connector] : manages
-[element] --> [label] : generates/parses
-[element] --> [template] : applies style
-
+Rel(document, element, "Manages")
+Rel(document, connector, "Manages")
+Rel(element, label, "Generates/parses")
+Rel(element, template_c, "Applies style")
 @enduml
 ....
 
@@ -219,21 +209,18 @@ package "drawio" {
 [plantuml, building-blocks-level2-model, png]
 ....
 @startuml
-skinparam componentStyle rectangle
-skinparam shadowing false
-skinparam defaultFontSize 11
+!include <C4/C4_Component>
 
-package "model" {
-  [types] <<Go Structs>>
-  [loader] <<JSONC I/O>>
-  [resolve] <<ID Resolution>>
-  [validate] <<Validation>>
+Container_Boundary(model, "model") {
+  Component(types, "types", "Go", "BausteinsichtModel, Element, Relationship, View structs")
+  Component(loader, "loader", "Go", "JSONC read/write with comment stripping")
+  Component(resolve, "resolve", "Go", "Dot-notation ID resolution and wildcard matching")
+  Component(validate, "validate", "Go", "Model validation rules")
 }
 
-[loader] --> [types] : populates
-[resolve] --> [types] : traverses
-[validate] --> [types] : checks
-
+Rel(loader, types, "Populates")
+Rel(resolve, types, "Traverses")
+Rel(validate, types, "Checks")
 @enduml
 ....
 


### PR DESCRIPTION
## Summary
- **Chapter 03** (Context): Replaced standard PlantUML actors/rectangles with C4 `Person()`, `System()`, `System_Ext()`, `Rel()`, `BiRel()`
- **Chapter 04** (Solution Strategy): Replaced ASCII art pipes-and-filters diagram with C4 `Container()`, `ContainerDb()`, `System_Boundary()`
- **Chapter 05** (Building Block View): Migrated all 4 diagrams (Level 1 + 3x Level 2) from `componentStyle rectangle` to C4 `Container()`, `Component()`, `Container_Boundary()`
- Chapters 06 (Runtime) and 07 (Deployment) kept as-is — sequence and deployment diagrams are standard UML, not C4

## Test plan
- [ ] Render with `./dtcw generateSite` and verify diagrams display correctly
- [ ] CI build passes

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)