### PR TITLE
fix: validate and normalize --format flag values (#145)

### DIFF
--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,16 @@ func NewRootCmd() *cobra.Command {
 		Use:     "bausteinsicht",
 		Short:   "Architecture-as-code with draw.io synchronization",
 		Version: version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("format")
+			format = strings.ToLower(format)
+			if format != "" && format != "text" && format != "json" {
+				return fmt.Errorf("unknown format %q: valid values are \"text\" and \"json\"", format)
+			}
+			// Normalize to lowercase for all subcommands.
+			_ = cmd.Flags().Set("format", format)
+			return nil
+		},
 	}
 
 	rootCmd.PersistentFlags().String("format", "text", "Output format: text or json")

--- a/cmd/bausteinsicht/root_test.go
+++ b/cmd/bausteinsicht/root_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/templates"
+)
+
+func executeRootCmd(args ...string) (string, error) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestRootCmd_RejectsInvalidFormat(t *testing.T) {
+	for _, format := range []string{"xml", "yaml", "csv", "HTML"} {
+		t.Run(format, func(t *testing.T) {
+			_, err := executeRootCmd("validate", "--format", format)
+			if err == nil {
+				t.Fatalf("expected error for invalid format %q, but got none", format)
+			}
+			if !strings.Contains(err.Error(), "unknown format") {
+				t.Fatalf("expected 'unknown format' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRootCmd_AcceptsJsonCaseInsensitive(t *testing.T) {
+	// "JSON" (uppercase) should be normalized to "json" and work correctly.
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeRootCmd("validate", "--model", modelPath, "--format", "JSON")
+	if err != nil {
+		t.Fatalf("expected no error for format 'JSON', got: %v", err)
+	}
+	// The command should succeed — this also proves normalization works
+	// since the validate command checks format == "json".
+	if !strings.Contains(out, "valid") {
+		t.Errorf("expected validation output, got: %q", out)
+	}
+}
+
+func TestRootCmd_AcceptsTextFormat(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeRootCmd("validate", "--model", modelPath, "--format", "text")
+	if err != nil {
+		t.Fatalf("expected no error for format 'text', got: %v", err)
+	}
+}
+
+func TestRootCmd_AcceptsJsonLowercase(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeRootCmd("validate", "--model", modelPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error for format 'json', got: %v", err)
+	}
+}
+
+func TestRootCmd_AcceptsTextCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := executeRootCmd("validate", "--model", modelPath, "--format", "TEXT")
+	if err != nil {
+		t.Fatalf("expected no error for format 'TEXT', got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `PersistentPreRunE` to root command that validates the `--format` flag
- Rejects invalid values like `xml`, `JSON` with a clear error message listing valid options
- Normalizes case (e.g., `JSON` → `json`) for valid values

## Test plan
- [x] RED test: verifies invalid format values are rejected
- [x] GREEN: validation added, test passes
- [x] `make test-race` passes

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)