### PR TITLE
fix: preserve JSONC comments in add element and add relationship (#122)

### DIFF
--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -112,8 +112,8 @@ func runAddElement(cmd *cobra.Command, args []string) error {
 		m.Model[id] = elem
 	}
 
-	// Save model
-	if err := model.Save(modelPath, m); err != nil {
+	// Save model — use comment-preserving insertion. (#122)
+	if err := saveAddedElement(modelPath, m, fullID, parent, id, elem); err != nil {
 		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
 	}
 
@@ -210,6 +210,55 @@ func splitDotPath(path string) []string {
 	if current != "" {
 		result = append(result, current)
 	}
+	return result
+}
+
+// saveAddedElement saves a newly added element using comment-preserving
+// insertion. Falls back to model.Save if patching fails. (#122)
+func saveAddedElement(modelPath string, m *model.BausteinsichtModel, fullID, parent, id string, elem model.Element) error {
+	elemJSON := marshalElementJSON(elem)
+
+	// Build the object path for insertion.
+	var objectPath []string
+	if parent != "" {
+		// Insert into the parent's "children" object.
+		parts := splitDotPath(parent)
+		objectPath = append([]string{"model"}, parts...)
+		objectPath = append(objectPath, "children")
+	} else {
+		objectPath = []string{"model"}
+	}
+
+	err := model.PatchInsert(modelPath, func(data []byte) ([]byte, error) {
+		return model.InsertObjectEntry(data, objectPath, id, elemJSON)
+	})
+	if err != nil {
+		// Fall back to full save if patching fails.
+		return model.Save(modelPath, m)
+	}
+	return nil
+}
+
+// marshalElementJSON builds a compact JSON object for an element.
+func marshalElementJSON(elem model.Element) string {
+	parts := []string{fmt.Sprintf(`"kind": %q`, elem.Kind)}
+	parts = append(parts, fmt.Sprintf(`"title": %q`, elem.Title))
+	if elem.Technology != "" {
+		parts = append(parts, fmt.Sprintf(`"technology": %q`, elem.Technology))
+	}
+	if elem.Description != "" {
+		parts = append(parts, fmt.Sprintf(`"description": %q`, elem.Description))
+	}
+
+	result := "{\n"
+	for i, p := range parts {
+		result += "      " + p
+		if i < len(parts)-1 {
+			result += ","
+		}
+		result += "\n"
+	}
+	result += "    }"
 	return result
 }
 

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docToolchain/Bauteinsicht/internal/model"
@@ -21,7 +22,9 @@ func writeSampleModel(t *testing.T, dir string) string {
       "container": {"notation": "box", "container": true}
     }
   },
+  // Architecture elements
   "model": {
+    // External user
     "customer": {
       "kind": "actor",
       "title": "Customer"
@@ -395,5 +398,47 @@ func TestAddElementWithOptionalFlags(t *testing.T) {
 	}
 	if elem.Description != "Handles payments" {
 		t.Errorf("expected description 'Handles payments', got %q", elem.Description)
+	}
+}
+
+// TestAddElementPreservesComments verifies that adding an element does not
+// strip JSONC comments from the model file. Regression test for #122.
+func TestAddElementPreservesComments(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "payments",
+		"--kind", "system",
+		"--title", "Payment Service",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read raw file — comments should be preserved.
+	data, err := os.ReadFile(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "// Architecture elements") {
+		t.Error("comment '// Architecture elements' was stripped")
+	}
+	if !strings.Contains(content, "// External user") {
+		t.Error("comment '// External user' was stripped")
+	}
+
+	// Model should still be parseable and contain the new element.
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatalf("model not parseable after add: %v", err)
+	}
+	if _, ok := m.Model["payments"]; !ok {
+		t.Error("new element 'payments' not found in model")
 	}
 }

--- a/cmd/bausteinsicht/add_relationship.go
+++ b/cmd/bausteinsicht/add_relationship.go
@@ -82,8 +82,16 @@ func runAddRelationship(cmd *cobra.Command, args []string) error {
 	}
 	m.Relationships = append(m.Relationships, rel)
 
-	if err := model.Save(modelPath, m); err != nil {
-		return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+	// Save using comment-preserving array append. (#122)
+	relJSON := marshalRelationshipJSON(rel)
+	err = model.PatchInsert(modelPath, func(data []byte) ([]byte, error) {
+		return model.AppendArrayEntry(data, []string{"relationships"}, relJSON)
+	})
+	if err != nil {
+		// Fall back to full save if patching fails.
+		if err := model.Save(modelPath, m); err != nil {
+			return exitWithCode(fmt.Errorf("saving model: %w", err), 2)
+		}
 	}
 
 	if format == "json" {
@@ -91,6 +99,34 @@ func runAddRelationship(cmd *cobra.Command, args []string) error {
 	}
 	printRelationshipText(rel)
 	return nil
+}
+
+// marshalRelationshipJSON builds a compact JSON object for a relationship.
+func marshalRelationshipJSON(rel model.Relationship) string {
+	parts := []string{
+		fmt.Sprintf(`"from": %q`, rel.From),
+		fmt.Sprintf(`"to": %q`, rel.To),
+	}
+	if rel.Label != "" {
+		parts = append(parts, fmt.Sprintf(`"label": %q`, rel.Label))
+	}
+	if rel.Kind != "" {
+		parts = append(parts, fmt.Sprintf(`"kind": %q`, rel.Kind))
+	}
+	if rel.Description != "" {
+		parts = append(parts, fmt.Sprintf(`"description": %q`, rel.Description))
+	}
+
+	result := "{\n"
+	for i, p := range parts {
+		result += "      " + p
+		if i < len(parts)-1 {
+			result += ","
+		}
+		result += "\n"
+	}
+	result += "    }"
+	return result
 }
 
 func printRelationshipText(r model.Relationship) {

--- a/internal/model/patch.go
+++ b/internal/model/patch.go
@@ -50,6 +50,42 @@ func PatchSave(path string, ops []PatchOp) error {
 	return nil
 }
 
+// PatchInsert reads the JSONC file at path, applies a raw data transformation,
+// and writes the result back atomically. Used by InsertObjectEntry and
+// AppendArrayEntry for comment-preserving insertions.
+func PatchInsert(path string, transform func([]byte) ([]byte, error)) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	data, err = transform(data)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".model-tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("renaming temp file: %w", err)
+	}
+	return nil
+}
+
 // PatchValue finds the JSON value at path in JSONC data and replaces it with
 // newValue. The rest of the document (comments, whitespace, key ordering)
 // is preserved. Returns the patched data or an error if the path is not found.
@@ -236,6 +272,111 @@ func skipBraced(data []byte, i, n int, open, close byte) int {
 		i++
 	}
 	return i
+}
+
+// InsertObjectEntry inserts a new key-value pair into the object at the given
+// path. The value is inserted before the closing '}' of the target object.
+// Comments and formatting are preserved.
+func InsertObjectEntry(data []byte, objectPath []string, key, valueJSON string) ([]byte, error) {
+	// Find the object's value range.
+	start, end, err := findValueRange(data, objectPath)
+	if err != nil {
+		return nil, err
+	}
+	if data[start] != '{' {
+		return nil, fmt.Errorf("value at path %v is not an object", objectPath)
+	}
+
+	// Find the closing '}' of this object (end-1 since findValueRange returns after it).
+	closeBrace := end - 1
+	for closeBrace > start && data[closeBrace] != '}' {
+		closeBrace--
+	}
+
+	// Detect indentation from the closing brace line.
+	indent := detectIndent(data, closeBrace)
+
+	// Check if the object has existing entries by scanning for non-whitespace
+	// between '{' and '}'.
+	hasEntries := false
+	scan := start + 1
+	scan = skipWhitespaceAndComments(data, scan, len(data))
+	if scan < closeBrace {
+		hasEntries = true
+	}
+
+	// Build the insertion text.
+	var insertion string
+	if hasEntries {
+		insertion = fmt.Sprintf(",\n%s  %q: %s", indent, key, valueJSON)
+	} else {
+		insertion = fmt.Sprintf("\n%s  %q: %s\n%s", indent, key, valueJSON, indent)
+	}
+
+	result := make([]byte, 0, len(data)+len(insertion))
+	result = append(result, data[:closeBrace]...)
+	result = append(result, []byte(insertion)...)
+	result = append(result, data[closeBrace:]...)
+	return result, nil
+}
+
+// AppendArrayEntry appends a new value to the array at the given path.
+// The value is inserted before the closing ']'. Comments and formatting
+// are preserved.
+func AppendArrayEntry(data []byte, arrayPath []string, valueJSON string) ([]byte, error) {
+	start, end, err := findValueRange(data, arrayPath)
+	if err != nil {
+		return nil, err
+	}
+	if data[start] != '[' {
+		return nil, fmt.Errorf("value at path %v is not an array", arrayPath)
+	}
+
+	// Find the closing ']'.
+	closeBracket := end - 1
+	for closeBracket > start && data[closeBracket] != ']' {
+		closeBracket--
+	}
+
+	indent := detectIndent(data, closeBracket)
+
+	// Check if the array has existing entries.
+	hasEntries := false
+	scan := start + 1
+	scan = skipWhitespaceAndComments(data, scan, len(data))
+	if scan < closeBracket {
+		hasEntries = true
+	}
+
+	var insertion string
+	if hasEntries {
+		insertion = fmt.Sprintf(",\n%s  %s", indent, valueJSON)
+	} else {
+		insertion = fmt.Sprintf("\n%s  %s\n%s", indent, valueJSON, indent)
+	}
+
+	result := make([]byte, 0, len(data)+len(insertion))
+	result = append(result, data[:closeBracket]...)
+	result = append(result, []byte(insertion)...)
+	result = append(result, data[closeBracket:]...)
+	return result, nil
+}
+
+// detectIndent returns the whitespace prefix of the line containing position pos.
+func detectIndent(data []byte, pos int) string {
+	lineStart := pos
+	for lineStart > 0 && data[lineStart-1] != '\n' {
+		lineStart--
+	}
+	indent := ""
+	for i := lineStart; i < pos; i++ {
+		if data[i] == ' ' || data[i] == '\t' {
+			indent += string(data[i])
+		} else {
+			break
+		}
+	}
+	return indent
 }
 
 // skipToChar advances to the first occurrence of ch, skipping strings and comments.

--- a/internal/model/patch_test.go
+++ b/internal/model/patch_test.go
@@ -163,3 +163,80 @@ func TestPatchSave_PreservesCommentsAndOrder(t *testing.T) {
 		t.Errorf("expected technology Rust, got %s", m.Model["mySystem"].Technology)
 	}
 }
+
+func TestInsertObjectEntry_PreservesComments(t *testing.T) {
+	input := `{
+  // Architecture model
+  "model": {
+    // External actor
+    "customer": {
+      "kind": "actor",
+      "title": "Customer"
+    }
+  }
+}`
+	newEntry := `{
+      "kind": "system",
+      "title": "New System"
+    }`
+	got, err := InsertObjectEntry([]byte(input), []string{"model"}, "newsystem", newEntry)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := string(got)
+
+	// Comments preserved.
+	if !strings.Contains(result, "// Architecture model") {
+		t.Error("top-level comment was stripped")
+	}
+	if !strings.Contains(result, "// External actor") {
+		t.Error("inline comment was stripped")
+	}
+	// New entry present.
+	if !strings.Contains(result, `"newsystem"`) {
+		t.Error("new entry key not found")
+	}
+	if !strings.Contains(result, `"New System"`) {
+		t.Error("new entry value not found")
+	}
+	// Original entry still present.
+	if !strings.Contains(result, `"customer"`) {
+		t.Error("existing entry removed")
+	}
+}
+
+func TestAppendArrayEntry_PreservesComments(t *testing.T) {
+	input := `{
+  // Relationships
+  "relationships": [
+    {
+      "from": "a",
+      "to": "b",
+      "label": "calls"
+    }
+  ]
+}`
+	newItem := `{
+      "from": "c",
+      "to": "d",
+      "label": "uses"
+    }`
+	got, err := AppendArrayEntry([]byte(input), []string{"relationships"}, newItem)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := string(got)
+
+	// Comment preserved.
+	if !strings.Contains(result, "// Relationships") {
+		t.Error("comment was stripped")
+	}
+	// Original entry present.
+	if !strings.Contains(result, `"from": "a"`) {
+		t.Error("existing entry removed")
+	}
+	// New entry present.
+	if !strings.Contains(result, `"from": "c"`) {
+		t.Error("new entry not found")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `InsertObjectEntry` and `AppendArrayEntry` functions to `model/patch.go` for comment-preserving JSONC insertion
- `add element` and `add relationship` commands now use text-based insertion instead of full JSON re-marshal
- Falls back to `model.Save()` if text-based insertion fails

Closes #122

## Test plan
- [x] `TestInsertObjectEntry_PreservesComments` — object insertion preserves comments
- [x] `TestAppendArrayEntry_PreservesComments` — array append preserves comments
- [x] `TestAddElementPreservesComments` — integration test: add element keeps JSONC comments
- [x] All existing add element/relationship tests pass
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)