### PR TITLE
fix: JSON error output and add element fields (#89)

### DIFF
--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -124,6 +124,12 @@ func runAddElement(cmd *cobra.Command, args []string) error {
 			"kind":  kind,
 			"title": title,
 		}
+		if technology != "" {
+			out["technology"] = technology
+		}
+		if description != "" {
+			out["description"] = description
+		}
 		data, _ := json.Marshal(out)
 		fmt.Println(string(data))
 	} else {

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -238,6 +239,110 @@ func TestAddElementJSONOutput(t *testing.T) {
 	}
 	if result["kind"] != "system" {
 		t.Errorf("expected kind 'system', got %q", result["kind"])
+	}
+}
+
+func TestAddElementJSONOutputIncludesAllFields(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--format", "json",
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+		"--technology", "Go",
+		"--description", "Handles payments",
+	})
+
+	err := cmd.Execute()
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	var result map[string]string
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, output)
+	}
+	if result["technology"] != "Go" {
+		t.Errorf("expected technology 'Go', got %q", result["technology"])
+	}
+	if result["description"] != "Handles payments" {
+		t.Errorf("expected description 'Handles payments', got %q", result["description"])
+	}
+}
+
+func TestAddElementJSONErrorOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	var errBuf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--format", "json",
+		"--id", "foo",
+		"--kind", "nonexistent",
+		"--title", "Foo",
+	})
+
+	err := ExecuteRoot(cmd)
+	if err == nil {
+		t.Fatal("expected error for invalid kind")
+	}
+
+	output := errBuf.String()
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("expected JSON error output, got: %s", output)
+	}
+	if _, ok := result["error"]; !ok {
+		t.Error("expected 'error' key in JSON error output")
+	}
+}
+
+func TestAddElementTextErrorOutput(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	var errBuf bytes.Buffer
+	cmd := NewRootCmd()
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "foo",
+		"--kind", "nonexistent",
+		"--title", "Foo",
+	})
+
+	err := ExecuteRoot(cmd)
+	if err == nil {
+		t.Fatal("expected error for invalid kind")
+	}
+
+	output := errBuf.String()
+	// Should be plain text, not JSON
+	var js map[string]interface{}
+	if json.Unmarshal([]byte(output), &js) == nil {
+		t.Error("expected plain text error, got JSON")
+	}
+	if !bytes.Contains(errBuf.Bytes(), []byte("nonexistent")) {
+		t.Errorf("expected error message to mention 'nonexistent', got: %s", output)
 	}
 }
 

--- a/cmd/bausteinsicht/main.go
+++ b/cmd/bausteinsicht/main.go
@@ -1,21 +1,16 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
+import "os"
 
 var version = "dev"
 
 func main() {
 	rootCmd := NewRootCmd()
 
-	if err := rootCmd.Execute(); err != nil {
+	if err := ExecuteRoot(rootCmd); err != nil {
 		if e, ok := err.(*exitError); ok {
-			fmt.Fprintln(os.Stderr, e.Error())
 			os.Exit(e.code)
 		}
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -1,6 +1,11 @@
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
 
 // NewRootCmd creates and returns the root cobra command with global flags.
 func NewRootCmd() *cobra.Command {
@@ -33,4 +38,30 @@ func (e *exitError) Error() string { return e.err.Error() }
 
 func exitWithCode(err error, code int) *exitError {
 	return &exitError{err: err, code: code}
+}
+
+// ExecuteRoot runs the root command and writes errors in the appropriate format
+// (JSON or plain text) to the command's error writer.
+func ExecuteRoot(cmd *cobra.Command) error {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	if err == nil {
+		return nil
+	}
+	format, _ := cmd.PersistentFlags().GetString("format")
+	code := 1
+	if e, ok := err.(*exitError); ok {
+		code = e.code
+	}
+	if format == "json" {
+		out, _ := json.Marshal(map[string]interface{}{
+			"error": err.Error(),
+			"code":  code,
+		})
+		fmt.Fprintln(cmd.ErrOrStderr(), string(out))
+	} else {
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+	}
+	return err
 }


### PR DESCRIPTION
## Summary
- Errors now output as `{"error": "...", "code": N}` on stderr when `--format json` is used
- `add element --format json` now includes `technology` and `description` fields when provided
- Added `ExecuteRoot` wrapper in `root.go` that centralizes format-aware error output
- `main.go` simplified to use `ExecuteRoot` instead of manual error handling

## Test plan
- [x] `TestAddElementJSONOutputIncludesAllFields` — verifies technology/description in JSON output
- [x] `TestAddElementJSONErrorOutput` — verifies errors formatted as JSON with `--format json`
- [x] `TestAddElementTextErrorOutput` — verifies plain text errors still work (default format)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)