### PR TITLE
fix: preserve user-added draw.io elements during view reconciliation (#115)

### DIFF
--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -363,6 +363,71 @@ func TestSyncConcurrentModelAndDrawioChanges(t *testing.T) {
 	}
 }
 
+// TestSyncPreservesUserAddedDrawioElement verifies that elements manually
+// added by the user in draw.io (with a bausteinsicht_id that does NOT exist
+// in the model) are preserved across sync cycles. Regression test for #115.
+func TestSyncPreservesUserAddedDrawioElement(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init the project.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Inject a user-added element into the draw.io XML.
+	// This simulates a user manually adding an <object> in draw.io.
+	drawioData, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert a user element before the closing </root> tag on the first view page.
+	userElemXML := `<object bausteinsicht_id="userelem" bausteinsicht_kind="system" label="User Custom Element" id="userelem">
+          <mxCell style="shape=rectangle;" vertex="1" parent="1">
+            <mxGeometry x="500" y="500" width="120" height="60" as="geometry"/>
+          </mxCell>
+        </object>`
+
+	modified := strings.Replace(string(drawioData), "</root>", userElemXML+"\n      </root>", 1)
+	if modified == string(drawioData) {
+		t.Fatal("failed to inject user element into draw.io XML")
+	}
+	if err := os.WriteFile("architecture.drawio", []byte(modified), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the element was injected.
+	if !strings.Contains(modified, "userelem") {
+		t.Fatal("precondition: user element not found in draw.io XML")
+	}
+
+	// Run sync.
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{"sync"})
+	captureStdout(t, func() {
+		if err := cmd2.Execute(); err != nil {
+			t.Fatalf("sync failed: %v", err)
+		}
+	})
+
+	// Read the draw.io file after sync and verify the user element is preserved.
+	afterSync, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(afterSync), `bausteinsicht_id="userelem"`) {
+		t.Error("user-added element 'userelem' was deleted during sync; it should be preserved (#115)")
+	}
+}
+
 func TestSyncWithExplicitModelPath(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -105,7 +105,7 @@ func applyForwardPerView(
 
 		// Reconciliation: remove elements on the page that are no longer
 		// in the resolved view (e.g., after exclude list changes). #102
-		reconcileViewPage(page, elemSet, scopeID, viewID, result)
+		reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
 	}
 }
 
@@ -515,9 +515,12 @@ func applyRelAdded(
 // reconcileViewPage removes elements from the page that are not in the
 // resolved view filter. This handles cases where view include/exclude rules
 // change without corresponding model element changes (no ChangeSet entries).
+// Elements not present in the flat model map are preserved — they were
+// manually added by the user in draw.io and should not be deleted. (#115)
 func reconcileViewPage(
 	page *drawio.Page,
 	elemFilter map[string]bool,
+	flat map[string]*model.Element,
 	scopeID string,
 	viewID string,
 	result *ForwardResult,
@@ -539,6 +542,12 @@ func reconcileViewPage(
 		}
 
 		if elemFilter[id] {
+			continue
+		}
+
+		// Preserve elements not in the model — they were manually added
+		// by the user in draw.io and should not be deleted. (#115)
+		if _, inModel := flat[id]; !inModel {
 			continue
 		}
 

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -343,3 +343,53 @@ func elementX(page *drawio.Page, id string) float64 {
 	}
 	return f
 }
+
+// TestReconcileViewPage_PreservesUserAddedElements verifies that elements
+// manually added by the user in draw.io (with bausteinsicht_id but NOT in
+// the model) are preserved during reconciliation, while model elements not
+// in the view's resolved set are deleted. Regression test for #115.
+func TestReconcileViewPage_PreservesUserAddedElements(t *testing.T) {
+	// Create a page with three elements:
+	// - "a": in the model AND in the view filter (should be kept)
+	// - "b": in the model but NOT in the view filter (should be deleted)
+	// - "useradded": NOT in the model at all (user-added, should be preserved)
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-test", "Test View")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "test--a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "b", CellID: "test--b", Kind: "container", Title: "B",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "useradded", CellID: "test--useradded", Kind: "container", Title: "User Added",
+	}, "")
+
+	elemFilter := map[string]bool{"a": true}
+	flat := map[string]*model.Element{
+		"a": {Kind: "container", Title: "A"},
+		"b": {Kind: "container", Title: "B"},
+	}
+
+	result := &ForwardResult{}
+	reconcileViewPage(page, elemFilter, flat, "", "test", result)
+
+	// "a" is in the filter — should be kept.
+	if page.FindElement("a") == nil {
+		t.Error("element 'a' should be preserved (in view filter)")
+	}
+
+	// "b" is in the model but not in the filter — should be deleted.
+	if page.FindElement("b") != nil {
+		t.Error("element 'b' should be deleted (in model, not in view filter)")
+	}
+
+	// "useradded" is NOT in the model — should be preserved (user-added).
+	if page.FindElement("useradded") == nil {
+		t.Error("element 'useradded' should be preserved (not in model, user-added in draw.io)")
+	}
+
+	if result.ElementsDeleted != 1 {
+		t.Errorf("expected 1 element deleted, got %d", result.ElementsDeleted)
+	}
+}

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -66,7 +66,7 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *R
 
 	case Added:
 		result.Warnings = append(result.Warnings,
-			"New element detected in draw.io (no bausteinsicht_id). Please add it to the model manually.")
+			fmt.Sprintf("New element %q detected in draw.io. Add it to the model to keep it synchronized.", ch.ID))
 	}
 }
 

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -139,8 +139,16 @@ func TestApplyReverse_AddedElementWarning(t *testing.T) {
 
 	r := ApplyReverse(cs, m)
 
-	if len(r.Warnings) != 1 || !strings.Contains(r.Warnings[0], "manually") {
-		t.Errorf("expected manual-add warning, got %v", r.Warnings)
+	if len(r.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(r.Warnings), r.Warnings)
+	}
+	// The warning should include the element ID and mention the model. (#115)
+	w := r.Warnings[0]
+	if !strings.Contains(w, `"unknown"`) {
+		t.Errorf("expected warning to include element ID %q, got: %s", "unknown", w)
+	}
+	if !strings.Contains(w, "model") {
+		t.Errorf("expected warning to mention 'model', got: %s", w)
 	}
 	if r.ElementsCreated != 0 {
 		t.Errorf("expected ElementsCreated=0, got %d", r.ElementsCreated)


### PR DESCRIPTION
## Summary
- `reconcileViewPage` now only removes elements whose bausteinsicht_id exists in the model
- Elements manually added by users in draw.io (not in model) are preserved
- Fixed misleading "no bausteinsicht_id" warning — now includes element ID

## Test plan
- [x] `TestReconcileViewPage_PreservesUserAddedElements` — unit test for reconciliation logic
- [x] `TestSyncPreservesUserAddedDrawioElement` — E2E integration test
- [x] `TestApplyReverse_AddedElementWarning` — updated for new warning format
- [x] Full test suite passes

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)