### PR TITLE
fix: reject empty title updates from draw.io during reverse sync (#150)

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -36,6 +36,12 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResul
 func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
+		// Reject empty title updates from draw.io (#150).
+		if ch.Field == "title" && strings.TrimSpace(ch.NewValue) == "" {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Element %q: ignoring empty title from draw.io", ch.ID))
+			return
+		}
 		err := modifyElement(m, ch.ID, func(e *model.Element) {
 			switch ch.Field {
 			case "title":

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -241,6 +241,35 @@ func TestApplyReverse_DeleteElementCleansViewIncludes(t *testing.T) {
 	}
 }
 
+func TestApplyReverse_EmptyTitleSkipped(t *testing.T) {
+	m := simpleModel("api", "Original Title", "", "")
+	cs := elemChangeSet("api", Modified, "title", "Original Title", "")
+
+	r := ApplyReverse(cs, m)
+
+	// Title should remain unchanged
+	if m.Model["api"].Title != "Original Title" {
+		t.Errorf("expected title to remain %q, got %q", "Original Title", m.Model["api"].Title)
+	}
+	// Should have a warning
+	if len(r.Warnings) == 0 {
+		t.Error("expected warning about empty title")
+	}
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "empty title") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning containing 'empty title', got: %v", r.Warnings)
+	}
+	// Should NOT count as an update
+	if r.ElementsUpdated != 0 {
+		t.Errorf("expected 0 updates (skipped), got %d", r.ElementsUpdated)
+	}
+}
+
 func TestApplyReverse_RelationshipAdded(t *testing.T) {
 	m := emptyModel()
 	cs := relChangeSet("x", "y", Added, "", "", "uses")


### PR DESCRIPTION
## Summary
- Adds validation in `applyElementChange()` to reject empty/whitespace title updates from draw.io
- Emits a warning instead of silently accepting an invalid title

## Test plan
- [x] RED test: `TestApplyReverse_RejectsEmptyTitle` verifies empty title is rejected with warning
- [x] GREEN: guard added, test passes
- [x] `make test-race` passes

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)