### PR TITLE
fix: validate drawio document structure to prevent data loss (#140)

### DIFF
--- a/internal/drawio/document.go
+++ b/internal/drawio/document.go
@@ -20,11 +20,34 @@ type Page struct {
 }
 
 // LoadDocument parses a draw.io XML file from disk.
+// It validates the document structure to prevent data loss from corrupt files.
 func LoadDocument(path string) (*Document, error) {
 	tree := etree.NewDocument()
 	if err := tree.ReadFromFile(path); err != nil {
 		return nil, fmt.Errorf("LoadDocument %q: %w", path, err)
 	}
+
+	// Validate document structure to prevent data loss from corrupt files.
+	root := tree.Root()
+	if root == nil || root.Tag != "mxfile" {
+		return nil, fmt.Errorf("LoadDocument %q: not a valid draw.io file (missing <mxfile> root)", path)
+	}
+	diagrams := root.SelectElements("diagram")
+	if len(diagrams) == 0 {
+		return nil, fmt.Errorf("LoadDocument %q: not a valid draw.io file (no <diagram> elements)", path)
+	}
+	for _, d := range diagrams {
+		model := d.FindElement("mxGraphModel")
+		if model == nil {
+			return nil, fmt.Errorf("LoadDocument %q: diagram %q missing <mxGraphModel>",
+				path, d.SelectAttrValue("id", "?"))
+		}
+		if model.FindElement("root") == nil {
+			return nil, fmt.Errorf("LoadDocument %q: diagram %q missing <root> element",
+				path, d.SelectAttrValue("id", "?"))
+		}
+	}
+
 	return &Document{tree: tree}, nil
 }
 

--- a/internal/drawio/document_test.go
+++ b/internal/drawio/document_test.go
@@ -107,6 +107,50 @@ func TestAddPage_BaseCells(t *testing.T) {
 	}
 }
 
+func TestLoadDocument_RejectsCorruptContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.drawio")
+	os.WriteFile(path, []byte("THIS IS NOT XML"), 0644)
+	_, err := drawio.LoadDocument(path)
+	if err == nil {
+		t.Fatal("expected error for corrupt drawio content")
+	}
+}
+
+func TestLoadDocument_RejectsEmptyMxfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.drawio")
+	os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile></mxfile>`), 0644)
+	_, err := drawio.LoadDocument(path)
+	if err == nil {
+		t.Fatal("expected error for mxfile with no diagrams")
+	}
+}
+
+func TestLoadDocument_RejectsMissingRoot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.drawio")
+	os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile><diagram id="d1" name="Page"><mxGraphModel></mxGraphModel></diagram></mxfile>`), 0644)
+	_, err := drawio.LoadDocument(path)
+	if err == nil {
+		t.Fatal("expected error for diagram missing root element")
+	}
+}
+
+func TestLoadDocument_AcceptsValidDocument(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.drawio")
+	xml := `<?xml version="1.0"?><mxfile><diagram id="d1" name="Page"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`
+	os.WriteFile(path, []byte(xml), 0644)
+	doc, err := drawio.LoadDocument(path)
+	if err != nil {
+		t.Fatalf("expected valid document, got error: %v", err)
+	}
+	if len(doc.Pages()) != 1 {
+		t.Errorf("expected 1 page, got %d", len(doc.Pages()))
+	}
+}
+
 func TestSaveDocument_Atomic(t *testing.T) {
 	doc := drawio.NewDocument()
 	doc.AddPage("p1", "Page 1")

--- a/internal/drawio/document_test.go
+++ b/internal/drawio/document_test.go
@@ -110,7 +110,9 @@ func TestAddPage_BaseCells(t *testing.T) {
 func TestLoadDocument_RejectsCorruptContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.drawio")
-	os.WriteFile(path, []byte("THIS IS NOT XML"), 0644)
+	if err := os.WriteFile(path, []byte("THIS IS NOT XML"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	_, err := drawio.LoadDocument(path)
 	if err == nil {
 		t.Fatal("expected error for corrupt drawio content")
@@ -120,7 +122,9 @@ func TestLoadDocument_RejectsCorruptContent(t *testing.T) {
 func TestLoadDocument_RejectsEmptyMxfile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.drawio")
-	os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile></mxfile>`), 0644)
+	if err := os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile></mxfile>`), 0644); err != nil {
+		t.Fatal(err)
+	}
 	_, err := drawio.LoadDocument(path)
 	if err == nil {
 		t.Fatal("expected error for mxfile with no diagrams")
@@ -130,7 +134,9 @@ func TestLoadDocument_RejectsEmptyMxfile(t *testing.T) {
 func TestLoadDocument_RejectsMissingRoot(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.drawio")
-	os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile><diagram id="d1" name="Page"><mxGraphModel></mxGraphModel></diagram></mxfile>`), 0644)
+	if err := os.WriteFile(path, []byte(`<?xml version="1.0"?><mxfile><diagram id="d1" name="Page"><mxGraphModel></mxGraphModel></diagram></mxfile>`), 0644); err != nil {
+		t.Fatal(err)
+	}
 	_, err := drawio.LoadDocument(path)
 	if err == nil {
 		t.Fatal("expected error for diagram missing root element")
@@ -141,7 +147,9 @@ func TestLoadDocument_AcceptsValidDocument(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.drawio")
 	xml := `<?xml version="1.0"?><mxfile><diagram id="d1" name="Page"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`
-	os.WriteFile(path, []byte(xml), 0644)
+	if err := os.WriteFile(path, []byte(xml), 0644); err != nil {
+		t.Fatal(err)
+	}
 	doc, err := drawio.LoadDocument(path)
 	if err != nil {
 		t.Fatalf("expected valid document, got error: %v", err)


### PR DESCRIPTION
## Summary
- Added structural validation in `LoadDocument()` that rejects corrupt draw.io files before sync can misinterpret empty content as "all elements deleted"
- Validates: `<mxfile>` root, at least one `<diagram>`, `<mxGraphModel>` and `<root>` per diagram

Closes #140

## Test plan
- [x] `TestLoadDocument_RejectsCorruptContent` — non-XML content rejected
- [x] `TestLoadDocument_RejectsEmptyMxfile` — no diagrams rejected
- [x] `TestLoadDocument_RejectsMissingRoot` — missing root rejected
- [x] `TestLoadDocument_AcceptsValidDocument` — valid files accepted
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)