### PR TITLE
feat: include description in element labels (#69)

### DIFF
--- a/internal/drawio/element.go
+++ b/internal/drawio/element.go
@@ -40,7 +40,7 @@ func (p *Page) CreateElement(data ElementData, style string) error {
 	}
 
 	obj := root.CreateElement("object")
-	obj.CreateAttr("label", GenerateLabel(data.Title, data.Technology))
+	obj.CreateAttr("label", GenerateLabel(data.Title, data.Technology, data.Description))
 	obj.CreateAttr("id", cellID)
 	obj.CreateAttr("bausteinsicht_id", data.ID)
 	obj.CreateAttr("bausteinsicht_kind", data.Kind)
@@ -105,7 +105,7 @@ func (p *Page) UpdateElement(id string, data ElementData) {
 		return
 	}
 
-	setAttr(obj, "label", GenerateLabel(data.Title, data.Technology))
+	setAttr(obj, "label", GenerateLabel(data.Title, data.Technology, data.Description))
 	setAttr(obj, "tooltip", data.Description)
 	setAttr(obj, "link", data.Link)
 	if data.Technology != "" {

--- a/internal/drawio/element_test.go
+++ b/internal/drawio/element_test.go
@@ -46,7 +46,7 @@ func TestCreateElement(t *testing.T) {
 		t.Errorf("tooltip: got %q, want %q", got, "Handles all API requests")
 	}
 
-	expectedLabel := GenerateLabel("API Gateway", "Spring Boot")
+	expectedLabel := GenerateLabel("API Gateway", "Spring Boot", "Handles all API requests")
 	if got := obj.SelectAttrValue("label", ""); got != expectedLabel {
 		t.Errorf("label: got %q, want %q", got, expectedLabel)
 	}
@@ -163,7 +163,7 @@ func TestUpdateElement(t *testing.T) {
 		t.Fatal("element not found after update")
 	}
 
-	expectedLabel := GenerateLabel("New Title", "MySQL")
+	expectedLabel := GenerateLabel("New Title", "MySQL", "New description")
 	if got := obj.SelectAttrValue("label", ""); got != expectedLabel {
 		t.Errorf("label after update: got %q, want %q", got, expectedLabel)
 	}

--- a/internal/drawio/label.go
+++ b/internal/drawio/label.go
@@ -5,16 +5,20 @@ import (
 )
 
 // GenerateLabel creates an HTML label for draw.io elements.
-// Format: <b>Title</b><br><font color="#666666">Technology</font>
-// If technology is empty, just: <b>Title</b>
+// Format: <b>Title</b><br><font color="#666666">[Technology]</font><br><font color="#999999">Description</font>
+// Technology is wrapped in square brackets per C4 convention.
+// Empty technology or description lines are omitted.
 // The returned string is unescaped HTML; etree handles XML attribute escaping.
-func GenerateLabel(title, technology string) string {
-	escaped := escapeHTML(title)
-	if technology == "" {
-		return "<b>" + escaped + "</b>"
+func GenerateLabel(title, technology, description string) string {
+	var b strings.Builder
+	b.WriteString("<b>" + escapeHTML(title) + "</b>")
+	if technology != "" {
+		b.WriteString("<br><font color=\"#666666\">[" + escapeHTML(technology) + "]</font>")
 	}
-	escapedTech := escapeHTML(technology)
-	return "<b>" + escaped + "</b><br><font color=\"#666666\">" + escapedTech + "</font>"
+	if description != "" {
+		b.WriteString("<br><font color=\"#999999\">" + escapeHTML(description) + "</font>")
+	}
+	return b.String()
 }
 
 // GenerateActorLabel creates a label for actor elements (just the title, no technology line).
@@ -22,42 +26,97 @@ func GenerateActorLabel(title string) string {
 	return "<b>" + escapeHTML(title) + "</b>"
 }
 
-// ParseLabel extracts title and technology from an HTML label.
-// Expected format: <b>Title</b><br><font color="#666666">Technology</font>
-// If the label doesn't match, return the full text as title with empty technology.
-func ParseLabel(html string) (title, technology string) {
-	// Try to match <b>...</b><br><font ...>...</font>
-	if strings.HasPrefix(html, "<b>") {
-		rest := html[len("<b>"):]
-		closeB := strings.Index(rest, "</b>")
-		if closeB >= 0 {
-			titlePart := rest[:closeB]
-			after := rest[closeB+len("</b>"):]
-
-			if after == "" {
-				return unescapeHTML(titlePart), ""
-			}
-
-			// Check for <br><font ...>...</font>
-			if strings.HasPrefix(after, "<br>") {
-				fontPart := after[len("<br>"):]
-				if strings.HasPrefix(fontPart, "<font") {
-					fontClose := strings.Index(fontPart, ">")
-					if fontClose >= 0 {
-						techRest := fontPart[fontClose+1:]
-						endFont := strings.Index(techRest, "</font>")
-						if endFont >= 0 {
-							tech := techRest[:endFont]
-							return unescapeHTML(titlePart), unescapeHTML(tech)
-						}
-					}
-				}
-			}
-		}
+// ParseLabel extracts title, technology and description from an HTML label.
+// Expected format: <b>Title</b><br><font color="#666666">[Technology]</font><br><font color="#999999">Description</font>
+// Also handles legacy format without brackets around technology.
+// If the label doesn't match, return the full text as title.
+func ParseLabel(html string) (title, technology, description string) {
+	if !strings.HasPrefix(html, "<b>") {
+		return stripTags(html), "", ""
 	}
 
-	// Fallback: strip all HTML tags and return plain text as title
-	return stripTags(html), ""
+	rest := html[len("<b>"):]
+	closeB := strings.Index(rest, "</b>")
+	if closeB < 0 {
+		return stripTags(html), "", ""
+	}
+
+	titlePart := rest[:closeB]
+	after := rest[closeB+len("</b>"):]
+
+	if after == "" {
+		return unescapeHTML(titlePart), "", ""
+	}
+
+	// Parse remaining <br><font ...>...</font> segments
+	segments := parseFontSegments(after)
+
+	switch len(segments) {
+	case 1:
+		seg := segments[0]
+		if seg.color == "#999999" {
+			// Description only (no technology)
+			return unescapeHTML(titlePart), "", unescapeHTML(seg.text)
+		}
+		// Technology (with or without brackets)
+		return unescapeHTML(titlePart), unescapeHTML(trimBrackets(seg.text)), ""
+	case 2:
+		tech := unescapeHTML(trimBrackets(segments[0].text))
+		desc := unescapeHTML(segments[1].text)
+		return unescapeHTML(titlePart), tech, desc
+	default:
+		return unescapeHTML(titlePart), "", ""
+	}
+}
+
+type fontSegment struct {
+	color string
+	text  string
+}
+
+// parseFontSegments extracts consecutive <br><font color="...">...</font> segments.
+func parseFontSegments(s string) []fontSegment {
+	var segments []fontSegment
+	for strings.HasPrefix(s, "<br>") {
+		s = s[len("<br>"):]
+		if !strings.HasPrefix(s, "<font") {
+			break
+		}
+		// Extract color attribute
+		colorStart := strings.Index(s, `color="`)
+		if colorStart < 0 {
+			break
+		}
+		colorStart += len(`color="`)
+		colorEnd := strings.Index(s[colorStart:], `"`)
+		if colorEnd < 0 {
+			break
+		}
+		color := s[colorStart : colorStart+colorEnd]
+
+		// Extract text content
+		tagClose := strings.Index(s, ">")
+		if tagClose < 0 {
+			break
+		}
+		textStart := tagClose + 1
+		endFont := strings.Index(s[textStart:], "</font>")
+		if endFont < 0 {
+			break
+		}
+		text := s[textStart : textStart+endFont]
+		segments = append(segments, fontSegment{color: color, text: text})
+		s = s[textStart+endFont+len("</font>"):]
+	}
+	return segments
+}
+
+// trimBrackets removes surrounding square brackets if present.
+func trimBrackets(s string) string {
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		return s[1 : len(s)-1]
+	}
+	return s
 }
 
 // escapeHTML escapes special HTML characters in text content.

--- a/internal/drawio/label_test.go
+++ b/internal/drawio/label_test.go
@@ -6,16 +6,17 @@ import (
 
 func TestGenerateLabel(t *testing.T) {
 	tests := []struct {
-		name       string
-		title      string
-		technology string
-		want       string
+		name        string
+		title       string
+		technology  string
+		description string
+		want        string
 	}{
 		{
 			name:       "standard label with title and technology",
 			title:      "REST API",
 			technology: "Spring Boot",
-			want:       `<b>REST API</b><br><font color="#666666">Spring Boot</font>`,
+			want:       `<b>REST API</b><br><font color="#666666">[Spring Boot]</font>`,
 		},
 		{
 			name:       "title only, no technology",
@@ -33,7 +34,7 @@ func TestGenerateLabel(t *testing.T) {
 			name:       "special characters in technology",
 			title:      "API",
 			technology: `Go & <fast>`,
-			want:       `<b>API</b><br><font color="#666666">Go &amp; &lt;fast&gt;</font>`,
+			want:       `<b>API</b><br><font color="#666666">[Go &amp; &lt;fast&gt;]</font>`,
 		},
 		{
 			name:       "empty title and technology",
@@ -45,15 +46,28 @@ func TestGenerateLabel(t *testing.T) {
 			name:       "empty title with technology",
 			title:      "",
 			technology: "Java",
-			want:       `<b></b><br><font color="#666666">Java</font>`,
+			want:       `<b></b><br><font color="#666666">[Java]</font>`,
+		},
+		{
+			name:        "title, technology and description",
+			title:       "REST API",
+			technology:  "Spring Boot",
+			description: "Handles business logic",
+			want:        `<b>REST API</b><br><font color="#666666">[Spring Boot]</font><br><font color="#999999">Handles business logic</font>`,
+		},
+		{
+			name:        "title and description, no technology",
+			title:       "Customer",
+			description: "End user of the system",
+			want:        `<b>Customer</b><br><font color="#999999">End user of the system</font>`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateLabel(tt.title, tt.technology)
+			got := GenerateLabel(tt.title, tt.technology, tt.description)
 			if got != tt.want {
-				t.Errorf("GenerateLabel(%q, %q)\n  got:  %q\n  want: %q", tt.title, tt.technology, got, tt.want)
+				t.Errorf("GenerateLabel(%q, %q, %q)\n  got:  %q\n  want: %q", tt.title, tt.technology, tt.description, got, tt.want)
 			}
 		})
 	}
@@ -94,14 +108,15 @@ func TestGenerateActorLabel(t *testing.T) {
 
 func TestParseLabel(t *testing.T) {
 	tests := []struct {
-		name       string
-		html       string
-		wantTitle  string
-		wantTech   string
+		name        string
+		html        string
+		wantTitle   string
+		wantTech    string
+		wantDesc    string
 	}{
 		{
 			name:      "standard label with title and technology",
-			html:      `<b>REST API</b><br><font color="#666666">Spring Boot</font>`,
+			html:      `<b>REST API</b><br><font color="#666666">[Spring Boot]</font>`,
 			wantTitle: "REST API",
 			wantTech:  "Spring Boot",
 		},
@@ -131,7 +146,7 @@ func TestParseLabel(t *testing.T) {
 		},
 		{
 			name:      "escaped chars in technology",
-			html:      `<b>API</b><br><font color="#666666">Go &amp; &lt;fast&gt;</font>`,
+			html:      `<b>API</b><br><font color="#666666">[Go &amp; &lt;fast&gt;]</font>`,
 			wantTitle: "API",
 			wantTech:  "Go & <fast>",
 		},
@@ -141,14 +156,33 @@ func TestParseLabel(t *testing.T) {
 			wantTitle: "",
 			wantTech:  "",
 		},
+		{
+			name:      "label with title, tech and description",
+			html:      `<b>REST API</b><br><font color="#666666">[Spring Boot]</font><br><font color="#999999">Handles requests</font>`,
+			wantTitle: "REST API",
+			wantTech:  "Spring Boot",
+			wantDesc:  "Handles requests",
+		},
+		{
+			name:      "label with title and description only",
+			html:      `<b>Customer</b><br><font color="#999999">End user</font>`,
+			wantTitle: "Customer",
+			wantDesc:  "End user",
+		},
+		{
+			name:      "legacy label without brackets (backward compat)",
+			html:      `<b>REST API</b><br><font color="#666666">Spring Boot</font>`,
+			wantTitle: "REST API",
+			wantTech:  "Spring Boot",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTitle, gotTech := ParseLabel(tt.html)
-			if gotTitle != tt.wantTitle || gotTech != tt.wantTech {
-				t.Errorf("ParseLabel(%q)\n  got:  (%q, %q)\n  want: (%q, %q)",
-					tt.html, gotTitle, gotTech, tt.wantTitle, tt.wantTech)
+			gotTitle, gotTech, gotDesc := ParseLabel(tt.html)
+			if gotTitle != tt.wantTitle || gotTech != tt.wantTech || gotDesc != tt.wantDesc {
+				t.Errorf("ParseLabel(%q)\n  got:  (%q, %q, %q)\n  want: (%q, %q, %q)",
+					tt.html, gotTitle, gotTech, gotDesc, tt.wantTitle, tt.wantTech, tt.wantDesc)
 			}
 		})
 	}
@@ -158,20 +192,23 @@ func TestRoundTrip(t *testing.T) {
 	tests := []struct {
 		title string
 		tech  string
+		desc  string
 	}{
-		{"REST API", "Spring Boot"},
-		{"My Service", ""},
-		{`A & B < C > D "E"`, "Go"},
-		{"", "Java"},
-		{"", ""},
+		{"REST API", "Spring Boot", ""},
+		{"My Service", "", ""},
+		{`A & B < C > D "E"`, "Go", ""},
+		{"", "Java", ""},
+		{"", "", ""},
+		{"REST API", "Spring Boot", "Handles requests"},
+		{"Customer", "", "End user of the system"},
 	}
 
 	for _, tt := range tests {
-		label := GenerateLabel(tt.title, tt.tech)
-		gotTitle, gotTech := ParseLabel(label)
-		if gotTitle != tt.title || gotTech != tt.tech {
-			t.Errorf("round-trip GenerateLabel(%q, %q) -> ParseLabel:\n  got:  (%q, %q)\n  want: (%q, %q)",
-				tt.title, tt.tech, gotTitle, gotTech, tt.title, tt.tech)
+		label := GenerateLabel(tt.title, tt.tech, tt.desc)
+		gotTitle, gotTech, gotDesc := ParseLabel(label)
+		if gotTitle != tt.title || gotTech != tt.tech || gotDesc != tt.desc {
+			t.Errorf("round-trip GenerateLabel(%q, %q, %q) -> ParseLabel:\n  got:  (%q, %q, %q)\n  want: (%q, %q, %q)",
+				tt.title, tt.tech, tt.desc, gotTitle, gotTech, gotDesc, tt.title, tt.tech, tt.desc)
 		}
 	}
 }

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -81,11 +81,15 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 				continue
 			}
 			label := obj.SelectAttrValue("label", "")
-			title, technology := drawio.ParseLabel(label)
+			title, technology, description := drawio.ParseLabel(label)
+			tooltipDesc := obj.SelectAttrValue("tooltip", "")
+			if description == "" {
+				description = tooltipDesc
+			}
 			result[id] = drawioElemSnapshot{
 				title:       title,
 				technology:  technology,
-				description: obj.SelectAttrValue("tooltip", ""),
+				description: description,
 				kind:        obj.SelectAttrValue("bausteinsicht_kind", ""),
 			}
 		}


### PR DESCRIPTION
## Summary
- Add description text to draw.io element labels below title and technology
- Technology is now wrapped in square brackets per C4 convention: `[Spring Boot]`
- Description shown in lighter gray (`#999999`) below technology
- `ParseLabel` updated to return 3 values (title, tech, description) with backward compatibility for old format

Closes #69

## Test plan
- [x] Existing label tests updated and passing
- [x] New test cases for labels with description
- [x] Round-trip tests verify generate→parse consistency
- [x] All project tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)