### PR TITLE
feat: lift relationships to parent elements in views (#70)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
@@ -108,6 +109,25 @@ func scopedCellID(viewID, elemID string) string {
 	return viewID + "--" + elemID
 }
 
+// liftEndpoint returns id if it is in elemFilter. Otherwise it walks up the
+// parent chain (by removing the last dot-segment) until a parent is found in
+// the filter. Returns "" if no ancestor is present on the page.
+func liftEndpoint(id string, elemFilter map[string]bool) string {
+	if elemFilter[id] {
+		return id
+	}
+	for {
+		dot := strings.LastIndex(id, ".")
+		if dot < 0 {
+			return ""
+		}
+		id = id[:dot]
+		if elemFilter[id] {
+			return id
+		}
+	}
+}
+
 // applyChangesToPage applies element and relationship changes to a single page.
 // If elemFilter is nil, all changes are applied. Otherwise only elements in the
 // filter set are processed, and relationships are only created when both
@@ -139,18 +159,31 @@ func applyChangesToPage(
 		}
 	}
 
+	liftedSeen := make(map[string]bool)
 	for _, ch := range cs.ModelRelationshipChanges {
-		if elemFilter != nil && (!elemFilter[ch.From] || !elemFilter[ch.To]) {
-			continue
+		from := ch.From
+		to := ch.To
+		if elemFilter != nil {
+			from = liftEndpoint(from, elemFilter)
+			to = liftEndpoint(to, elemFilter)
+			if from == "" || to == "" || from == to {
+				continue
+			}
 		}
+		lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
+		pairKey := from + "->" + to
 		switch ch.Type {
 		case Added:
-			applyRelAdded(ch, viewID, page, templates, result)
+			if liftedSeen[pairKey] {
+				continue
+			}
+			liftedSeen[pairKey] = true
+			applyRelAdded(lifted, viewID, page, templates, result)
 		case Modified:
-			page.UpdateConnectorLabel(ch.From, ch.To, ch.NewValue)
+			page.UpdateConnectorLabel(from, to, ch.NewValue)
 			result.ConnectorsUpdated++
 		case Deleted:
-			page.DeleteConnector(ch.From, ch.To)
+			page.DeleteConnector(from, to)
 			result.ConnectorsDeleted++
 		}
 	}

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -145,6 +145,145 @@ func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
 	}
 }
 
+// TestApplyForward_RelationshipLifting verifies that relationships are lifted
+// to parent elements when the original endpoint is not on the page.
+// Example: customer → webshop.frontend should render as customer → webshop
+// on the context page where only customer and webshop are present.
+func TestApplyForward_RelationshipLifting(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	doc.AddPage("view-containers", "Container View")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "actor", Title: "Customer"},
+			"webshop": {Kind: "system", Title: "Online Shop", Children: map[string]model.Element{
+				"frontend": {Kind: "container", Title: "Frontend"},
+				"api":      {Kind: "container", Title: "API"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "webshop.frontend", Label: "uses"},
+			{From: "webshop.frontend", To: "webshop.api", Label: "calls"},
+		},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"customer", "webshop"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "webshop",
+				Include: []string{"customer", "webshop.*"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.frontend", Type: Added},
+			{ID: "webshop.api", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop.frontend", Type: Added, NewValue: "uses"},
+			{From: "webshop.frontend", To: "webshop.api", Type: Added, NewValue: "calls"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	// Context page: customer → webshop.frontend should be lifted to customer → webshop
+	contextPage := doc.GetPage("view-context")
+	if contextPage == nil {
+		t.Fatal("context page not found")
+	}
+
+	conns := contextPage.FindAllConnectors()
+	if len(conns) == 0 {
+		t.Fatal("expected at least one connector on context page (lifted relationship)")
+	}
+
+	// Should have a connector from customer to webshop (lifted from webshop.frontend)
+	found := false
+	for _, c := range conns {
+		src := c.SelectAttrValue("source", "")
+		tgt := c.SelectAttrValue("target", "")
+		if src == "context--customer" && tgt == "context--webshop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected lifted connector customer→webshop on context page")
+	}
+
+	// Container page: customer → webshop.frontend should NOT be lifted (frontend is on the page)
+	containerPage := doc.GetPage("view-containers")
+	if containerPage == nil {
+		t.Fatal("container page not found")
+	}
+	if containerPage.FindConnector("containers--customer", "containers--webshop.frontend") == nil {
+		t.Error("expected original connector customer→webshop.frontend on container page")
+	}
+}
+
+// TestApplyForward_RelationshipLiftingDedup verifies that when multiple child
+// relationships lift to the same parent pair, only one connector is created.
+func TestApplyForward_RelationshipLiftingDedup(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "system", Title: "A", Children: map[string]model.Element{
+				"x": {Kind: "container", Title: "X"},
+				"y": {Kind: "container", Title: "Y"},
+			}},
+			"b": {Kind: "system", Title: "B", Children: map[string]model.Element{
+				"z": {Kind: "container", Title: "Z"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "a.x", To: "b.z", Label: "calls"},
+			{From: "a.y", To: "b.z", Label: "reads"},
+		},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"a", "b"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "a", Type: Added},
+			{ID: "b", Type: Added},
+			{ID: "a.x", Type: Added},
+			{ID: "a.y", Type: Added},
+			{ID: "b.z", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a.x", To: "b.z", Type: Added, NewValue: "calls"},
+			{From: "a.y", To: "b.z", Type: Added, NewValue: "reads"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	contextPage := doc.GetPage("view-context")
+	conns := contextPage.FindAllConnectors()
+
+	// Both relationships lift to a→b, but only one connector should be created.
+	if len(conns) != 1 {
+		t.Errorf("expected 1 connector (deduped), got %d", len(conns))
+	}
+}
+
 // TestApplyForward_NoViewsFallback verifies backward compatibility:
 // when no views are defined, elements go to the first page.
 func TestApplyForward_NoViewsFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- When a relationship endpoint is not on a view page, walk up the parent chain to find an ancestor that IS on the page
- Example: `customer → webshop.frontend` renders as `customer → webshop` on the context page
- Duplicate lifted connectors are deduplicated (multiple child relationships lifting to same parent pair → one connector)
- Self-loops from lifting are skipped (e.g., `webshop.api → webshop.db` doesn't become `webshop → webshop`)

Closes #70

## Test plan
- [x] TestApplyForward_RelationshipLifting: verifies lifting on context page, original on container page
- [x] TestApplyForward_RelationshipLiftingDedup: verifies deduplication of lifted connectors
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)