### PR TITLE
fix: strip UTF-8 BOM from JSONC model files (#147)

### DIFF
--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -67,6 +67,11 @@ func AutoDetect(dir string) (string, error) {
 // StripJSONC removes single-line comments and trailing commas from JSONC data.
 // Comments inside strings are preserved.
 func StripJSONC(data []byte) []byte {
+	// Strip UTF-8 BOM if present.
+	if len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF {
+		data = data[3:]
+	}
+
 	var sb strings.Builder
 	src := string(data)
 	i := 0

--- a/internal/model/loader_test.go
+++ b/internal/model/loader_test.go
@@ -208,3 +208,37 @@ func TestStripJSONC_RemovesTrailingCommaBeforeArrayEnd(t *testing.T) {
 		t.Errorf("expected trailing comma in array removed, got: %s", string(out))
 	}
 }
+
+func TestStripJSONC_StripsBOM(t *testing.T) {
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	input := append(bom, []byte(`{"key": "value"}`)...)
+	out := StripJSONC(input)
+	expected := `{"key": "value"}`
+	if string(out) != expected {
+		t.Errorf("expected BOM stripped, got: %q", string(out))
+	}
+}
+
+func TestLoad_ModelWithBOM(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.jsonc")
+
+	// Read a valid model, prepend BOM, write it out
+	original, err := os.ReadFile("testdata/minimal-model.jsonc")
+	if err != nil {
+		t.Fatalf("failed to read testdata: %v", err)
+	}
+	bom := []byte{0xEF, 0xBB, 0xBF}
+	withBOM := append(bom, original...)
+	if err := os.WriteFile(path, withBOM, 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	m, err := Load(path)
+	if err != nil {
+		t.Fatalf("expected no error for BOM file, got: %v", err)
+	}
+	if len(m.Model) == 0 {
+		t.Error("expected non-empty model")
+	}
+}


### PR DESCRIPTION
## Summary
- Strip 3-byte UTF-8 BOM (`0xEF 0xBB 0xBF`) at start of `StripJSONC` before any processing
- Windows editors like Notepad add BOM by default, causing cryptic parse errors

Closes #147

## Test plan
- [x] `TestStripJSONC_StripsBOM` — BOM stripped from raw input
- [x] `TestLoad_ModelWithBOM` — full model with BOM loads successfully
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)