### PR TITLE
fix: detect duplicate relationships in validate command (#117)

### DIFF
--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -65,6 +65,8 @@ func validateElement(m *BausteinsichtModel, path string, elem Element) []Validat
 
 func validateRelationships(m *BausteinsichtModel) []ValidationError {
 	var errs []ValidationError
+	seen := make(map[string]int) // "from->to" → first index
+
 	for i, rel := range m.Relationships {
 		path := fmt.Sprintf("relationships[%d]", i)
 
@@ -87,6 +89,17 @@ func validateRelationships(m *BausteinsichtModel) []ValidationError {
 					Message: fmt.Sprintf("unknown relationship kind %q", rel.Kind),
 				})
 			}
+		}
+
+		// Detect duplicate from/to pairs. (#117)
+		key := rel.From + "->" + rel.To
+		if firstIdx, exists := seen[key]; exists {
+			errs = append(errs, ValidationError{
+				Path:    path,
+				Message: fmt.Sprintf("duplicate relationship %s → %s (first at relationships[%d])", rel.From, rel.To, firstIdx),
+			})
+		} else {
+			seen[key] = i
 		}
 	}
 	return errs

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -157,6 +157,18 @@ func TestValidate_ViewNonExistentScope(t *testing.T) {
 	}
 }
 
+func TestValidate_DuplicateRelationship(t *testing.T) {
+	m := buildValidModel()
+	// Add a duplicate relationship (same from/to as the existing one).
+	m.Relationships = append(m.Relationships,
+		Relationship{From: "customer", To: "shop", Kind: "uses"})
+
+	errs := Validate(m)
+	if !containsMessage(errs, "duplicate") {
+		t.Errorf("expected error about duplicate relationship, got %v", errs)
+	}
+}
+
 // containsPath checks whether any error has the given path.
 func containsPath(errs []ValidationError, path string) bool {
 	for _, e := range errs {


### PR DESCRIPTION
## Summary
- `validateRelationships` now detects duplicate from/to pairs and reports errors with index references
- Previously only the `add relationship` CLI command checked for duplicates

Closes #117

## Test plan
- [x] `TestValidate_DuplicateRelationship` — duplicate from/to pair detected
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)