### PR TITLE
fix: reject empty and whitespace-only element IDs in validate (#146)

### DIFF
--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -27,6 +27,9 @@ func Validate(m *BausteinsichtModel) []ValidationError {
 func validateElements(m *BausteinsichtModel) []ValidationError {
 	var errs []ValidationError
 	for id, elem := range m.Model {
+		if err := validateElementID(id); err != nil {
+			errs = append(errs, ValidationError{Path: "model." + id, Message: err.Error()})
+		}
 		errs = append(errs, validateElement(m, "model."+id, elem)...)
 	}
 	return errs
@@ -57,6 +60,9 @@ func validateElement(m *BausteinsichtModel, path string, elem Element) []Validat
 	}
 
 	for childID, child := range elem.Children {
+		if err := validateElementID(childID); err != nil {
+			errs = append(errs, ValidationError{Path: path + "." + childID, Message: err.Error()})
+		}
 		errs = append(errs, validateElement(m, path+"."+childID, child)...)
 	}
 
@@ -122,6 +128,14 @@ func validateViews(m *BausteinsichtModel) []ValidationError {
 		}
 	}
 	return errs
+}
+
+// validateElementID checks that an element ID is valid.
+func validateElementID(id string) error {
+	if strings.TrimSpace(id) == "" {
+		return fmt.Errorf("invalid element ID %q: must not be empty or whitespace", id)
+	}
+	return nil
 }
 
 // lookupElement resolves a dot-notation path to an Element within the model.

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -166,6 +167,76 @@ func TestValidate_DuplicateRelationship(t *testing.T) {
 	errs := Validate(m)
 	if !containsMessage(errs, "duplicate") {
 		t.Errorf("expected error about duplicate relationship, got %v", errs)
+	}
+}
+
+func TestValidate_EmptyElementID(t *testing.T) {
+	m := &BausteinsichtModel{
+		Specification: Specification{
+			Elements: map[string]ElementKind{"system": {Notation: "System"}},
+		},
+		Model: map[string]Element{
+			"": {Kind: "system", Title: "Empty ID"},
+		},
+	}
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected validation error for empty element ID")
+	}
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "invalid element ID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'invalid element ID' error, got: %v", errs)
+	}
+}
+
+func TestValidate_WhitespaceElementID(t *testing.T) {
+	m := &BausteinsichtModel{
+		Specification: Specification{
+			Elements: map[string]ElementKind{"system": {Notation: "System"}},
+		},
+		Model: map[string]Element{
+			" ": {Kind: "system", Title: "Whitespace"},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "invalid element ID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'invalid element ID' error for whitespace-only ID, got: %v", errs)
+	}
+}
+
+func TestValidate_EmptyChildID(t *testing.T) {
+	m := &BausteinsichtModel{
+		Specification: Specification{
+			Elements: map[string]ElementKind{
+				"system": {Notation: "System", Container: true},
+			},
+		},
+		Model: map[string]Element{
+			"parent": {Kind: "system", Title: "Parent", Children: map[string]Element{
+				"": {Kind: "system", Title: "Empty Child"},
+			}},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "invalid element ID") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'invalid element ID' error for empty child ID, got: %v", errs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Added `validateElementID()` check in `validateElements()` and `validateElement()` (for children)
- Catches empty `""` and whitespace-only `" "` element IDs that bypass `add element` validation
- Uses simple empty/whitespace check (not strict regex) to avoid breaking existing models

Closes #146

## Test plan
- [x] `TestValidate_EmptyElementID` — empty string key rejected
- [x] `TestValidate_WhitespaceElementID` — whitespace-only key rejected
- [x] `TestValidate_EmptyChildID` — empty child key rejected
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)