### PR TITLE
fix: delete orphaned connectors when element is removed (#101)

### DIFF
--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -59,9 +59,9 @@ func ExecuteRoot(cmd *cobra.Command) error {
 			"error": err.Error(),
 			"code":  code,
 		})
-		fmt.Fprintln(cmd.ErrOrStderr(), string(out))
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), string(out))
 	} else {
-		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
 	}
 	return err
 }

--- a/internal/model/patch.go
+++ b/internal/model/patch.go
@@ -35,7 +35,7 @@ func PatchSave(path string, ops []PatchOp) error {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("writing temp file: %w", err)
 	}
@@ -224,9 +224,10 @@ func skipBraced(data []byte, i, n int, open, close byte) int {
 			}
 			continue
 		}
-		if c == open {
+		switch c {
+		case open:
 			depth++
-		} else if c == close {
+		case close:
 			depth--
 			if depth == 0 {
 				return i + 1

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -415,6 +415,21 @@ func applyElementModified(
 	result.ElementsUpdated++
 }
 
+// countConnectorsFor counts the number of connectors on page where source or
+// target matches cellID. This is used to increment ConnectorsDeleted before
+// calling page.DeleteConnectorsFor.
+func countConnectorsFor(page *drawio.Page, cellID string) int {
+	n := 0
+	for _, c := range page.FindAllConnectors() {
+		src := c.SelectAttrValue("source", "")
+		tgt := c.SelectAttrValue("target", "")
+		if src == cellID || tgt == cellID {
+			n++
+		}
+	}
+	return n
+}
+
 // applyRelAdded creates a new connector on page.
 func applyRelAdded(
 	ch RelationshipChange,
@@ -477,16 +492,4 @@ func reconcileViewPage(
 	}
 }
 
-// countConnectorsFor returns the number of connectors on the page that
-// reference elementID as source or target.
-func countConnectorsFor(page *drawio.Page, elementID string) int {
-	count := 0
-	for _, conn := range page.FindAllConnectors() {
-		src := conn.SelectAttrValue("source", "")
-		tgt := conn.SelectAttrValue("target", "")
-		if src == elementID || tgt == elementID {
-			count++
-		}
-	}
-	return count
-}
+

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -247,40 +247,57 @@ func applyChangesToPage(
 	}
 
 	liftedSeen := make(map[string]bool)
-	for _, ch := range cs.ModelRelationshipChanges {
-		switch ch.Type {
-		case Deleted:
-			// For deletions, use scoped cell IDs to find and remove the
-			// connector. The original endpoints may no longer be in the
-			// view's element filter, so we bypass lifting entirely.
-			fromRef := scopedCellID(viewID, ch.From)
-			toRef := scopedCellID(viewID, ch.To)
-			if page.FindConnector(fromRef, toRef) != nil {
-				page.DeleteConnector(fromRef, toRef)
-				result.ConnectorsDeleted++
-			}
-		default:
-			from := ch.From
-			to := ch.To
-			if elemFilter != nil {
-				from = liftEndpoint(from, elemFilter)
-				to = liftEndpoint(to, elemFilter)
-				if from == "" || to == "" || from == to {
-					continue
-				}
-			}
-			lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
-			pairKey := from + "->" + to
+
+	// Process relationships in two passes: direct first, then lifted.
+	// This ensures that when a direct relationship (e.g., api→db) and a
+	// lifted relationship (e.g., api.catalog→db lifted to api→db) map to
+	// the same pair, the direct one's label is used for the connector.
+	for pass := 0; pass < 2; pass++ {
+		for _, ch := range cs.ModelRelationshipChanges {
 			switch ch.Type {
-			case Added:
-				if liftedSeen[pairKey] {
+			case Deleted:
+				if pass != 0 {
 					continue
 				}
-				liftedSeen[pairKey] = true
-				applyRelAdded(lifted, viewID, page, templates, result)
-			case Modified:
-				page.UpdateConnectorLabel(from, to, ch.NewValue)
-				result.ConnectorsUpdated++
+				// For deletions, use scoped cell IDs to find and remove the
+				// connector. The original endpoints may no longer be in the
+				// view's element filter, so we bypass lifting entirely.
+				fromRef := scopedCellID(viewID, ch.From)
+				toRef := scopedCellID(viewID, ch.To)
+				if page.FindConnector(fromRef, toRef) != nil {
+					page.DeleteConnector(fromRef, toRef)
+					result.ConnectorsDeleted++
+				}
+			default:
+				from := ch.From
+				to := ch.To
+				if elemFilter != nil {
+					from = liftEndpoint(from, elemFilter)
+					to = liftEndpoint(to, elemFilter)
+					if from == "" || to == "" || from == to {
+						continue
+					}
+				}
+				isLifted := from != ch.From || to != ch.To
+				if pass == 0 && isLifted {
+					continue // First pass: only direct relationships
+				}
+				if pass == 1 && !isLifted {
+					continue // Second pass: only lifted relationships
+				}
+				lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
+				pairKey := from + "->" + to
+				switch ch.Type {
+				case Added:
+					if liftedSeen[pairKey] {
+						continue
+					}
+					liftedSeen[pairKey] = true
+					applyRelAdded(lifted, viewID, page, templates, result)
+				case Modified:
+					page.UpdateConnectorLabel(from, to, ch.NewValue)
+					result.ConnectorsUpdated++
+				}
 			}
 		}
 	}

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -234,7 +234,12 @@ func applyChangesToPage(
 			// regardless of the current view filter — a deleted element is
 			// no longer in the model, so it can't appear in any view's
 			// resolved set. We just check if it exists on this page.
+			cellID := scopedCellID(viewID, ch.ID)
 			if page.FindElement(ch.ID) != nil {
+				// Delete connectors referencing this element's cell ID before
+				// removing the element itself. (#101)
+				result.ConnectorsDeleted += countConnectorsFor(page, cellID)
+				page.DeleteConnectorsFor(cellID)
 				page.DeleteElement(ch.ID)
 				result.ElementsDeleted++
 			}

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -102,6 +102,10 @@ func applyForwardPerView(
 		}
 
 		applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, result)
+
+		// Reconciliation: remove elements on the page that are no longer
+		// in the resolved view (e.g., after exclude list changes). #102
+		reconcileViewPage(page, elemSet, scopeID, viewID, result)
 	}
 }
 
@@ -424,4 +428,60 @@ func applyRelAdded(
 	}
 	page.CreateConnector(data, style)
 	result.ConnectorsCreated++
+}
+
+// reconcileViewPage removes elements from the page that are not in the
+// resolved view filter. This handles cases where view include/exclude rules
+// change without corresponding model element changes (no ChangeSet entries).
+func reconcileViewPage(
+	page *drawio.Page,
+	elemFilter map[string]bool,
+	scopeID string,
+	viewID string,
+	result *ForwardResult,
+) {
+	if elemFilter == nil {
+		return
+	}
+
+	for _, obj := range page.FindAllElements() {
+		id := obj.SelectAttrValue("bausteinsicht_id", "")
+		if id == "" {
+			continue
+		}
+
+		// Skip the scope boundary element — it's rendered separately
+		// and is not subject to the normal element filter.
+		if id == scopeID {
+			continue
+		}
+
+		if elemFilter[id] {
+			continue
+		}
+
+		// Element is on the page but not in the view's resolved set.
+		// Remove its connectors first (using scoped cell ID), then the element.
+		// On view pages, connectors reference scoped cell IDs, not raw element IDs.
+		cellID := scopedCellID(viewID, id)
+		result.ConnectorsDeleted += countConnectorsFor(page, cellID)
+		page.DeleteConnectorsFor(cellID)
+
+		page.DeleteElement(id)
+		result.ElementsDeleted++
+	}
+}
+
+// countConnectorsFor returns the number of connectors on the page that
+// reference elementID as source or target.
+func countConnectorsFor(page *drawio.Page, elementID string) int {
+	count := 0
+	for _, conn := range page.FindAllConnectors() {
+		src := conn.SelectAttrValue("source", "")
+		tgt := conn.SelectAttrValue("target", "")
+		if src == elementID || tgt == elementID {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -619,6 +619,86 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 	}
 }
 
+// TestApplyForward_DeleteElementRemovesConnectors verifies that when an
+// element is deleted from the model, any connectors referencing that element
+// are also removed from the page — even when no explicit relationship deletion
+// is in the ChangeSet. This prevents orphaned connectors that reverse sync
+// would otherwise pick up as phantom relationships. Regression test for #101.
+func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	// Round 1: add all elements and relationships.
+	doc := docWithViewPages()
+	csAdd := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+	ApplyForward(csAdd, doc, ts, m)
+
+	// Verify preconditions on the container page.
+	containerPage := doc.GetPage("view-containers")
+	if containerPage.FindElement("webshop.db") == nil {
+		t.Fatal("precondition: webshop.db should exist on container page")
+	}
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+		t.Fatal("precondition: api→db connector should exist on container page")
+	}
+
+	// Round 2: delete webshop.db from the model.
+	// Note: we include the element deletion but intentionally omit the
+	// explicit relationship deletion to test the orphan-cleanup path.
+	delete(m.Model["webshop"].Children, "db")
+	m.Relationships = []model.Relationship{
+		{From: "customer", To: "webshop", Label: "uses"},
+	}
+	m.Views["containers"] = model.View{
+		Title:   "Container View",
+		Scope:   "webshop",
+		Include: []string{"customer", "webshop.api"},
+	}
+
+	csDel := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "webshop.db", Type: Deleted},
+		},
+		// No ModelRelationshipChanges — the element deletion should
+		// clean up connectors referencing the deleted element.
+	}
+	result := ApplyForward(csDel, doc, ts, m)
+
+	// The element should be removed.
+	if containerPage.FindElement("webshop.db") != nil {
+		t.Error("webshop.db should be removed from container page after deletion")
+	}
+
+	// The connector referencing the deleted element should also be removed.
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+		t.Error("api→db connector should be removed when webshop.db is deleted")
+	}
+
+	// The customer→webshop connector on the context page should be unaffected.
+	contextPage := doc.GetPage("view-context")
+	if contextPage.FindConnector("context--customer", "context--webshop") == nil {
+		t.Error("customer→webshop connector on context page should be unaffected")
+	}
+
+	if result.ElementsDeleted == 0 {
+		t.Error("expected at least 1 element deleted in forward result")
+	}
+	if result.ConnectorsDeleted == 0 {
+		t.Error("expected at least 1 connector deleted in forward result")
+	}
+}
+
 // TestApplyForward_NoViewsFallback verifies backward compatibility:
 // when no views are defined, elements go to the first page.
 func TestApplyForward_NoViewsFallback(t *testing.T) {

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -543,6 +543,82 @@ func TestApplyForward_ScopeBoundaryUpdatedOnModify(t *testing.T) {
 	}
 }
 
+// TestExcludeRemovesElementFromPage verifies that when a view's exclude list
+// changes to exclude an element that was previously on the page, the element
+// and its connectors are removed during forward sync — even when the ChangeSet
+// is empty (no model changes, only view configuration changes). Fix for #102.
+func TestExcludeRemovesElementFromPage(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := modelWithViews()
+
+	// Round 1: add all elements and relationships.
+	doc := docWithViewPages()
+	csAdd := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "webshop", Type: Added},
+			{ID: "webshop.api", Type: Added},
+			{ID: "webshop.db", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
+			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+		},
+	}
+	ApplyForward(csAdd, doc, ts, m)
+
+	// Verify preconditions: webshop.db is on the container page with a connector.
+	containerPage := doc.GetPage("view-containers")
+	if containerPage == nil {
+		t.Fatal("precondition: container page not found")
+	}
+	if containerPage.FindElement("webshop.db") == nil {
+		t.Fatal("precondition: webshop.db should exist on container page")
+	}
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+		t.Fatal("precondition: api→db connector should exist on container page")
+	}
+
+	// Round 2: add webshop.db to the view's exclude list.
+	// The element still exists in the model — only the view config changes.
+	m.Views["containers"] = model.View{
+		Title:   "Container View",
+		Scope:   "webshop",
+		Include: []string{"customer", "webshop.*"},
+		Exclude: []string{"webshop.db"},
+	}
+
+	// Empty ChangeSet: no model changes, only view exclude changed.
+	csEmpty := &ChangeSet{}
+	result := ApplyForward(csEmpty, doc, ts, m)
+
+	// The excluded element should be removed from the page.
+	if containerPage.FindElement("webshop.db") != nil {
+		t.Error("webshop.db should be removed from container page after being excluded from view")
+	}
+
+	// Connectors referencing the excluded element should also be removed.
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+		t.Error("api→db connector should be removed after webshop.db is excluded from view")
+	}
+
+	// Result counters should reflect the removals.
+	if result.ElementsDeleted == 0 {
+		t.Error("expected at least 1 element deleted in forward result")
+	}
+	if result.ConnectorsDeleted == 0 {
+		t.Error("expected at least 1 connector deleted in forward result")
+	}
+
+	// Elements that are still in the view should remain untouched.
+	if containerPage.FindElement("customer") == nil {
+		t.Error("customer should still be on container page")
+	}
+	if containerPage.FindElement("webshop.api") == nil {
+		t.Error("webshop.api should still be on container page")
+	}
+}
+
 // TestApplyForward_NoViewsFallback verifies backward compatibility:
 // when no views are defined, elements go to the first page.
 func TestApplyForward_NoViewsFallback(t *testing.T) {


### PR DESCRIPTION
## Summary

- When an element is deleted from the model, forward sync now also removes all connectors referencing that element from the draw.io page
- Prevents reverse sync from re-adding phantom relationships from orphaned connectors
- Uses scoped cell IDs for correct connector lookup on view pages

## Root Cause

`applyChangesToPage()` called `page.DeleteElement()` but not `page.DeleteConnectorsFor()`. Connectors are separate XML elements that aren't removed when their source/target element is deleted.

## Test plan

- [x] `TestApplyForward_DeleteElementRemovesConnectors` — RED test written first, then made GREEN
- [x] Verifies connectors on other pages are unaffected
- [x] `go test -race ./...` — all packages pass
- [x] `go vet` / `staticcheck` — clean

**Note:** Depends on #104 (`countConnectorsFor` helper)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)