### PR TITLE
docs: add user manual (#65)

### DIFF
--- a/src/docs/manual/user-manual.adoc
+++ b/src/docs/manual/user-manual.adoc
@@ -1,0 +1,447 @@
+:jbake-title: User Manual
+:jbake-type: page_toc
+:jbake-status: published
+:jbake-menu: Manual
+:jbake-order: 1
+
+ifndef::imagesdir[:imagesdir: ../../images]
+
+:toc:
+
+== Bausteinsicht User Manual
+
+Bausteinsicht is an architecture-as-code tool that keeps a JSONC model and draw.io diagrams in bidirectional sync.
+You define your architecture in a text file, and Bausteinsicht generates and updates visual diagrams automatically.
+
+=== Installation
+
+==== Build from Source
+
+[source,bash]
+----
+git clone https://github.com/docToolchain/Bausteinsicht.git
+cd Bausteinsicht
+go build -o bausteinsicht ./cmd/bausteinsicht/
+----
+
+Move the binary to a directory in your `PATH`:
+
+[source,bash]
+----
+sudo mv bausteinsicht /usr/local/bin/
+----
+
+Verify the installation:
+
+[source,bash]
+----
+bausteinsicht --version
+----
+
+==== Prerequisites
+
+* https://www.drawio.com/[draw.io Desktop] or the VS Code draw.io extension
+* A text editor with JSON support (VS Code recommended for autocompletion via JSON Schema)
+
+=== Quick Start
+
+[source,bash]
+----
+mkdir my-architecture && cd my-architecture
+bausteinsicht init
+bausteinsicht sync
+----
+
+This creates a sample Online Shop architecture with three views.
+Open `architecture.drawio` in draw.io to see the generated diagrams.
+
+For a detailed walkthrough, see the link:../spec/06_tutorial.adoc[Getting Started Tutorial].
+
+=== Daily Workflow
+
+The typical workflow alternates between editing the model and arranging diagrams:
+
+----
+┌─────────────────┐     sync      ┌─────────────────┐
+│  architecture   │ ───────────►  │  architecture   │
+│    .jsonc       │ ◄───────────  │    .drawio      │
+│  (text editor)  │               │  (draw.io)      │
+└─────────────────┘               └─────────────────┘
+----
+
+==== Forward Sync (Model → Diagram)
+
+1. Edit `architecture.jsonc` in your text editor
+2. Run `bausteinsicht sync`
+3. Reload the `.drawio` file — new elements appear with a red dashed border
+4. Drag elements to arrange the layout, then save
+
+==== Reverse Sync (Diagram → Model)
+
+1. Open `architecture.drawio` in draw.io
+2. Edit element labels, descriptions, or technology directly in draw.io
+3. Save the `.drawio` file
+4. Run `bausteinsicht sync`
+5. Check `architecture.jsonc` — your changes are reflected
+
+==== Watch Mode
+
+For continuous synchronization while you work:
+
+[source,bash]
+----
+bausteinsicht watch
+----
+
+Bausteinsicht watches both files and syncs automatically on save. Press `Ctrl+C` to stop.
+
+=== The Architecture Model
+
+The model file (`architecture.jsonc`) is a JSONC file with four sections.
+
+==== Specification
+
+Defines the element kinds and relationship kinds available in your model.
+This is like a vocabulary for your architecture:
+
+[source,jsonc]
+----
+"specification": {
+  "elements": {
+    "actor":     { "notation": "Actor",           "description": "A person or external system" },
+    "system":    { "notation": "Software System",  "container": true },
+    "container": { "notation": "Container",        "container": true },
+    "component": { "notation": "Component",        "container": true }
+  },
+  "relationships": {
+    "uses":  { "notation": "uses" },
+    "async": { "notation": "async", "dashed": true }
+  }
+}
+----
+
+Set `container: true` for kinds that can hold children.
+
+==== Model
+
+Defines your architecture elements in a hierarchy.
+Element keys are unique IDs, children nest naturally:
+
+[source,jsonc]
+----
+"model": {
+  "customer": {
+    "kind": "actor",
+    "title": "Customer",
+    "description": "End user of the webshop"
+  },
+  "webshop": {
+    "kind": "system",
+    "title": "Webshop",
+    "children": {
+      "api": {
+        "kind": "container",
+        "title": "REST API",
+        "technology": "Go"
+      }
+    }
+  }
+}
+----
+
+Nested elements are referenced with dot notation: `webshop.api`.
+
+==== Relationships
+
+Connections between elements:
+
+[source,jsonc]
+----
+"relationships": [
+  {
+    "from": "customer",
+    "to": "webshop.api",
+    "label": "uses",
+    "kind": "uses",
+    "description": "Sends HTTP requests"
+  }
+]
+----
+
+==== Views
+
+Views define which elements appear on each diagram page.
+See <<views>> for details.
+
+=== Adding Elements and Relationships
+
+==== Via Text Editor
+
+Edit `architecture.jsonc` directly, then run `bausteinsicht sync`.
+
+==== Via CLI
+
+Add elements without editing JSON:
+
+[source,bash]
+----
+bausteinsicht add element \
+  --id emailservice \
+  --kind container \
+  --title "Email Service" \
+  --technology "Go" \
+  --parent onlineshop \
+  --description "Sends transactional emails"
+----
+
+Add relationships:
+
+[source,bash]
+----
+bausteinsicht add relationship \
+  --from onlineshop.api \
+  --to onlineshop.emailservice \
+  --label "sends emails" \
+  --kind uses
+----
+
+After adding, run `bausteinsicht sync` to update the diagram.
+
+[[views]]
+=== Multi-View Architecture
+
+Views control which elements appear on each diagram page.
+Each view becomes a tab in the draw.io file.
+
+==== Basic View
+
+A simple view lists elements to include:
+
+[source,jsonc]
+----
+"context": {
+  "title": "System Context",
+  "include": ["customer", "webshop"]
+}
+----
+
+==== Wildcard Includes
+
+Use `.*` to include all direct children of an element:
+
+[source,jsonc]
+----
+"containers": {
+  "title": "Container View",
+  "include": ["customer", "webshop.*"]
+}
+----
+
+`webshop.*` matches `webshop.api`, `webshop.frontend`, `webshop.db` — but not `webshop` itself.
+
+==== Scope and Bounding Boxes
+
+The `scope` property renders the parent element as a visual boundary (swimlane) with its children nested inside:
+
+[source,jsonc]
+----
+"containers": {
+  "title": "Container View",
+  "scope": "webshop",
+  "include": ["customer", "webshop.*"]
+}
+----
+
+This renders `webshop` as a labeled box containing its children, with `customer` outside as an external actor.
+
+==== Exclude
+
+Remove specific elements from a view:
+
+[source,jsonc]
+----
+"overview": {
+  "title": "Overview",
+  "include": ["webshop.*"],
+  "exclude": ["webshop.db"]
+}
+----
+
+==== Relationship Lifting
+
+When a relationship endpoint is not on a view page but its parent is, the connector is automatically "lifted" to the parent.
+
+Example: the model has `customer → webshop.frontend`, but the System Context view only includes `customer` and `webshop`. Bausteinsicht renders this as `customer → webshop` on the context page.
+
+This happens automatically — no configuration needed.
+
+=== Template Customization
+
+Templates control the visual style of elements in draw.io.
+
+==== Template File Structure
+
+The template (`template.drawio`) is a draw.io file with sample elements tagged via `bausteinsicht_template`:
+
+* Element templates: `bausteinsicht_template="actor"`, `"system"`, `"container"`, `"component"`
+* Boundary templates: `bausteinsicht_template="system_boundary"`, `"container_boundary"`
+* Connector template: `bausteinsicht_template="relationship"`
+
+==== Customizing Styles
+
+1. Open `template.drawio` in draw.io
+2. Modify colors, fonts, shapes, sizes of the template elements
+3. Save the file
+4. Run `bausteinsicht sync` — new elements use the updated styles
+
+Existing elements keep their current style. Only newly created elements pick up template changes.
+
+==== Template Properties Used
+
+From each template element, Bausteinsicht extracts:
+
+* **style** — the full mxCell style string
+* **width** and **height** — default dimensions from mxGeometry
+
+=== Validation
+
+Check your model for errors before syncing:
+
+[source,bash]
+----
+bausteinsicht validate
+----
+
+Output: `Model is valid.` or a list of errors.
+
+For machine-readable output:
+
+[source,bash]
+----
+bausteinsicht validate --format json
+----
+
+[source,json]
+----
+{
+  "valid": true,
+  "errors": []
+}
+----
+
+=== LLM Integration
+
+Bausteinsicht is designed for AI-assisted architecture work.
+All commands support `--format json` for machine-readable output.
+
+==== AI Agent Workflow
+
+An LLM can drive architecture changes entirely through CLI commands:
+
+[source,bash]
+----
+# Add elements
+bausteinsicht add element --id cache --kind container \
+  --title "Cache" --technology "Redis" --parent webshop --format json
+
+# Add relationships
+bausteinsicht add relationship --from webshop.api --to webshop.cache \
+  --label "caches" --kind uses --format json
+
+# Sync and verify
+bausteinsicht sync --format json
+bausteinsicht validate --format json
+----
+
+==== JSON Schema Support
+
+The model file references a JSON Schema for IDE autocompletion and validation:
+
+[source,jsonc]
+----
+{
+  "$schema": "https://raw.githubusercontent.com/docToolchain/Bauteinsicht/main/schema/bausteinsicht.schema.json",
+  ...
+}
+----
+
+This enables autocompletion in VS Code, IntelliJ, and other editors without plugins.
+
+=== Troubleshooting
+
+==== "no such file or directory" on sync
+
+The `.drawio` file must exist before syncing. Run `bausteinsicht init` first, or ensure both `architecture.jsonc` and `architecture.drawio` are present.
+
+==== Elements appear with red dashed borders
+
+This is intentional. New elements are marked with a red dashed border (`strokeColor=#FF0000;dashed=1;`) so you can spot them in draw.io. Edit the element's style in draw.io to remove the marker after arranging.
+
+==== Changes not appearing after sync
+
+* **draw.io**: Close and reopen the file, or press `Ctrl+Shift+R` to reload
+* **Watch mode**: Verify the watcher is running and the correct files are being watched
+* **Relationships missing**: Check that both endpoints are included in the view's `include` list
+
+==== Sync conflict
+
+When both the model and draw.io change the same field between syncs, Bausteinsicht reports a conflict. Resolve by choosing one version and running sync again.
+
+==== draw.io pages look identical
+
+If element IDs collide across pages, draw.io may render pages incorrectly. Bausteinsicht uses page-scoped IDs (`viewID--elementID`) to prevent this. If you see this issue, delete `.bausteinsicht-sync` and `architecture.drawio`, then re-init and sync.
+
+=== Command Reference
+
+See the link:../spec/02_cli_specification.adoc[CLI Specification] for full command details.
+
+[cols="2,3"]
+|===
+| Command | Description
+
+| `bausteinsicht init`
+| Initialize a new project with sample model and template
+
+| `bausteinsicht sync`
+| Run one bidirectional sync cycle
+
+| `bausteinsicht validate`
+| Validate model without syncing
+
+| `bausteinsicht watch`
+| Continuously sync on file changes
+
+| `bausteinsicht add element`
+| Add element to model
+
+| `bausteinsicht add relationship`
+| Add relationship to model
+
+| `bausteinsicht --version`
+| Display version number
+|===
+
+=== Global Flags
+
+[cols="2,3"]
+|===
+| Flag | Description
+
+| `--format json\|text`
+| Output format (default: text)
+
+| `--model <path>`
+| Path to model file (default: auto-detect)
+
+| `--template <path>`
+| Path to template file
+
+| `--verbose`
+| Enable debug output
+|===
+
+=== Further Reading
+
+* link:../spec/03_data_models.adoc[Data Models] — JSONC structure, draw.io XML format, Go structs
+* link:../spec/05_sync_specification.adoc[Sync Specification] — three-way sync algorithm details
+* link:../spec/06_tutorial.adoc[Getting Started Tutorial] — step-by-step walkthrough


### PR DESCRIPTION
## Summary
- New user manual at `src/docs/manual/user-manual.adoc`
- Covers: installation, daily workflow, forward/reverse sync, watch mode, model structure, adding elements/relationships via CLI, multi-view architecture (scope, wildcards, relationship lifting), template customization, validation, LLM integration, troubleshooting
- References existing spec docs for deep-dive topics (no duplication)
- Written in AsciiDoc, consistent with project documentation style

Closes #65

## Test plan
- [x] All topics from issue #65 covered
- [x] Practical examples in each section
- [x] Cross-references to spec docs
- [x] Under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)