### PR TITLE
fix: reject non-drawio files for --template flag (#148)

### DIFF
--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -22,6 +23,13 @@ func NewRootCmd() *cobra.Command {
 			}
 			// Normalize to lowercase for all subcommands.
 			_ = cmd.Flags().Set("format", format)
+
+			// Validate --template extension when provided.
+			templatePath, _ := cmd.Flags().GetString("template")
+			if templatePath != "" && filepath.Ext(templatePath) != ".drawio" {
+				return fmt.Errorf("template file %q must have a .drawio extension", templatePath)
+			}
+
 			return nil
 		},
 	}

--- a/cmd/bausteinsicht/root_test.go
+++ b/cmd/bausteinsicht/root_test.go
@@ -91,3 +91,64 @@ func TestRootCmd_AcceptsTextCaseInsensitive(t *testing.T) {
 		t.Fatalf("expected no error for format 'TEXT', got: %v", err)
 	}
 }
+
+func TestRootCmd_RejectsNonDrawioTemplate(t *testing.T) {
+	for _, name := range []string{"model.jsonc", "styles.xml", "template.png", "notes.txt"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			// Create the file so it exists on disk.
+			fpath := filepath.Join(dir, name)
+			if err := os.WriteFile(fpath, []byte("dummy"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			// Also create a valid model so the command doesn't fail for
+			// unrelated auto-detect reasons.
+			modelPath := filepath.Join(dir, "arch.jsonc")
+			if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := executeRootCmd("validate", "--model", modelPath, "--template", fpath)
+			if err == nil {
+				t.Fatalf("expected error for non-.drawio template %q, but got none", name)
+			}
+			if !strings.Contains(err.Error(), ".drawio") {
+				t.Fatalf("expected error to mention .drawio, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRootCmd_AcceptsDrawioTemplate(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Create a minimal .drawio template file.
+	tmplPath := filepath.Join(dir, "custom.drawio")
+	if err := os.WriteFile(tmplPath, []byte("<mxfile/>"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The command may fail for other reasons (e.g. missing drawio file for sync),
+	// but it should NOT fail due to template extension validation.
+	_, err := executeRootCmd("validate", "--model", modelPath, "--template", tmplPath)
+	if err != nil && strings.Contains(err.Error(), ".drawio") && strings.Contains(err.Error(), "must have") {
+		t.Fatalf("should accept .drawio template, got: %v", err)
+	}
+}
+
+func TestRootCmd_AcceptsEmptyTemplate(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No --template flag should work fine (uses default).
+	_, err := executeRootCmd("validate", "--model", modelPath)
+	if err != nil {
+		t.Fatalf("expected no error without --template flag, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds validation in `PersistentPreRunE` that rejects `--template` values without `.drawio` extension
- Prevents degraded styling when wrong file types are passed

## Test plan
- [x] RED test: verifies non-.drawio extensions are rejected
- [x] GREEN: validation added, test passes
- [x] `make test-race` passes

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)