### PR TITLE
fix: element/relationship deletion with view-scoped pages (#85)

### DIFF
--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -37,7 +37,7 @@ func Save(path string, model *BausteinsichtModel) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("writing temp file: %w", err)
 	}

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"strings"
+
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
@@ -97,20 +99,56 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 	return result
 }
 
+// buildCellIDToElemID builds a mapping from draw.io cell IDs to bausteinsicht
+// element IDs. When views are used, cell IDs are scoped (e.g., "context--customer")
+// while element IDs are un-scoped (e.g., "customer").
+func buildCellIDToElemID(doc *drawio.Document) map[string]string {
+	m := make(map[string]string)
+	for _, page := range doc.Pages() {
+		for _, obj := range page.FindAllElements() {
+			elemID := obj.SelectAttrValue("bausteinsicht_id", "")
+			cellID := obj.SelectAttrValue("id", "")
+			if elemID != "" && cellID != "" {
+				m[cellID] = elemID
+			}
+		}
+	}
+	return m
+}
+
 // extractDrawioRelationships gathers connector data from all pages.
+// Connector source/target cell IDs are resolved to element IDs using the
+// bausteinsicht_id attributes of referenced elements.
+// Lifted connectors (where an endpoint was lifted to a parent because the
+// original target is not visible on a view) are excluded to avoid phantom
+// reverse changes.
 func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipState {
+	cellToElem := buildCellIDToElemID(doc)
 	result := make(map[string]RelationshipState)
 	for _, page := range doc.Pages() {
 		for _, cell := range page.FindAllConnectors() {
-			from := cell.SelectAttrValue("source", "")
-			to := cell.SelectAttrValue("target", "")
-			if from == "" || to == "" {
+			fromCell := cell.SelectAttrValue("source", "")
+			toCell := cell.SelectAttrValue("target", "")
+			if fromCell == "" || toCell == "" {
 				continue
 			}
-			result[relKey(from, to)] = RelationshipState{
-				From:  from,
-				To:    to,
-				Label: cell.SelectAttrValue("value", ""),
+			// Resolve scoped cell IDs to element IDs.
+			// Fall back to raw cell ID for legacy (non-view) documents.
+			from := fromCell
+			if elemID, ok := cellToElem[fromCell]; ok {
+				from = elemID
+			}
+			to := toCell
+			if elemID, ok := cellToElem[toCell]; ok {
+				to = elemID
+			}
+			key := relKey(from, to)
+			if _, exists := result[key]; !exists {
+				result[key] = RelationshipState{
+					From:  from,
+					To:    to,
+					Label: cell.SelectAttrValue("value", ""),
+				}
 			}
 		}
 	}
@@ -264,6 +302,12 @@ func detectRelationshipChanges(
 		// Draw.io side
 		switch {
 		case inDrawio && !inLast:
+			// Skip lifted connectors: when a view lifts a relationship
+			// endpoint to a parent (e.g., A→B.child becomes A→B),
+			// the lifted connector should not be treated as a new relationship.
+			if isLiftedRelationship(from, to, modelRels) {
+				continue
+			}
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
 				From: from, To: to, Type: Added,
 			})
@@ -295,6 +339,30 @@ func unionRelKeys(
 		all[k] = struct{}{}
 	}
 	return all
+}
+
+// isLiftedRelationship returns true if the relationship from→to is a "lifted"
+// version of an existing model relationship. A relationship is lifted when a
+// view shows a connector between parent elements because the original endpoint
+// is not visible. For example, model has A→B.child but the view only shows A
+// and B, so the connector is lifted to A→B.
+func isLiftedRelationship(from, to string, modelRels map[string]RelationshipState) bool {
+	for _, mr := range modelRels {
+		// Same from, model to is more specific (to is ancestor of mr.To)
+		if mr.From == from && mr.To != to && strings.HasPrefix(mr.To, to+".") {
+			return true
+		}
+		// Same to, model from is more specific
+		if mr.To == to && mr.From != from && strings.HasPrefix(mr.From, from+".") {
+			return true
+		}
+		// Both endpoints lifted
+		if mr.From != from && mr.To != to &&
+			strings.HasPrefix(mr.From, from+".") && strings.HasPrefix(mr.To, to+".") {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveRelFromTo returns the from/to pair from the first non-empty source.

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -300,3 +300,204 @@ func TestDetectChanges_DrawioRelationshipAdded(t *testing.T) {
 		t.Errorf("expected drawio relationship added, changes: %+v", cs.DrawioRelationshipChanges)
 	}
 }
+
+// docWithScopedConnector creates a document simulating a view-based layout
+// where elements have scoped cell IDs (viewID--elemID) but bausteinsicht_id
+// attributes contain the un-scoped element ID.
+func docWithScopedConnector(viewID, fromElemID, toElemID, label string) *drawio.Document {
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-"+viewID, viewID+" View")
+	// Create elements with scoped cell IDs (as forward sync does)
+	_ = page.CreateElement(drawio.ElementData{
+		ID:     fromElemID,
+		CellID: viewID + "--" + fromElemID,
+		Kind:   "system",
+		Title:  fromElemID,
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID:     toElemID,
+		CellID: viewID + "--" + toElemID,
+		Kind:   "system",
+		Title:  toElemID,
+	}, "")
+	// Create connector using scoped cell IDs as source/target (as forward sync does)
+	page.CreateConnector(drawio.ConnectorData{
+		From:      fromElemID,
+		To:        toElemID,
+		Label:     label,
+		SourceRef: viewID + "--" + fromElemID,
+		TargetRef: viewID + "--" + toElemID,
+	}, "")
+	return doc
+}
+
+func TestDetectChanges_ScopedConnectorsMappedToElementIDs(t *testing.T) {
+	// State has a relationship with un-scoped element IDs (the correct form).
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "customer", To: "webshop", Label: "uses"},
+	}
+
+	// Model matches state — no model-side changes.
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "system", Title: "Customer"},
+			"webshop":  {Kind: "system", Title: "Webshop"},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "webshop", Label: "uses"},
+		},
+	}
+
+	// draw.io has scoped cell IDs (e.g., context--customer) on connectors.
+	doc := docWithScopedConnector("context", "customer", "webshop", "uses")
+
+	cs := DetectChanges(m, doc, state)
+
+	// There should be NO drawio relationship changes — the connector represents
+	// the same relationship as in state, just with scoped cell IDs.
+	if len(cs.DrawioRelationshipChanges) != 0 {
+		t.Errorf("expected no drawio relationship changes when connectors use scoped cell IDs, got %d: %+v",
+			len(cs.DrawioRelationshipChanges), cs.DrawioRelationshipChanges)
+	}
+
+	// There should be NO model relationship changes either.
+	if len(cs.ModelRelationshipChanges) != 0 {
+		t.Errorf("expected no model relationship changes, got %d: %+v",
+			len(cs.ModelRelationshipChanges), cs.ModelRelationshipChanges)
+	}
+}
+
+func TestDetectChanges_ScopedConnectorsMultipleViews(t *testing.T) {
+	// Same relationship appears on multiple view pages with different scoped IDs.
+	// It should be detected as a single relationship, not duplicates.
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "customer", To: "webshop", Label: "uses"},
+	}
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "system", Title: "Customer"},
+			"webshop":  {Kind: "system", Title: "Webshop"},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "webshop", Label: "uses"},
+		},
+	}
+
+	// Build a doc with the same relationship on two view pages.
+	doc := drawio.NewDocument()
+	for _, viewID := range []string{"context", "containers"} {
+		page := doc.AddPage("view-"+viewID, viewID+" View")
+		_ = page.CreateElement(drawio.ElementData{
+			ID: "customer", CellID: viewID + "--customer", Kind: "system", Title: "Customer",
+		}, "")
+		_ = page.CreateElement(drawio.ElementData{
+			ID: "webshop", CellID: viewID + "--webshop", Kind: "system", Title: "Webshop",
+		}, "")
+		page.CreateConnector(drawio.ConnectorData{
+			From: "customer", To: "webshop", Label: "uses",
+			SourceRef: viewID + "--customer", TargetRef: viewID + "--webshop",
+		}, "")
+	}
+
+	cs := DetectChanges(m, doc, state)
+
+	if len(cs.DrawioRelationshipChanges) != 0 {
+		t.Errorf("expected no drawio relationship changes for multi-view scoped connectors, got %d: %+v",
+			len(cs.DrawioRelationshipChanges), cs.DrawioRelationshipChanges)
+	}
+	if len(cs.ModelRelationshipChanges) != 0 {
+		t.Errorf("expected no model relationship changes, got %d: %+v",
+			len(cs.ModelRelationshipChanges), cs.ModelRelationshipChanges)
+	}
+}
+
+func TestDetectChanges_LiftedConnectorIgnored(t *testing.T) {
+	// The model has customer → shop.frontend. On the context view,
+	// the relationship is lifted to customer → shop (because shop.frontend
+	// is not on the context view). The lifted connector should NOT
+	// be treated as a new drawio relationship.
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "customer", To: "shop.frontend", Label: "uses"},
+	}
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "system", Title: "Customer"},
+			"shop": {Kind: "system", Title: "Shop", Children: map[string]model.Element{
+				"frontend": {Kind: "container", Title: "Frontend"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "shop.frontend", Label: "uses"},
+		},
+	}
+
+	// Create a doc where the connector uses lifted endpoints.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-ctx", "Context")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "customer", CellID: "ctx--customer", Kind: "system", Title: "Customer",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "shop", CellID: "ctx--shop", Kind: "system", Title: "Shop",
+	}, "")
+	// This is a lifted connector: the original relationship is customer → shop.frontend
+	// but the connector endpoints were lifted to customer → shop.
+	page.CreateConnector(drawio.ConnectorData{
+		From: "customer", To: "shop",
+		Label:     "uses",
+		SourceRef: "ctx--customer",
+		TargetRef: "ctx--shop",
+	}, "")
+
+	cs := DetectChanges(m, doc, state)
+
+	// The lifted connector (customer → shop) should NOT appear as a new
+	// drawio relationship, because it's a visual representation of an
+	// existing model relationship (customer → shop.frontend).
+	for _, ch := range cs.DrawioRelationshipChanges {
+		if ch.From == "customer" && ch.To == "shop" && ch.Type == Added {
+			t.Errorf("lifted connector customer→shop should not be detected as a new drawio relationship, got: %+v",
+				cs.DrawioRelationshipChanges)
+		}
+	}
+}
+
+func TestDetectChanges_ScopedConnectorLabelChange(t *testing.T) {
+	// Relationship exists in state with label "uses". draw.io connector (scoped)
+	// has label "calls". Should detect a drawio-side label modification.
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "a", To: "b", Label: "uses"},
+	}
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "system", Title: "A"},
+			"b": {Kind: "system", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+		},
+	}
+
+	doc := docWithScopedConnector("ctx", "a", "b", "calls")
+
+	cs := DetectChanges(m, doc, state)
+
+	found := false
+	for _, ch := range cs.DrawioRelationshipChanges {
+		if ch.From == "a" && ch.To == "b" && ch.Type == Modified &&
+			ch.Field == "label" && ch.OldValue == "uses" && ch.NewValue == "calls" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected drawio label modification for scoped connector, got: %+v",
+			cs.DrawioRelationshipChanges)
+	}
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3,6 +3,9 @@ package sync
 import (
 	"strings"
 	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
 
 // --- Test 1: Empty sync (no changes) → zero counts ---
@@ -133,7 +136,79 @@ func TestRun_ConflictModelWins(t *testing.T) {
 	}
 }
 
-// --- Test 5: Full round-trip ---
+// --- Test 5: Full round-trip with views (regression test for #83) ---
+//
+// Verifies that after a forward sync with views, a second sync detects no
+// phantom changes. Scoped cell IDs on connectors must be resolved back to
+// element IDs so the state comparison works correctly.
+
+func TestRun_ViewBasedSyncNoPhantomChanges(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "container", Title: "Customer"},
+			"shop":     {Kind: "container", Title: "Shop"},
+		},
+		Relationships: []model.Relationship{
+			{From: "customer", To: "shop", Label: "uses"},
+		},
+		Views: map[string]model.View{
+			"ctx": {Title: "Context", Include: []string{"customer", "shop"}},
+		},
+	}
+
+	// Build empty doc with the view page.
+	doc := drawio.NewDocument()
+	doc.AddPage("view-ctx", "Context")
+
+	state := emptyState()
+
+	// Round 1: forward sync populates the doc.
+	r1 := Run(m, doc, state, ts)
+	if r1.Forward.ElementsCreated != 2 {
+		t.Fatalf("round 1: expected 2 elements created, got %d", r1.Forward.ElementsCreated)
+	}
+	if r1.Forward.ConnectorsCreated != 1 {
+		t.Fatalf("round 1: expected 1 connector created, got %d", r1.Forward.ConnectorsCreated)
+	}
+
+	// Build state after round 1 (mirrors what BuildState does).
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"customer": {Title: "Customer", Kind: "container"},
+			"shop":     {Title: "Shop", Kind: "container"},
+		},
+		Relationships: []RelationshipState{
+			{From: "customer", To: "shop", Label: "uses"},
+		},
+	}
+
+	// Round 2: nothing changed — sync should be a complete no-op.
+	r2 := Run(m, doc, state1, ts)
+
+	if r2.Forward.ElementsCreated != 0 || r2.Forward.ElementsUpdated != 0 || r2.Forward.ElementsDeleted != 0 {
+		t.Errorf("round 2: expected no forward element changes, got created=%d updated=%d deleted=%d",
+			r2.Forward.ElementsCreated, r2.Forward.ElementsUpdated, r2.Forward.ElementsDeleted)
+	}
+	if r2.Forward.ConnectorsCreated != 0 || r2.Forward.ConnectorsUpdated != 0 || r2.Forward.ConnectorsDeleted != 0 {
+		t.Errorf("round 2: expected no forward connector changes, got created=%d updated=%d deleted=%d",
+			r2.Forward.ConnectorsCreated, r2.Forward.ConnectorsUpdated, r2.Forward.ConnectorsDeleted)
+	}
+	if r2.Reverse.ElementsCreated != 0 || r2.Reverse.ElementsUpdated != 0 || r2.Reverse.ElementsDeleted != 0 {
+		t.Errorf("round 2: expected no reverse element changes, got created=%d updated=%d deleted=%d",
+			r2.Reverse.ElementsCreated, r2.Reverse.ElementsUpdated, r2.Reverse.ElementsDeleted)
+	}
+	if r2.Reverse.RelationshipsCreated != 0 || r2.Reverse.RelationshipsDeleted != 0 {
+		t.Errorf("round 2: expected no reverse relationship changes, got created=%d deleted=%d",
+			r2.Reverse.RelationshipsCreated, r2.Reverse.RelationshipsDeleted)
+	}
+	if len(r2.Conflicts) != 0 {
+		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
+	}
+}
+
+// --- Test 6: Full round-trip ---
 //
 // Round 1: model has one element, doc is empty, state is empty → forward populates doc.
 // Build new state manually.

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -214,46 +214,65 @@ func applyChangesToPage(
 	pl := computePlacement(page)
 
 	for _, ch := range cs.ModelElementChanges {
-		if elemFilter != nil && !elemFilter[ch.ID] {
-			continue
-		}
 		switch ch.Type {
 		case Added:
+			if elemFilter != nil && !elemFilter[ch.ID] {
+				continue
+			}
 			applyElementAdded(ch.ID, viewID, scopeID, page, templates, flat, &pl, result)
 		case Modified:
+			if elemFilter != nil && !elemFilter[ch.ID] {
+				continue
+			}
 			applyElementModified(ch, page, flat, result)
 		case Deleted:
-			page.DeleteElement(ch.ID)
-			result.ElementsDeleted++
+			// Deleted elements are removed from all pages where they exist,
+			// regardless of the current view filter — a deleted element is
+			// no longer in the model, so it can't appear in any view's
+			// resolved set. We just check if it exists on this page.
+			if page.FindElement(ch.ID) != nil {
+				page.DeleteElement(ch.ID)
+				result.ElementsDeleted++
+			}
 		}
 	}
 
 	liftedSeen := make(map[string]bool)
 	for _, ch := range cs.ModelRelationshipChanges {
-		from := ch.From
-		to := ch.To
-		if elemFilter != nil {
-			from = liftEndpoint(from, elemFilter)
-			to = liftEndpoint(to, elemFilter)
-			if from == "" || to == "" || from == to {
-				continue
-			}
-		}
-		lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
-		pairKey := from + "->" + to
 		switch ch.Type {
-		case Added:
-			if liftedSeen[pairKey] {
-				continue
-			}
-			liftedSeen[pairKey] = true
-			applyRelAdded(lifted, viewID, page, templates, result)
-		case Modified:
-			page.UpdateConnectorLabel(from, to, ch.NewValue)
-			result.ConnectorsUpdated++
 		case Deleted:
-			page.DeleteConnector(from, to)
-			result.ConnectorsDeleted++
+			// For deletions, use scoped cell IDs to find and remove the
+			// connector. The original endpoints may no longer be in the
+			// view's element filter, so we bypass lifting entirely.
+			fromRef := scopedCellID(viewID, ch.From)
+			toRef := scopedCellID(viewID, ch.To)
+			if page.FindConnector(fromRef, toRef) != nil {
+				page.DeleteConnector(fromRef, toRef)
+				result.ConnectorsDeleted++
+			}
+		default:
+			from := ch.From
+			to := ch.To
+			if elemFilter != nil {
+				from = liftEndpoint(from, elemFilter)
+				to = liftEndpoint(to, elemFilter)
+				if from == "" || to == "" || from == to {
+					continue
+				}
+			}
+			lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
+			pairKey := from + "->" + to
+			switch ch.Type {
+			case Added:
+				if liftedSeen[pairKey] {
+					continue
+				}
+				liftedSeen[pairKey] = true
+				applyRelAdded(lifted, viewID, page, templates, result)
+			case Modified:
+				page.UpdateConnectorLabel(from, to, ch.NewValue)
+				result.ConnectorsUpdated++
+			}
 		}
 	}
 }

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -366,6 +366,119 @@ func TestApplyForward_ScopeBoundingBox(t *testing.T) {
 	}
 }
 
+// TestApplyForward_DeletedElementRemovedFromViewPages verifies that when an
+// element is deleted from the model, it is removed from all view pages where
+// it previously appeared. Regression test for #85.
+func TestApplyForward_DeletedElementRemovedFromViewPages(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	// Round 1: add all elements to doc.
+	doc := docWithViewPages()
+	csAdd := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+	ApplyForward(csAdd, doc, ts, m)
+
+	// Verify db exists on container page before deletion.
+	containerPage := doc.GetPage("view-containers")
+	if containerPage.FindElement("webshop.db") == nil {
+		t.Fatal("precondition: webshop.db should exist on container page before deletion")
+	}
+
+	// Round 2: remove webshop.db from the model.
+	delete(m.Model["webshop"].Children, "db")
+	// Update relationships: remove the one referencing db.
+	m.Relationships = []model.Relationship{
+		{From: "customer", To: "webshop", Label: "uses"},
+	}
+	// Also update the containers view to exclude db.
+	m.Views["containers"] = model.View{
+		Title:   "Container View",
+		Scope:   "webshop",
+		Include: []string{"customer", "webshop.api"},
+	}
+
+	csDel := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "webshop.db", Type: Deleted},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "webshop.api", To: "webshop.db", Type: Deleted},
+		},
+	}
+	result := ApplyForward(csDel, doc, ts, m)
+
+	// The element should be removed from the container page.
+	if containerPage.FindElement("webshop.db") != nil {
+		t.Error("webshop.db should be removed from container page after deletion")
+	}
+
+	if result.ElementsDeleted == 0 {
+		t.Error("expected at least 1 element deleted in forward result")
+	}
+}
+
+// TestApplyForward_DeletedRelationshipRemovedFromViewPages verifies that when
+// a relationship is deleted from the model, its connector is removed from
+// view pages. Regression test for #85.
+func TestApplyForward_DeletedRelationshipRemovedFromViewPages(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	// Round 1: add all elements and relationships.
+	doc := docWithViewPages()
+	csAdd := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+	ApplyForward(csAdd, doc, ts, m)
+
+	// Verify connector exists before deletion.
+	containerPage := doc.GetPage("view-containers")
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+		t.Fatal("precondition: api→db connector should exist on container page")
+	}
+
+	// Round 2: delete the api→db relationship.
+	m.Relationships = []model.Relationship{
+		{From: "customer", To: "webshop", Label: "uses"},
+	}
+
+	csDel := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "webshop.api", To: "webshop.db", Type: Deleted},
+		},
+	}
+	result := ApplyForward(csDel, doc, ts, m)
+
+	// The connector should be removed from the container page.
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+		t.Error("api→db connector should be removed from container page after deletion")
+	}
+
+	if result.ConnectorsDeleted == 0 {
+		t.Error("expected at least 1 connector deleted in forward result")
+	}
+}
+
 // TestApplyForward_NoViewsFallback verifies backward compatibility:
 // when no views are defined, elements go to the first page.
 func TestApplyForward_NoViewsFallback(t *testing.T) {


### PR DESCRIPTION
## Summary
- Element deletion in forward sync now bypasses the view's `elemFilter` — deleted elements aren't in any view's resolved set, so the old blanket filter skipped them entirely
- Relationship deletion now uses scoped cell IDs (`viewID--elemID`) to find connectors on view pages
- Added regression tests for both element and relationship deletion in view-based mode

Fixes #85

## Test plan
- [x] `TestApplyForward_DeletedElementRemovedFromViewPages` — verifies element removal from view page
- [x] `TestApplyForward_DeletedRelationshipRemovedFromViewPages` — verifies connector removal via scoped cell IDs
- [x] `make test-race` — all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)