### PR TITLE
fix: validate element IDs and reject empty titles (#123, #124)

### DIFF
--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -3,10 +3,20 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/docToolchain/Bauteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
+
+// validIDPattern matches element IDs: letters, digits, hyphens, underscores.
+// Dots are NOT allowed since they serve as hierarchy separators.
+var validIDPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// isValidID checks if the given ID is a valid element identifier.
+func isValidID(id string) bool {
+	return validIDPattern.MatchString(id)
+}
 
 func newAddElementCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -39,6 +49,19 @@ func runAddElement(cmd *cobra.Command, args []string) error {
 
 	modelPath, _ := cmd.Flags().GetString("model")
 	format, _ := cmd.Flags().GetString("format")
+
+	// Validate ID format. (#123)
+	if !isValidID(id) {
+		return exitWithCode(
+			fmt.Errorf("invalid element ID %q: must contain only letters, digits, hyphens, or underscores", id),
+			1,
+		)
+	}
+
+	// Validate title is not empty. (#124)
+	if title == "" {
+		return exitWithCode(fmt.Errorf("title must not be empty"), 1)
+	}
 
 	// Load model
 	if modelPath == "" {

--- a/cmd/bausteinsicht/add_element_test.go
+++ b/cmd/bausteinsicht/add_element_test.go
@@ -442,3 +442,84 @@ func TestAddElementPreservesComments(t *testing.T) {
 		t.Error("new element 'payments' not found in model")
 	}
 }
+
+// TestAddElementInvalidIDs verifies that IDs with dots, spaces, or special
+// characters are rejected. Regression test for #123.
+func TestAddElementInvalidIDs(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	invalidIDs := []string{
+		"foo.bar",    // dot (hierarchy separator)
+		"foo bar",    // space
+		"foo@bar",    // special char
+		"foo/bar",    // slash
+		"",           // empty
+		"123invalid", // starts with digit
+	}
+
+	for _, id := range invalidIDs {
+		t.Run(id, func(t *testing.T) {
+			cmd := NewRootCmd()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"add", "element",
+				"--model", modelPath,
+				"--id", id,
+				"--kind", "system",
+				"--title", "Test",
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Errorf("expected error for invalid ID %q", id)
+			}
+		})
+	}
+}
+
+// TestAddElementEmptyTitle verifies that empty title is rejected.
+// Regression test for #124.
+func TestAddElementEmptyTitle(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeSampleModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"add", "element",
+		"--model", modelPath,
+		"--id", "test",
+		"--kind", "system",
+		"--title", "",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for empty title")
+	}
+}
+
+// TestAddElementValidIDs verifies that valid IDs are accepted.
+func TestAddElementValidIDs(t *testing.T) {
+	validIDs := []string{"api", "my-service", "my_service", "API", "a1"}
+
+	for _, id := range validIDs {
+		t.Run(id, func(t *testing.T) {
+			dir := t.TempDir()
+			modelPath := writeSampleModel(t, dir)
+
+			cmd := NewRootCmd()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"add", "element",
+				"--model", modelPath,
+				"--id", id,
+				"--kind", "system",
+				"--title", "Test",
+			})
+			err := cmd.Execute()
+			if err != nil {
+				t.Errorf("unexpected error for valid ID %q: %v", id, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Element IDs must match `^[a-zA-Z][a-zA-Z0-9_-]*$` — dots, spaces, special chars rejected
- Empty titles rejected at CLI level before model load
- Both validations happen early with clear error messages

Closes #123
Closes #124

## Test plan
- [x] `TestAddElementInvalidIDs` — dots, spaces, special chars, empty, digit-start rejected
- [x] `TestAddElementEmptyTitle` — empty title rejected
- [x] `TestAddElementValidIDs` — normal IDs accepted
- [x] Full test suite passes with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)