### PR TITLE
Fix: view-aware forward sync (#64)

### DIFF
--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
 
 func TestSyncAfterInit(t *testing.T) {
@@ -130,6 +132,19 @@ func TestSyncDetectsModelChanges(t *testing.T) {
 		t.Fatalf("add element failed: %v", err)
 	}
 
+	// Add newservice to the context view so forward sync picks it up.
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+	if v, ok := m.Views["context"]; ok {
+		v.Include = append(v.Include, "newservice")
+		m.Views["context"] = v
+	}
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save model: %v", err)
+	}
+
 	// Sync should detect the new element.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
@@ -137,7 +152,7 @@ func TestSyncDetectsModelChanges(t *testing.T) {
 
 	cmd3 := NewRootCmd()
 	cmd3.SetArgs([]string{"sync", "--format", "json"})
-	err := cmd3.Execute()
+	err = cmd3.Execute()
 
 	_ = w.Close()
 	os.Stdout = oldStdout

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -27,6 +27,8 @@ type ForwardResult struct {
 
 // ApplyForward applies ModelElementChanges and ModelRelationshipChanges from cs
 // to doc, using templates for styles and m for element data.
+// When the model defines views, elements and relationships are placed on their
+// corresponding view pages. Without views, falls back to the first page.
 func ApplyForward(
 	cs *ChangeSet,
 	doc *drawio.Document,
@@ -36,18 +38,88 @@ func ApplyForward(
 	result := &ForwardResult{}
 	flat := model.FlattenElements(m)
 
-	page := firstPage(doc)
-	if page == nil {
-		result.Warnings = append(result.Warnings, "no page found in document")
+	if len(m.Views) == 0 {
+		applyForwardToPage(cs, doc, templates, flat, nil, result)
 		return result
 	}
 
-	placement := computePlacement(page)
+	applyForwardPerView(cs, doc, templates, flat, m, result)
+	return result
+}
+
+// applyForwardToPage applies all changes to a single page (legacy/no-views mode).
+func applyForwardToPage(
+	cs *ChangeSet,
+	doc *drawio.Document,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	elemFilter map[string]bool,
+	result *ForwardResult,
+) {
+	page := firstPage(doc)
+	if page == nil {
+		result.Warnings = append(result.Warnings, "no page found in document")
+		return
+	}
+	applyChangesToPage(cs, page, templates, flat, elemFilter, result)
+}
+
+// applyForwardPerView iterates over model views and applies changes per page.
+func applyForwardPerView(
+	cs *ChangeSet,
+	doc *drawio.Document,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	m *model.BausteinsichtModel,
+	result *ForwardResult,
+) {
+	for viewID, view := range m.Views {
+		pageID := "view-" + viewID
+		page := doc.GetPage(pageID)
+		if page == nil {
+			result.Warnings = append(result.Warnings,
+				"no page found for view: "+viewID)
+			continue
+		}
+
+		viewCopy := view
+		resolved, err := model.ResolveView(m, &viewCopy)
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				"resolving view "+viewID+": "+err.Error())
+			continue
+		}
+
+		elemSet := make(map[string]bool, len(resolved))
+		for _, id := range resolved {
+			elemSet[id] = true
+		}
+
+		applyChangesToPage(cs, page, templates, flat, elemSet, result)
+	}
+}
+
+// applyChangesToPage applies element and relationship changes to a single page.
+// If elemFilter is nil, all changes are applied. Otherwise only elements in the
+// filter set are processed, and relationships are only created when both
+// endpoints are in the filter set.
+func applyChangesToPage(
+	cs *ChangeSet,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	elemFilter map[string]bool,
+	result *ForwardResult,
+) {
+	pl := computePlacement(page)
 
 	for _, ch := range cs.ModelElementChanges {
+		if elemFilter != nil && !elemFilter[ch.ID] {
+			continue
+		}
 		switch ch.Type {
 		case Added:
-			applyElementAdded(ch.ID, page, templates, flat, &placement, result)
+			applyElementAdded(ch.ID, page, templates, flat, &pl, result)
 		case Modified:
 			applyElementModified(ch, page, flat, result)
 		case Deleted:
@@ -57,6 +129,9 @@ func ApplyForward(
 	}
 
 	for _, ch := range cs.ModelRelationshipChanges {
+		if elemFilter != nil && (!elemFilter[ch.From] || !elemFilter[ch.To]) {
+			continue
+		}
 		switch ch.Type {
 		case Added:
 			applyRelAdded(ch, page, templates, result)
@@ -68,8 +143,6 @@ func ApplyForward(
 			result.ConnectorsDeleted++
 		}
 	}
-
-	return result
 }
 
 // firstPage returns the first page in doc, or nil if there are none.

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -1,0 +1,168 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// modelWithViews returns a model with two top-level elements, a child, and two views.
+func modelWithViews() *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "container", Title: "Customer"},
+			"webshop": {Kind: "container", Title: "Webshop", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API"},
+				"db":  {Kind: "container", Title: "Database"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "webshop", Label: "uses"},
+			{From: "webshop.api", To: "webshop.db", Label: "reads"},
+		},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"customer", "webshop"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "webshop",
+				Include: []string{"customer", "webshop.*"},
+			},
+		},
+	}
+}
+
+// docWithViewPages creates a document with pages matching the model's views.
+func docWithViewPages() *drawio.Document {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	doc.AddPage("view-containers", "Container View")
+	return doc
+}
+
+// TestApplyForward_ElementOnCorrectViewPage verifies that elements are placed
+// on the page corresponding to their view, not all on the first page.
+func TestApplyForward_ElementOnCorrectViewPage(t *testing.T) {
+	doc := docWithViewPages()
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	// Context view should have customer and webshop.
+	contextPage := doc.GetPage("view-context")
+	if contextPage == nil {
+		t.Fatal("context page not found")
+	}
+	if contextPage.FindElement("customer") == nil {
+		t.Error("expected 'customer' on context page")
+	}
+	if contextPage.FindElement("webshop") == nil {
+		t.Error("expected 'webshop' on context page")
+	}
+
+	// Context view should NOT have api or db (those are children, not in context includes).
+	if contextPage.FindElement("webshop.api") != nil {
+		t.Error("'webshop.api' should NOT be on context page")
+	}
+	if contextPage.FindElement("webshop.db") != nil {
+		t.Error("'webshop.db' should NOT be on context page")
+	}
+
+	// Container view should have customer, api, db (from includes: customer + webshop.*).
+	containerPage := doc.GetPage("view-containers")
+	if containerPage == nil {
+		t.Fatal("container page not found")
+	}
+	if containerPage.FindElement("customer") == nil {
+		t.Error("expected 'customer' on container page")
+	}
+	if containerPage.FindElement("webshop.api") == nil {
+		t.Error("expected 'webshop.api' on container page")
+	}
+	if containerPage.FindElement("webshop.db") == nil {
+		t.Error("expected 'webshop.db' on container page")
+	}
+}
+
+// TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints verifies that
+// connectors are only created on pages where both from and to elements exist.
+func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
+	doc := docWithViewPages()
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	// Context page: customer→webshop connector should exist.
+	contextPage := doc.GetPage("view-context")
+	if contextPage.FindConnector("customer", "webshop") == nil {
+		t.Error("expected connector customer→webshop on context page")
+	}
+
+	// Context page: api→db connector should NOT exist (endpoints not on this page).
+	if contextPage.FindConnector("webshop.api", "webshop.db") != nil {
+		t.Error("connector api→db should NOT be on context page")
+	}
+
+	// Container page: api→db connector should exist.
+	containerPage := doc.GetPage("view-containers")
+	if containerPage.FindConnector("webshop.api", "webshop.db") == nil {
+		t.Error("expected connector api→db on container page")
+	}
+}
+
+// TestApplyForward_NoViewsFallback verifies backward compatibility:
+// when no views are defined, elements go to the first page.
+func TestApplyForward_NoViewsFallback(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := modelWithElem("api", "container", "API")
+	// m.Views is nil — should fall back to first page.
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Added},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsCreated != 1 {
+		t.Fatalf("expected 1 element created, got %d", result.ElementsCreated)
+	}
+
+	page := doc.Pages()[0]
+	if page.FindElement("api") == nil {
+		t.Error("expected 'api' on first page when no views defined")
+	}
+}


### PR DESCRIPTION
## Summary
- `ApplyForward` now iterates over model views and resolves which elements belong to each view page using `model.ResolveView()`
- Elements and relationships are placed on their corresponding `view-<id>` diagram pages instead of all going to the first page
- Relationships are only created on pages where both endpoints are present
- Falls back to first-page behavior when no views are defined (backward compatible)

## Changes
- `internal/sync/forward.go`: Restructured into `applyForwardPerView()` and `applyChangesToPage()` with element filter
- `internal/sync/forward_views_test.go`: 3 new tests for view-aware placement
- `cmd/bausteinsicht/sync_test.go`: Updated test to add element to view includes

## Test plan
- [x] New tests verify elements land on correct view pages
- [x] New tests verify relationships only on pages with both endpoints
- [x] Backward compatibility test passes (no views = first page)
- [x] All 47 sync tests pass
- [x] All project tests pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)