### PR TITLE
fix: prevent duplicate connectors when sync state is missing (#119)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -497,7 +497,8 @@ func countConnectorsFor(page *drawio.Page, cellID string) int {
 	return n
 }
 
-// applyRelAdded creates a new connector on page.
+// applyRelAdded creates a new connector on page. If the connector already
+// exists (e.g., sync state was deleted), it is skipped to avoid duplicates. (#119)
 func applyRelAdded(
 	ch RelationshipChange,
 	viewID string,
@@ -505,13 +506,21 @@ func applyRelAdded(
 	templates *drawio.TemplateSet,
 	result *ForwardResult,
 ) {
+	srcRef := scopedCellID(viewID, ch.From)
+	tgtRef := scopedCellID(viewID, ch.To)
+
+	// Skip if connector already exists to prevent duplicates. (#119)
+	if page.FindConnector(srcRef, tgtRef) != nil {
+		return
+	}
+
 	style := templates.GetConnectorStyle()
 	data := drawio.ConnectorData{
 		From:      ch.From,
 		To:        ch.To,
 		Label:     ch.NewValue,
-		SourceRef: scopedCellID(viewID, ch.From),
-		TargetRef: scopedCellID(viewID, ch.To),
+		SourceRef: srcRef,
+		TargetRef: tgtRef,
 	}
 	page.CreateConnector(data, style)
 	result.ConnectorsCreated++

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -470,3 +470,51 @@ func TestApplyForward_NoViewsReconciliation(t *testing.T) {
 		t.Errorf("expected 1 element deleted (orphan), got %d", result.ElementsDeleted)
 	}
 }
+
+// TestApplyForward_NoDuplicateConnectors verifies that when a connector
+// already exists on the page, an Added relationship change does not create
+// a duplicate. This happens when sync state is deleted and all relationships
+// are treated as new. Regression test for #119.
+func TestApplyForward_NoDuplicateConnectors(t *testing.T) {
+	// Create a document with two elements and an existing connector.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "b", CellID: "b", Kind: "container", Title: "B",
+	}, "")
+	page.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "calls",
+		SourceRef: "a", TargetRef: "b",
+	}, "endArrow=block;")
+
+	// Verify precondition: one connector exists.
+	if len(page.FindAllConnectors()) != 1 {
+		t.Fatalf("precondition: expected 1 connector, got %d", len(page.FindAllConnectors()))
+	}
+
+	m := fwdModelWithRel("a", "b")
+	ts := minimalTemplates(t)
+
+	// Simulate sync state deletion: all relationships appear as Added.
+	cs := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Type: Added, NewValue: "calls"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	// Should NOT create a duplicate connector.
+	connectors := page.FindAllConnectors()
+	if len(connectors) != 1 {
+		t.Errorf("expected 1 connector (no duplicate), got %d", len(connectors))
+	}
+
+	// Should report 0 connectors created (already exists).
+	if result.ConnectorsCreated != 0 {
+		t.Errorf("expected 0 connectors created, got %d", result.ConnectorsCreated)
+	}
+}


### PR DESCRIPTION
## Summary
- `applyRelAdded` now checks `page.FindConnector()` before creating a connector
- Prevents duplicate connectors when sync state file is deleted and all relationships appear as Added
- Lightweight fix: 3 lines added to the creation path

## Test plan
- [x] `TestApplyForward_NoDuplicateConnectors` — verifies no duplicate when connector already exists
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)