### PR TITLE
fix: remove orphaned elements from draw.io in no-views mode (#110)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -63,6 +63,11 @@ func applyForwardToPage(
 		return
 	}
 	applyChangesToPage(cs, page, templates, flat, elemFilter, "", "", result)
+
+	// Reconcile orphaned elements: remove any element on the page whose
+	// bausteinsicht_id is not present in the current model. This handles
+	// cases where the sync state is missing or the model was emptied. (#110)
+	reconcileOrphanedElements(page, flat, result)
 }
 
 // applyForwardPerView iterates over model views and applies changes per page.
@@ -563,4 +568,28 @@ func reconcileViewPage(
 	}
 }
 
-
+// reconcileOrphanedElements removes elements from the page whose
+// bausteinsicht_id does not exist in the current model. This is the
+// no-views equivalent of reconcileViewPage and handles cases where
+// sync state is missing or the model was emptied. (#110)
+func reconcileOrphanedElements(
+	page *drawio.Page,
+	flat map[string]*model.Element,
+	result *ForwardResult,
+) {
+	for _, obj := range page.FindAllElements() {
+		id := obj.SelectAttrValue("bausteinsicht_id", "")
+		if id == "" {
+			continue
+		}
+		if _, inModel := flat[id]; inModel {
+			continue
+		}
+		// Element is on the page but not in the model — remove it.
+		cellID := id // no view scoping in legacy mode
+		result.ConnectorsDeleted += countConnectorsFor(page, cellID)
+		page.DeleteConnectorsFor(cellID)
+		page.DeleteElement(id)
+		result.ElementsDeleted++
+	}
+}

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -393,3 +393,80 @@ func TestReconcileViewPage_PreservesUserAddedElements(t *testing.T) {
 		t.Errorf("expected 1 element deleted, got %d", result.ElementsDeleted)
 	}
 }
+
+// TestApplyForward_EmptyModelRemovesElements verifies that when the model is
+// emptied (no elements), forward sync removes all elements from the draw.io
+// page, including in no-views (legacy) mode. Regression test for #110.
+func TestApplyForward_EmptyModelRemovesElements(t *testing.T) {
+	// Start with a document that has two elements on the page.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "b", CellID: "b", Kind: "container", Title: "B",
+	}, "")
+
+	// Empty model — no elements, no views.
+	m := emptyModel()
+	ts := minimalTemplates(t)
+
+	// ChangeSet has explicit deletions for both elements.
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "a", Type: Deleted},
+			{ID: "b", Type: Deleted},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ElementsDeleted != 2 {
+		t.Errorf("expected 2 elements deleted, got %d", result.ElementsDeleted)
+	}
+	if page.FindElement("a") != nil {
+		t.Error("element 'a' should have been removed")
+	}
+	if page.FindElement("b") != nil {
+		t.Error("element 'b' should have been removed")
+	}
+}
+
+// TestApplyForward_NoViewsReconciliation verifies that in no-views (legacy)
+// mode, orphaned elements on the page are cleaned up even without explicit
+// Deleted changes in the ChangeSet. This handles the case where sync state
+// is missing or out of sync. Regression test for #110.
+func TestApplyForward_NoViewsReconciliation(t *testing.T) {
+	// Document has elements "a" and "orphan" on the page.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "orphan", CellID: "orphan", Kind: "container", Title: "Orphan",
+	}, "")
+
+	// Model only has element "a" — "orphan" is not in the model.
+	// But there's NO Deleted entry in the ChangeSet (e.g., sync state lost).
+	m := modelWithElem("a", "container", "A")
+	ts := minimalTemplates(t)
+	cs := &ChangeSet{} // No changes — but orphan should still be cleaned up.
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	// "a" should be preserved.
+	if page.FindElement("a") == nil {
+		t.Error("element 'a' should be preserved (in model)")
+	}
+
+	// "orphan" should be removed — it's not in the model.
+	if page.FindElement("orphan") != nil {
+		t.Error("orphan element should be removed (not in model)")
+	}
+
+	if result.ElementsDeleted != 1 {
+		t.Errorf("expected 1 element deleted (orphan), got %d", result.ElementsDeleted)
+	}
+}


### PR DESCRIPTION
## Summary
- In no-views (legacy) mode, orphaned elements on draw.io pages were not cleaned up when the model was emptied or sync state was missing
- Adds `reconcileOrphanedElements` function that removes elements from the page whose `bausteinsicht_id` is not in the current model
- Called after `applyChangesToPage` in the no-views path as a safety net

## Test plan
- [x] `TestApplyForward_EmptyModelRemovesElements` — explicit deletions work
- [x] `TestApplyForward_NoViewsReconciliation` — orphaned elements cleaned up even without explicit ChangeSet entries
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)