### PR TITLE
fix: strip HTML tags from title and prefer tooltip for description (#112, #113)

### DIFF
--- a/internal/drawio/label.go
+++ b/internal/drawio/label.go
@@ -44,8 +44,10 @@ func ParseLabel(html string) (title, technology, description string) {
 	titlePart := rest[:closeB]
 	after := rest[closeB+len("</b>"):]
 
+	cleanTitle := stripTags(titlePart)
+
 	if after == "" {
-		return unescapeHTML(titlePart), "", ""
+		return cleanTitle, "", ""
 	}
 
 	// Parse remaining <br><font ...>...</font> segments
@@ -56,16 +58,16 @@ func ParseLabel(html string) (title, technology, description string) {
 		seg := segments[0]
 		if seg.color == "#999999" {
 			// Description only (no technology)
-			return unescapeHTML(titlePart), "", unescapeHTML(seg.text)
+			return cleanTitle, "", unescapeHTML(seg.text)
 		}
 		// Technology (with or without brackets)
-		return unescapeHTML(titlePart), unescapeHTML(trimBrackets(seg.text)), ""
+		return cleanTitle, unescapeHTML(trimBrackets(seg.text)), ""
 	case 2:
 		tech := unescapeHTML(trimBrackets(segments[0].text))
 		desc := unescapeHTML(segments[1].text)
-		return unescapeHTML(titlePart), tech, desc
+		return cleanTitle, tech, desc
 	default:
-		return unescapeHTML(titlePart), "", ""
+		return cleanTitle, "", ""
 	}
 }
 

--- a/internal/drawio/label_test.go
+++ b/internal/drawio/label_test.go
@@ -188,6 +188,34 @@ func TestParseLabel(t *testing.T) {
 	}
 }
 
+func TestParseLabel_StripsNestedHTMLTags(t *testing.T) {
+	html := `<b><i>Styled</i> Customer</b>`
+	gotTitle, gotTech, gotDesc := ParseLabel(html)
+	if gotTitle != "Styled Customer" {
+		t.Errorf("expected title %q, got %q", "Styled Customer", gotTitle)
+	}
+	if gotTech != "" {
+		t.Errorf("expected empty technology, got %q", gotTech)
+	}
+	if gotDesc != "" {
+		t.Errorf("expected empty description, got %q", gotDesc)
+	}
+}
+
+func TestParseLabel_StripsUnderlineTags(t *testing.T) {
+	html := `<b><u>Important</u> System</b><br><font color="#666666">[Go]</font>`
+	gotTitle, gotTech, gotDesc := ParseLabel(html)
+	if gotTitle != "Important System" {
+		t.Errorf("expected title %q, got %q", "Important System", gotTitle)
+	}
+	if gotTech != "Go" {
+		t.Errorf("expected technology %q, got %q", "Go", gotTech)
+	}
+	if gotDesc != "" {
+		t.Errorf("expected empty description, got %q", gotDesc)
+	}
+}
+
 func TestRoundTrip(t *testing.T) {
 	tests := []struct {
 		title string

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -109,10 +109,11 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 				continue
 			}
 			label := obj.SelectAttrValue("label", "")
-			title, technology, description := drawio.ParseLabel(label)
+			title, technology, labelDesc := drawio.ParseLabel(label)
 			tooltipDesc := obj.SelectAttrValue("tooltip", "")
+			description := tooltipDesc
 			if description == "" {
-				description = tooltipDesc
+				description = labelDesc
 			}
 			result[id] = drawioElemSnapshot{
 				title:       title,

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -467,6 +467,44 @@ func TestDetectChanges_LiftedConnectorIgnored(t *testing.T) {
 	}
 }
 
+func TestDetectChanges_TooltipChangeDetected(t *testing.T) {
+	// Sync state has element with description "Old Desc"
+	state := stateWithElem("app", "App", "Old Desc", "Go")
+
+	// Model has same description (no model-side change)
+	m := simpleModel("app", "App", "Old Desc", "Go")
+
+	// Create draw.io doc where label still has "Old Desc" in description,
+	// but the tooltip attribute has been changed to "New Desc" by the user
+	doc := docWithElem("app", "App", "Go", "Old Desc")
+	// Manually update the tooltip attribute to simulate user editing tooltip in draw.io
+	for _, page := range doc.Pages() {
+		obj := page.FindElement("app")
+		if obj != nil {
+			attr := obj.SelectAttr("tooltip")
+			if attr != nil {
+				attr.Value = "New Desc"
+			} else {
+				obj.CreateAttr("tooltip", "New Desc")
+			}
+		}
+	}
+
+	cs := DetectChanges(m, doc, state)
+
+	// Should detect a drawio-side description change from "Old Desc" to "New Desc"
+	found := false
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "app" && ch.Type == Modified && ch.Field == "description" &&
+			ch.OldValue == "Old Desc" && ch.NewValue == "New Desc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected drawio description modification from tooltip change, got: %+v", cs.DrawioElementChanges)
+	}
+}
+
 func simpleModelWithKind(id, title, description, technology, kind string) *model.BausteinsichtModel {
 	return &model.BausteinsichtModel{
 		Model: map[string]model.Element{


### PR DESCRIPTION
## Summary
- `ParseLabel` now strips nested HTML tags (`<i>`, `<u>`, `<font>`) from title text (#112)
- `extractDrawioElements` uses tooltip attribute as primary description source, label description as fallback (#113)

## Test plan
- [x] `TestParseLabel_StripsNestedHTMLTags` — `<i>` tags stripped from title
- [x] `TestParseLabel_StripsUnderlineTags` — `<u>` tags stripped, technology preserved
- [x] `TestDetectChanges_TooltipChangeDetected` — tooltip-only edit detected
- [x] Full test suite passes

Closes #112
Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)