### PR TITLE
fix: detect element kind changes during sync (#107)

### DIFF
--- a/internal/drawio/element.go
+++ b/internal/drawio/element.go
@@ -113,6 +113,20 @@ func (p *Page) UpdateElement(id string, data ElementData) {
 	}
 }
 
+// UpdateElementKind updates the bausteinsicht_kind attribute and the mxCell style
+// of an existing element. If style is empty, the mxCell style is not changed.
+func (p *Page) UpdateElementKind(id, kind, style string) {
+	obj := p.FindElement(id)
+	if obj == nil {
+		return
+	}
+	setAttr(obj, "bausteinsicht_kind", kind)
+	cell := obj.FindElement("mxCell")
+	if cell != nil && style != "" {
+		setAttr(cell, "style", style)
+	}
+}
+
 // DeleteElement removes the <object> element with the given bausteinsicht_id.
 // It also removes any mxCell connectors that reference this element as source or target.
 func (p *Page) DeleteElement(id string) {

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -193,6 +193,7 @@ func detectElementChanges(
 			appendIfChanged(id, "title", lastElem.Title, me.Title, &cs.ModelElementChanges)
 			appendIfChanged(id, "description", lastElem.Description, me.Description, &cs.ModelElementChanges)
 			appendIfChanged(id, "technology", lastElem.Technology, me.Technology, &cs.ModelElementChanges)
+			appendIfChanged(id, "kind", lastElem.Kind, me.Kind, &cs.ModelElementChanges)
 		}
 
 		// Draw.io side changes
@@ -205,6 +206,9 @@ func detectElementChanges(
 			appendIfChanged(id, "title", lastElem.Title, de.title, &cs.DrawioElementChanges)
 			appendIfChanged(id, "description", lastElem.Description, de.description, &cs.DrawioElementChanges)
 			appendIfChanged(id, "technology", lastElem.Technology, de.technology, &cs.DrawioElementChanges)
+			// Note: kind is not compared on the draw.io side because scope
+			// boundary elements have a derived kind (e.g. "system_boundary")
+			// that legitimately differs from the model kind ("system").
 		}
 
 		// Conflicts: both sides modified the same field
@@ -212,6 +216,8 @@ func detectElementChanges(
 			checkElemConflict(cs, id, "title", lastElem.Title, me.Title, de.title)
 			checkElemConflict(cs, id, "description", lastElem.Description, me.Description, de.description)
 			checkElemConflict(cs, id, "technology", lastElem.Technology, me.Technology, de.technology)
+			// Note: kind conflicts are not checked because kind is
+			// model-authoritative and draw.io boundary kinds are derived.
 		}
 	}
 }

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -467,6 +467,37 @@ func TestDetectChanges_LiftedConnectorIgnored(t *testing.T) {
 	}
 }
 
+func simpleModelWithKind(id, title, description, technology, kind string) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			id: {Kind: kind, Title: title, Description: description, Technology: technology},
+		},
+		Relationships: []model.Relationship{},
+	}
+}
+
+func TestDetectChanges_ModelModifiedKind(t *testing.T) {
+	state := stateWithElem("app", "App", "Desc", "Go")
+	m := simpleModelWithKind("app", "App", "Desc", "Go", "component")
+	doc := docWithElem("app", "App", "Go", "Desc")
+
+	cs := DetectChanges(m, doc, state)
+
+	found := false
+	for _, ch := range cs.ModelElementChanges {
+		if ch.ID == "app" && ch.Type == Modified && ch.Field == "kind" &&
+			ch.OldValue == "container" && ch.NewValue == "component" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected model kind modification, changes: %+v", cs.ModelElementChanges)
+	}
+	if len(cs.Conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %d", len(cs.Conflicts))
+	}
+}
+
 func TestDetectChanges_ScopedConnectorLabelChange(t *testing.T) {
 	// Relationship exists in state with label "uses". draw.io connector (scoped)
 	// has label "calls". Should detect a drawio-side label modification.

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -228,7 +228,7 @@ func applyChangesToPage(
 			if elemFilter != nil && !elemFilter[ch.ID] && ch.ID != scopeID {
 				continue
 			}
-			applyElementModified(ch, page, flat, result)
+			applyElementModified(ch, page, templates, flat, result)
 		case Deleted:
 			// Deleted elements are removed from all pages where they exist,
 			// regardless of the current view filter — a deleted element is
@@ -412,6 +412,7 @@ func applyElementAdded(
 func applyElementModified(
 	ch ElementChange,
 	page *drawio.Page,
+	templates *drawio.TemplateSet,
 	flat map[string]*model.Element,
 	result *ForwardResult,
 ) {
@@ -429,6 +430,15 @@ func applyElementModified(
 	}
 
 	page.UpdateElement(ch.ID, data)
+
+	if ch.Field == "kind" {
+		style := ""
+		if ts, ok := templates.GetStyle(elem.Kind); ok {
+			style = ts.Style
+		}
+		page.UpdateElementKind(ch.ID, elem.Kind, style)
+	}
+
 	result.ElementsUpdated++
 }
 

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -61,6 +61,84 @@ func fwdModelWithRel(fromID, toID string) *model.BausteinsichtModel {
 	}
 }
 
+// templatesWithComponent returns a TemplateSet with both "container" and "component" kinds.
+func templatesWithComponent(t *testing.T) *drawio.TemplateSet {
+	t.Helper()
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<mxfile>
+  <diagram id="t1" name="templates">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object bausteinsicht_template="container" label="" id="tpl-container">
+          <mxCell style="shape=mxgraph.c4;c4Type=container;" vertex="1" parent="1">
+            <mxGeometry width="120" height="60" as="geometry"/>
+          </mxCell>
+        </object>
+        <object bausteinsicht_template="component" label="" id="tpl-component">
+          <mxCell style="shape=mxgraph.c4;c4Type=component;" vertex="1" parent="1">
+            <mxGeometry width="100" height="50" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell bausteinsicht_template="relationship" style="endArrow=block;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>`
+	ts, err := drawio.LoadTemplateFromBytes([]byte(xml))
+	if err != nil {
+		t.Fatalf("LoadTemplateFromBytes: %v", err)
+	}
+	return ts
+}
+
+// TestApplyForward_ElementKindChanged verifies that a kind change updates
+// the bausteinsicht_kind attribute and the mxCell style.
+func TestApplyForward_ElementKindChanged(t *testing.T) {
+	// Create a doc with an element of kind "container"
+	doc := docWithElem("api", "API", "Go", "")
+	ts := templatesWithComponent(t)
+	// Model now has kind "component"
+	m := modelWithElem("api", "component", "API")
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Modified, Field: "kind", OldValue: "container", NewValue: "component"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsUpdated != 1 {
+		t.Fatalf("expected 1 element updated, got %d", result.ElementsUpdated)
+	}
+
+	page := doc.Pages()[0]
+	obj := page.FindElement("api")
+	if obj == nil {
+		t.Fatal("element 'api' not found")
+	}
+
+	// Verify bausteinsicht_kind attribute was updated
+	kindAttr := obj.SelectAttrValue("bausteinsicht_kind", "")
+	if kindAttr != "component" {
+		t.Errorf("expected bausteinsicht_kind='component', got %q", kindAttr)
+	}
+
+	// Verify style was updated to component style
+	cell := obj.FindElement("mxCell")
+	if cell == nil {
+		t.Fatal("mxCell not found under element")
+	}
+	style := cell.SelectAttrValue("style", "")
+	if !strings.Contains(style, "c4Type=component") {
+		t.Errorf("expected style to contain component template style, got: %s", style)
+	}
+}
+
 // TestApplyForward_NewElement verifies that an Added element change creates the element.
 func TestApplyForward_NewElement(t *testing.T) {
 	doc := emptyDoc()


### PR DESCRIPTION
## Summary
- Three-way diff now detects `kind` field changes on the model side
- Forward sync updates `bausteinsicht_kind` attribute and mxCell style from templates when kind changes
- Kind is model-authoritative — not compared on draw.io side to avoid false positives from scope boundary elements (`system_boundary` vs `system`)

## Test plan
- [x] `TestDetectChanges_ModelModifiedKind` — verifies kind change detected as Modified
- [x] `TestApplyForward_ElementKindChanged` — verifies kind attribute and style updated in draw.io
- [x] Full test suite passes
- [x] Static analysis clean

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)