### PR TITLE
feat: render scope element as bounding box in views (#71)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -62,7 +62,7 @@ func applyForwardToPage(
 		result.Warnings = append(result.Warnings, "no page found in document")
 		return
 	}
-	applyChangesToPage(cs, page, templates, flat, elemFilter, "", result)
+	applyChangesToPage(cs, page, templates, flat, elemFilter, "", "", result)
 }
 
 // applyForwardPerView iterates over model views and applies changes per page.
@@ -96,7 +96,12 @@ func applyForwardPerView(
 			elemSet[id] = true
 		}
 
-		applyChangesToPage(cs, page, templates, flat, elemSet, viewID, result)
+		scopeID := view.Scope
+		if scopeID != "" {
+			createScopeBoundary(scopeID, viewID, page, templates, flat, result)
+		}
+
+		applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, result)
 	}
 }
 
@@ -107,6 +112,12 @@ func scopedCellID(viewID, elemID string) string {
 		return elemID
 	}
 	return viewID + "--" + elemID
+}
+
+// isChildOf returns true if id is a direct or nested child of parentID.
+// Example: isChildOf("shop.api", "shop") → true
+func isChildOf(id, parentID string) bool {
+	return strings.HasPrefix(id, parentID+".")
 }
 
 // liftEndpoint returns id if it is in elemFilter. Otherwise it walks up the
@@ -128,11 +139,68 @@ func liftEndpoint(id string, elemFilter map[string]bool) string {
 	}
 }
 
+// createScopeBoundary creates a boundary/swimlane element for the scope element
+// of a view (e.g., the parent system in a container view).
+func createScopeBoundary(
+	scopeID string,
+	viewID string,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	result *ForwardResult,
+) {
+	// Skip if already present on the page.
+	if page.FindElement(scopeID) != nil {
+		return
+	}
+
+	elem, ok := flat[scopeID]
+	if !ok {
+		result.Warnings = append(result.Warnings, "scope element not found in model: "+scopeID)
+		return
+	}
+
+	boundaryKind := elem.Kind + "_boundary"
+	ts, ok := templates.GetBoundaryStyle(boundaryKind)
+	if !ok {
+		ts = drawio.TemplateStyle{Width: 400, Height: 300}
+		result.Warnings = append(result.Warnings, "no boundary template for kind: "+boundaryKind)
+	}
+
+	style := ts.Style
+	width := ts.Width
+	if width == 0 {
+		width = 400
+	}
+	height := ts.Height
+	if height == 0 {
+		height = 300
+	}
+
+	data := drawio.ElementData{
+		ID:          scopeID,
+		CellID:      scopedCellID(viewID, scopeID),
+		Kind:        boundaryKind,
+		Title:       elem.Title,
+		Technology:  elem.Technology,
+		Description: elem.Description,
+		X:           elementGap,
+		Y:           elementGap,
+		Width:       width,
+		Height:      height,
+	}
+
+	if err := page.CreateElement(data, style); err != nil {
+		result.Warnings = append(result.Warnings, "failed to create scope boundary "+scopeID+": "+err.Error())
+	}
+}
+
 // applyChangesToPage applies element and relationship changes to a single page.
 // If elemFilter is nil, all changes are applied. Otherwise only elements in the
 // filter set are processed, and relationships are only created when both
 // endpoints are in the filter set.
 // viewID is used to scope cell IDs for file-wide uniqueness (empty = legacy).
+// scopeID identifies the boundary element for parenting children (empty = no scope).
 func applyChangesToPage(
 	cs *ChangeSet,
 	page *drawio.Page,
@@ -140,6 +208,7 @@ func applyChangesToPage(
 	flat map[string]*model.Element,
 	elemFilter map[string]bool,
 	viewID string,
+	scopeID string,
 	result *ForwardResult,
 ) {
 	pl := computePlacement(page)
@@ -150,7 +219,7 @@ func applyChangesToPage(
 		}
 		switch ch.Type {
 		case Added:
-			applyElementAdded(ch.ID, viewID, page, templates, flat, &pl, result)
+			applyElementAdded(ch.ID, viewID, scopeID, page, templates, flat, &pl, result)
 		case Modified:
 			applyElementModified(ch, page, flat, result)
 		case Deleted:
@@ -232,9 +301,12 @@ func computePlacement(page *drawio.Page) placement {
 }
 
 // applyElementAdded creates a new element on page with a visual new-element marker.
+// If scopeID is set and the element is a child of the scope, it is parented to the
+// scope boundary cell.
 func applyElementAdded(
 	id string,
 	viewID string,
+	scopeID string,
 	page *drawio.Page,
 	templates *drawio.TemplateSet,
 	flat map[string]*model.Element,
@@ -275,6 +347,11 @@ func applyElementAdded(
 		Y:           pl.nextY,
 		Width:       width,
 		Height:      height,
+	}
+
+	// Parent children of the scope element to the boundary cell.
+	if scopeID != "" && isChildOf(id, scopeID) {
+		data.ParentID = scopedCellID(viewID, scopeID)
 	}
 
 	if err := page.CreateElement(data, style); err != nil {

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -284,6 +284,88 @@ func TestApplyForward_RelationshipLiftingDedup(t *testing.T) {
 	}
 }
 
+// TestApplyForward_ScopeBoundingBox verifies that the scope element of a view
+// is rendered as a boundary/swimlane on the page, with children nested inside.
+func TestApplyForward_ScopeBoundingBox(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-containers", "Container View")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "actor", Title: "Customer"},
+			"shop": {Kind: "system", Title: "Online Shop", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API", Technology: "Go"},
+				"db":  {Kind: "container", Title: "Database", Technology: "PostgreSQL"},
+			}},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"containers": {
+				Title:   "Container View",
+				Scope:   "shop",
+				Include: []string{"customer", "shop.*"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "shop.api", Type: Added},
+			{ID: "shop.db", Type: Added},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	page := doc.GetPage("view-containers")
+	if page == nil {
+		t.Fatal("container page not found")
+	}
+
+	// The scope element "shop" should appear as a boundary.
+	scopeElem := page.FindElement("shop")
+	if scopeElem == nil {
+		t.Fatal("expected scope element 'shop' as boundary on container page")
+	}
+
+	// It should have a bausteinsicht_kind attribute indicating it's a boundary.
+	kind := scopeElem.SelectAttrValue("bausteinsicht_kind", "")
+	if kind != "system_boundary" {
+		t.Errorf("scope element kind: got %q, want %q", kind, "system_boundary")
+	}
+
+	// Children (api, db) should be parented to the scope boundary cell.
+	scopeCellID := scopeElem.SelectAttrValue("id", "")
+	apiElem := page.FindElement("shop.api")
+	if apiElem == nil {
+		t.Fatal("expected 'shop.api' on container page")
+	}
+	apiCell := apiElem.FindElement("mxCell")
+	if apiCell == nil {
+		t.Fatal("shop.api has no mxCell")
+	}
+	apiParent := apiCell.SelectAttrValue("parent", "")
+	if apiParent != scopeCellID {
+		t.Errorf("shop.api parent: got %q, want scope cell ID %q", apiParent, scopeCellID)
+	}
+
+	// customer should NOT be parented to the scope (it's external).
+	custElem := page.FindElement("customer")
+	if custElem == nil {
+		t.Fatal("expected 'customer' on container page")
+	}
+	custCell := custElem.FindElement("mxCell")
+	if custCell == nil {
+		t.Fatal("customer has no mxCell")
+	}
+	custParent := custCell.SelectAttrValue("parent", "")
+	if custParent == scopeCellID {
+		t.Error("customer should NOT be parented to scope boundary")
+	}
+}
+
 // TestApplyForward_NoViewsFallback verifies backward compatibility:
 // when no views are defined, elements go to the first page.
 func TestApplyForward_NoViewsFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- When a view has a `scope` element, render it as a boundary/swimlane on the page
- Children of the scope element are nested inside the boundary (parent = boundary cell ID)
- External elements (like `customer`) remain at top-level (parent = "1")
- Boundary style is derived from element kind + `_boundary` suffix (e.g., `system` → `system_boundary`)

Closes #71

## Test plan
- [x] TestApplyForward_ScopeBoundingBox: verifies boundary creation, child parenting, and external element independence
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)