### PR TITLE
fix: remove double WARNING prefix from conflict resolution (#116)

### DIFF
--- a/internal/sync/conflict.go
+++ b/internal/sync/conflict.go
@@ -37,7 +37,7 @@ func (r *ModelWinsResolver) Resolve(conflicts []Conflict) []ResolvedConflict {
 	resolved := make([]ResolvedConflict, 0, len(conflicts))
 	for _, c := range conflicts {
 		warning := fmt.Sprintf(
-			"WARNING: Conflict detected for element %q:\n"+
+			"Conflict detected for element %q:\n"+
 				"  Field: %s\n"+
 				"  Model value:   %q\n"+
 				"  draw.io value: %q\n"+

--- a/internal/sync/conflict_test.go
+++ b/internal/sync/conflict_test.go
@@ -85,6 +85,27 @@ func TestModelWinsResolver_WarningFormat(t *testing.T) {
 	}
 }
 
+func TestModelWinsResolver_NoDoubleWarningPrefix(t *testing.T) {
+	r := NewModelWinsResolver()
+	conflicts := []Conflict{
+		{
+			ElementID:     "svc",
+			Field:         "title",
+			ModelValue:    "A",
+			DrawioValue:   "B",
+			LastSyncValue: "A",
+		},
+	}
+	result := r.Resolve(conflicts)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+	w := result[0].Warning
+	if strings.HasPrefix(w, "WARNING:") {
+		t.Errorf("warning should not start with 'WARNING:' (caller adds prefix), got:\n%s", w)
+	}
+}
+
 func TestConflictResolverInterface(t *testing.T) {
 	// Ensure ModelWinsResolver satisfies the ConflictResolver interface.
 	var _ ConflictResolver = NewModelWinsResolver()


### PR DESCRIPTION
## Summary
- Removed duplicate `WARNING:` prefix from `conflict.go` format string — callers already add the prefix when printing warnings

Closes #116

## Test plan
- [x] Added `TestModelWinsResolver_NoDoubleWarningPrefix` asserting warning text does not start with `WARNING:`
- [x] All existing sync tests pass
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)