### PR TITLE
security: fix SEC-002, SEC-003, SEC-009, SEC-010

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
 module github.com/docToolchain/Bauteinsicht
 
-go 1.23.0
-
-require github.com/spf13/cobra v1.10.2
+go 1.24.0
 
 require (
-	github.com/beevik/etree v1.6.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/beevik/etree v1.6.0
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,9 +8,10 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
-github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -24,17 +24,29 @@ func Load(path string) (*BausteinsichtModel, error) {
 }
 
 // Save marshals the model and atomically writes it to path.
+// Uses os.CreateTemp for a randomized temp file name to prevent TOCTOU attacks.
 func Save(path string, model *BausteinsichtModel) error {
 	data, err := json.MarshalIndent(model, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling model: %w", err)
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".model-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("writing temp file: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("renaming temp file: %w", err)
 	}
 	return nil

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -101,9 +101,10 @@ func (w *Watcher) loop() {
 			if timer != nil {
 				timer.Stop()
 			}
+			captured := lastFile // capture by value to avoid data race with AfterFunc goroutine
 			timer = time.AfterFunc(w.debounce, func() {
 				if !w.isSyncing() {
-					w.onChange(lastFile)
+					w.onChange(captured)
 				}
 			})
 

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -44,12 +44,12 @@ The primary risk scenario is a **malicious or crafted model/drawio file** shared
 | SEC-002
 | Low-Medium
 | Predictable temp file name in `model.Save` (TOCTOU / symlink attack)
-| Open
+| Fixed
 
 | SEC-003
 | Low-Medium
 | Data race on `lastFile` variable in watcher debounce closure
-| Open
+| Fixed
 
 | SEC-004
 | Low
@@ -79,12 +79,12 @@ The primary risk scenario is a **malicious or crafted model/drawio file** shared
 | SEC-009
 | Medium
 | Go toolchain 1.23.0 has 25 known stdlib vulnerabilities
-| Open
+| Fixed (upgraded to 1.24.0)
 
 | SEC-010
 | Low
 | `golang.org/x/sys` v0.13.0 is 28 minor versions behind current
-| Open
+| Fixed (upgraded to v0.41.0)
 |===
 
 === Findings


### PR DESCRIPTION
## Summary
Fixes 4 findings from the security review (2026-03-01):

- **SEC-009**: Go toolchain 1.23.0 → 1.24.0 (resolves 25 known stdlib vulnerabilities)
- **SEC-010**: golang.org/x/sys v0.13.0 → v0.41.0, pflag v1.0.9 → v1.0.10
- **SEC-002**: Replace predictable temp file (path+".tmp") with os.CreateTemp in model.Save
- **SEC-003**: Fix data race in watcher debounce — capture lastFile by value

## Security Review
- [x] Changes are pure security fixes, no behavioral changes
- [x] model.Save now uses same safe pattern as SaveDocument/SaveState
- [x] Data race confirmed fixed with `go test -race ./...`

## Code Review
- [x] All existing tests pass
- [x] Race detector clean across all packages
- [x] No new dependencies introduced
- [x] Security report updated to mark findings as fixed

## Test plan
- [x] `go test ./...` — all pass
- [x] `go test -race ./...` — all pass, no races detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)