### PR TITLE
fix: prevent reverse sync from deleting view-filtered elements (#108, #118)

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -57,6 +57,31 @@ func relKey(from, to string) string {
 	return from + ":" + to
 }
 
+// computeVisibleElements returns the set of element IDs that should be visible
+// across all views. If the model has no views, returns nil (meaning ALL elements
+// are visible on the single page).
+func computeVisibleElements(m *model.BausteinsichtModel) map[string]bool {
+	if len(m.Views) == 0 {
+		return nil // all elements visible
+	}
+	visible := make(map[string]bool)
+	for _, view := range m.Views {
+		v := view
+		resolved, err := model.ResolveView(m, &v)
+		if err != nil {
+			continue
+		}
+		for _, id := range resolved {
+			visible[id] = true
+		}
+		// The scope element itself is also visible (rendered as boundary).
+		if view.Scope != "" {
+			visible[view.Scope] = true
+		}
+	}
+	return visible
+}
+
 // DetectChanges performs a three-way diff between the model, draw.io document,
 // and the last known sync state.
 func DetectChanges(m *model.BausteinsichtModel, doc *drawio.Document, lastState *SyncState) *ChangeSet {
@@ -64,7 +89,8 @@ func DetectChanges(m *model.BausteinsichtModel, doc *drawio.Document, lastState 
 
 	flatModel := model.FlattenElements(m)
 	drawioElems := extractDrawioElements(doc)
-	detectElementChanges(cs, flatModel, drawioElems, lastState)
+	visibleElems := computeVisibleElements(m)
+	detectElementChanges(cs, flatModel, drawioElems, lastState, visibleElems)
 
 	modelRels := buildModelRelMap(m)
 	drawioRels := extractDrawioRelationships(doc)
@@ -170,11 +196,14 @@ func buildModelRelMap(m *model.BausteinsichtModel) map[string]RelationshipState 
 }
 
 // detectElementChanges performs three-way comparison for elements.
+// visibleElems is the set of element IDs visible across all views. If nil,
+// all elements are considered visible (no views defined).
 func detectElementChanges(
 	cs *ChangeSet,
 	flatModel map[string]*model.Element,
 	drawioElems map[string]drawioElemSnapshot,
 	lastState *SyncState,
+	visibleElems map[string]bool,
 ) {
 	allIDs := unionElementIDs(flatModel, drawioElems, lastState)
 
@@ -200,7 +229,12 @@ func detectElementChanges(
 		case inDrawio && !inLast:
 			cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Added})
 		case !inDrawio && inLast:
-			cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Deleted})
+			// Only treat as deleted if the element should be visible on at least one
+			// view page. Elements not in any view's resolved set are simply filtered
+			// out and their absence from draw.io is expected, not a deletion. (#108, #118)
+			if visibleElems == nil || visibleElems[id] {
+				cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Deleted})
+			}
 		case inDrawio && inLast:
 			appendIfChanged(id, "title", lastElem.Title, de.title, &cs.DrawioElementChanges)
 			appendIfChanged(id, "description", lastElem.Description, de.description, &cs.DrawioElementChanges)

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -501,3 +501,156 @@ func TestDetectChanges_ScopedConnectorLabelChange(t *testing.T) {
 			cs.DrawioRelationshipChanges)
 	}
 }
+
+// --- View-aware deletion tests (#108, #118) ---
+
+// modelWithCustomViews creates a model with the given elements and views.
+func modelWithCustomViews(elements map[string]model.Element, views map[string]model.View) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Model:         elements,
+		Views:         views,
+		Relationships: []model.Relationship{},
+	}
+}
+
+// docWithElems creates a draw.io document with multiple elements by ID.
+func docWithElems(ids ...string) *drawio.Document {
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	for _, id := range ids {
+		_ = page.CreateElement(drawio.ElementData{
+			ID:    id,
+			Kind:  "container",
+			Title: id,
+		}, "")
+	}
+	return doc
+}
+
+// stateWithElems creates a SyncState with multiple elements by ID.
+func stateWithElems(ids ...string) *SyncState {
+	s := emptyState()
+	for _, id := range ids {
+		s.Elements[id] = ElementState{Title: id, Kind: "container"}
+	}
+	return s
+}
+
+func TestDetectChanges_ElementNotOnViewNotTreatedAsDeleted(t *testing.T) {
+	// Model has elements a, b, c.
+	// View only includes a and b.
+	// Sync state has a, b, c (from a previous sync without views).
+	// draw.io only has a, b (because c is filtered out by the view).
+	// c should NOT appear as a DrawioElementChange Deleted.
+	m := modelWithCustomViews(
+		map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+			"c": {Kind: "container", Title: "C"},
+		},
+		map[string]model.View{
+			"main": {Title: "Main", Include: []string{"a", "b"}},
+		},
+	)
+	state := stateWithElems("a", "b", "c")
+	doc := docWithElems("a", "b")
+
+	cs := DetectChanges(m, doc, state)
+
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "c" && ch.Type == Deleted {
+			t.Errorf("element 'c' is not in any view and should NOT be treated as deleted from draw.io, got: %+v",
+				cs.DrawioElementChanges)
+		}
+	}
+}
+
+func TestDetectChanges_ExcludedElementNotTreatedAsDeleted(t *testing.T) {
+	// Model has elements a and b.
+	// View includes a and b but explicitly excludes b.
+	// Sync state has a and b.
+	// draw.io only has a (b excluded from view).
+	// b should NOT appear as a DrawioElementChange Deleted.
+	m := modelWithCustomViews(
+		map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		map[string]model.View{
+			"main": {Title: "Main", Include: []string{"a", "b"}, Exclude: []string{"b"}},
+		},
+	)
+	state := stateWithElems("a", "b")
+	doc := docWithElems("a")
+
+	cs := DetectChanges(m, doc, state)
+
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "b" && ch.Type == Deleted {
+			t.Errorf("element 'b' is excluded from all views and should NOT be treated as deleted from draw.io, got: %+v",
+				cs.DrawioElementChanges)
+		}
+	}
+}
+
+func TestDetectChanges_TrueDeletionStillDetected(t *testing.T) {
+	// Model has elements a and b.
+	// View includes both a and b (both visible).
+	// Sync state has a and b.
+	// draw.io only has a (user actually deleted b from draw.io).
+	// b SHOULD appear as a DrawioElementChange Deleted.
+	m := modelWithCustomViews(
+		map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		map[string]model.View{
+			"main": {Title: "Main", Include: []string{"a", "b"}},
+		},
+	)
+	state := stateWithElems("a", "b")
+	doc := docWithElems("a")
+
+	cs := DetectChanges(m, doc, state)
+
+	found := false
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "b" && ch.Type == Deleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("element 'b' is visible on a view and was removed from draw.io; should be detected as deleted, got: %+v",
+			cs.DrawioElementChanges)
+	}
+}
+
+func TestDetectChanges_NoViewsAllDeletionsDetected(t *testing.T) {
+	// No views (legacy mode / backward compatibility).
+	// Sync state has a and b.
+	// draw.io only has a.
+	// b SHOULD appear as a DrawioElementChange Deleted.
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{},
+		// No Views field → nil map
+	}
+	state := stateWithElems("a", "b")
+	doc := docWithElems("a")
+
+	cs := DetectChanges(m, doc, state)
+
+	found := false
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "b" && ch.Type == Deleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("with no views, element 'b' absent from draw.io should be detected as deleted, got: %+v",
+			cs.DrawioElementChanges)
+	}
+}


### PR DESCRIPTION
## Summary
- Elements absent from draw.io because they're not in any view's resolved set are no longer treated as "deleted in draw.io"
- `computeVisibleElements()` resolves all views to build a union set of visible element IDs
- Draw.io-side deletion is only detected when the element should be visible on at least one view page (or when no views exist)
- Backward compatible: no-views mode unchanged

## Root cause
The three-way diff interpreted any element absent from draw.io as "user deleted it." This is incorrect when elements are absent because they were excluded by a view's `exclude` array (#118) or never included in any view (#108).

## Test plan
- [x] `TestDetectChanges_ElementNotOnViewNotTreatedAsDeleted`
- [x] `TestDetectChanges_ExcludedElementNotTreatedAsDeleted`
- [x] `TestDetectChanges_TrueDeletionStillDetected` — real deletions still work
- [x] `TestDetectChanges_NoViewsAllDeletionsDetected` — backward compat
- [x] Full test suite passes
- [x] Static analysis clean

Closes #108
Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)