### PR TITLE
fix: support JSONC block comments in parser and patcher (#121)

### DIFF
--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -91,6 +91,27 @@ func StripJSONC(data []byte) []byte {
 			}
 			continue
 		}
+		// Handle block comments
+		if i+1 < len(src) && src[i] == '/' && src[i+1] == '*' {
+			// Trim trailing whitespace before comment if it's only
+			// whitespace since the last newline (i.e., comment on its own line).
+			s := sb.String()
+			lastNL := strings.LastIndex(s, "\n")
+			linePrefix := s[lastNL+1:]
+			if strings.TrimRight(linePrefix, " \t") == "" {
+				sb.Reset()
+				sb.WriteString(s[:lastNL+1])
+			}
+			i += 2
+			for i+1 < len(src) {
+				if src[i] == '*' && src[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
 		// Handle single-line comments
 		if i+1 < len(src) && src[i] == '/' && src[i+1] == '/' {
 			// Trim trailing whitespace written before the comment

--- a/internal/model/loader_test.go
+++ b/internal/model/loader_test.go
@@ -142,6 +142,55 @@ func TestStripJSONC_PreservesCommentInString(t *testing.T) {
 	}
 }
 
+func TestStripJSONC_RemovesBlockComments(t *testing.T) {
+	input := []byte(`{
+  /* this is a block comment */
+  "key": "value"
+}`)
+	out := StripJSONC(input)
+	expected := `{
+
+  "key": "value"
+}`
+	if string(out) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(out))
+	}
+}
+
+func TestStripJSONC_RemovesInlineBlockComment(t *testing.T) {
+	input := []byte(`{"key": /* comment */ "value"}`)
+	out := StripJSONC(input)
+	expected := `{"key":  "value"}`
+	if string(out) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(out))
+	}
+}
+
+func TestStripJSONC_PreservesBlockCommentInString(t *testing.T) {
+	input := []byte(`{"key": "value /* not a comment */"}`)
+	out := StripJSONC(input)
+	if string(out) != `{"key": "value /* not a comment */"}` {
+		t.Errorf("block comment inside string should not be stripped, got: %s", string(out))
+	}
+}
+
+func TestStripJSONC_MultilineBlockComment(t *testing.T) {
+	input := []byte(`{
+  /* multi
+     line
+     comment */
+  "key": "value"
+}`)
+	out := StripJSONC(input)
+	expected := `{
+
+  "key": "value"
+}`
+	if string(out) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(out))
+	}
+}
+
 func TestStripJSONC_RemovesTrailingCommas(t *testing.T) {
 	input := []byte(`{"a": 1, "b": 2,}`)
 	out := StripJSONC(input)

--- a/internal/model/patch.go
+++ b/internal/model/patch.go
@@ -193,6 +193,17 @@ func skipWhitespaceAndComments(data []byte, i, n int) int {
 			}
 			continue
 		}
+		if i+1 < n && data[i] == '/' && data[i+1] == '*' {
+			i += 2
+			for i+1 < n {
+				if data[i] == '*' && data[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
 		break
 	}
 	return i
@@ -234,8 +245,8 @@ func skipValue(data []byte, i, n int) int {
 			if c == ',' || c == '}' || c == ']' || c == ' ' || c == '\t' || c == '\n' || c == '\r' {
 				break
 			}
-			// Also stop at // comment.
-			if c == '/' && i+1 < n && data[i+1] == '/' {
+			// Also stop at // or /* comment.
+			if c == '/' && i+1 < n && (data[i+1] == '/' || data[i+1] == '*') {
 				break
 			}
 			i++
@@ -256,6 +267,17 @@ func skipBraced(data []byte, i, n int, open, close byte) int {
 		}
 		if c == '/' && i+1 < n && data[i+1] == '/' {
 			for i < n && data[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		if c == '/' && i+1 < n && data[i+1] == '*' {
+			i += 2
+			for i+1 < n {
+				if data[i] == '*' && data[i+1] == '/' {
+					i += 2
+					break
+				}
 				i++
 			}
 			continue
@@ -388,6 +410,17 @@ func skipToChar(data []byte, i, n int, ch byte) int {
 		}
 		if data[i] == '/' && i+1 < n && data[i+1] == '/' {
 			for i < n && data[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		if data[i] == '/' && i+1 < n && data[i+1] == '*' {
+			i += 2
+			for i+1 < n {
+				if data[i] == '*' && data[i+1] == '/' {
+					i += 2
+					break
+				}
 				i++
 			}
 			continue

--- a/internal/model/patch_test.go
+++ b/internal/model/patch_test.go
@@ -240,3 +240,22 @@ func TestAppendArrayEntry_PreservesComments(t *testing.T) {
 		t.Error("new entry not found")
 	}
 }
+
+func TestPatchValue_WithBlockComments(t *testing.T) {
+	input := `{
+  /* block comment */
+  "name": "old",
+  "age": 42
+}`
+	got, err := PatchValue([]byte(input), []string{"name"}, `"new"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), `"name": "new"`) {
+		t.Errorf("expected name to be patched, got:\n%s", got)
+	}
+	// Block comment should be preserved
+	if !strings.Contains(string(got), "/* block comment */") {
+		t.Errorf("expected block comment to be preserved, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Extended `StripJSONC` in `loader.go` to handle `/* ... */` block comments (single-line and multi-line)
- Extended `skipWhitespaceAndComments` and related functions in `patch.go` to skip block comments
- Block comment syntax inside JSON strings is correctly preserved

Closes #121

## Test plan
- [x] Added `TestStripJSONC_RemovesBlockComments`, `TestStripJSONC_RemovesInlineBlockComment`, `TestStripJSONC_PreservesBlockCommentInString`, `TestStripJSONC_MultilineBlockComment`
- [x] Added `TestPatchValue_WithBlockComments`
- [x] All existing model tests pass
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)