### PR TITLE
fix: clean view include/exclude arrays on element deletion (#114)

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -61,6 +61,12 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *R
 			return
 		}
 		result.ElementsDeleted++
+		// Clean stale references from view include/exclude lists.
+		for viewID, v := range m.Views {
+			v.Include = removeFromSlice(v.Include, ch.ID)
+			v.Exclude = removeFromSlice(v.Exclude, ch.ID)
+			m.Views[viewID] = v
+		}
 		result.Warnings = append(result.Warnings,
 			fmt.Sprintf("Element %q was deleted in draw.io and removed from model", ch.ID))
 
@@ -180,4 +186,18 @@ func deleteFromMap(elems map[string]model.Element, parts []string, fullID string
 	}
 	elems[key] = elem
 	return nil
+}
+
+// removeFromSlice returns a new slice with all occurrences of val removed.
+func removeFromSlice(s []string, val string) []string {
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if v != val {
+			result = append(result, v)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -199,6 +199,48 @@ func TestApplyReverse_RelationshipDeleted(t *testing.T) {
 	}
 }
 
+func TestApplyReverse_DeleteElementCleansViewIncludes(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api":    {Kind: "container", Title: "API"},
+			"webapp": {Kind: "container", Title: "WebApp"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"overview": {
+				Title:   "Overview",
+				Include: []string{"api", "webapp"},
+				Exclude: []string{"api"},
+			},
+		},
+	}
+
+	cs := elemChangeSet("api", Deleted, "", "", "")
+	ApplyReverse(cs, m)
+
+	v := m.Views["overview"]
+	for _, inc := range v.Include {
+		if inc == "api" {
+			t.Error("deleted element 'api' should be removed from view Include")
+		}
+	}
+	for _, exc := range v.Exclude {
+		if exc == "api" {
+			t.Error("deleted element 'api' should be removed from view Exclude")
+		}
+	}
+	// "webapp" should remain
+	found := false
+	for _, inc := range v.Include {
+		if inc == "webapp" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'webapp' to remain in Include")
+	}
+}
+
 func TestApplyReverse_RelationshipAdded(t *testing.T) {
 	m := emptyModel()
 	cs := relChangeSet("x", "y", Added, "", "", "uses")


### PR DESCRIPTION
## Summary
- After deleting an element in reverse sync, stale references are now removed from all views' `include` and `exclude` arrays
- Added `removeFromSlice` helper that returns nil for empty results (matching `omitempty` JSON behavior)

Closes #114

## Test plan
- [x] Added `TestApplyReverse_DeleteElementCleansViewIncludes` verifying cleanup of both Include and Exclude
- [x] All existing sync tests pass
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)