### PR TITLE
fix: render self-referencing relationships in draw.io (#111)

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -279,7 +279,7 @@ func applyChangesToPage(
 				if elemFilter != nil {
 					from = liftEndpoint(from, elemFilter)
 					to = liftEndpoint(to, elemFilter)
-					if from == "" || to == "" || from == to {
+					if from == "" || to == "" || (from == to && (from != ch.From || to != ch.To)) {
 						continue
 					}
 				}

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -518,3 +518,39 @@ func TestApplyForward_NoDuplicateConnectors(t *testing.T) {
 		t.Errorf("expected 0 connectors created, got %d", result.ConnectorsCreated)
 	}
 }
+
+// TestApplyForward_SelfReferencingRelationship verifies that a relationship
+// where From == To (self-referencing) creates a connector. The condition
+// that skips from == to after liftEndpoint should not skip genuine
+// self-references. Regression test for #111.
+func TestApplyForward_SelfReferencingRelationship(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-default", "Default")
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API"},
+		},
+		Relationships: []model.Relationship{
+			{From: "api", To: "api", Label: "calls self"},
+		},
+		Views: map[string]model.View{
+			"default": {Title: "Default", Include: []string{"*"}},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "api", To: "api", Type: Added, NewValue: "calls self"},
+		},
+		ModelElementChanges: []ElementChange{
+			{ID: "api", Type: Added},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ConnectorsCreated < 1 {
+		t.Errorf("expected at least 1 connector for self-referencing relationship, got %d", result.ConnectorsCreated)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed condition in `forward.go` that incorrectly skipped genuine self-referencing relationships (`from == to`)
- Now only skips `from == to` when the relationship was actually lifted (endpoints changed by `liftEndpoint`)

Closes #111

## Test plan
- [x] Added `TestApplyForward_SelfReferencingRelationship` verifying a self-ref connector is created
- [x] All existing sync tests pass
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)