### PR TITLE
fix: validate element references in view include and exclude (#151)

### DIFF
--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -126,6 +126,28 @@ func validateViews(m *BausteinsichtModel) []ValidationError {
 				})
 			}
 		}
+		for _, entry := range view.Include {
+			if strings.Contains(entry, "*") {
+				continue
+			}
+			if _, err := lookupElement(m, entry); err != nil {
+				errs = append(errs, ValidationError{
+					Path:    path + ".include",
+					Message: fmt.Sprintf("element %q does not exist", entry),
+				})
+			}
+		}
+		for _, entry := range view.Exclude {
+			if strings.Contains(entry, "*") {
+				continue
+			}
+			if _, err := lookupElement(m, entry); err != nil {
+				errs = append(errs, ValidationError{
+					Path:    path + ".exclude",
+					Message: fmt.Sprintf("element %q does not exist", entry),
+				})
+			}
+		}
 	}
 	return errs
 }

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -240,6 +240,70 @@ func TestValidate_EmptyChildID(t *testing.T) {
 	}
 }
 
+func TestValidate_ViewIncludeNonExistentElement(t *testing.T) {
+	m := buildValidModel()
+	m.Views["overview"] = View{
+		Title:   "Overview",
+		Include: []string{"nonexistent"},
+	}
+
+	errs := Validate(m)
+	if !containsPath(errs, "views.overview.include") {
+		t.Errorf("expected error at views.overview.include, got %v", errs)
+	}
+	if !containsMessage(errs, `element "nonexistent" does not exist`) {
+		t.Errorf("expected error message about element not existing, got %v", errs)
+	}
+}
+
+func TestValidate_ViewExcludeNonExistentElement(t *testing.T) {
+	m := buildValidModel()
+	m.Views["overview"] = View{
+		Title:   "Overview",
+		Include: []string{"customer"},
+		Exclude: []string{"nonexistent"},
+	}
+
+	errs := Validate(m)
+	if !containsPath(errs, "views.overview.exclude") {
+		t.Errorf("expected error at views.overview.exclude, got %v", errs)
+	}
+	if !containsMessage(errs, `element "nonexistent" does not exist`) {
+		t.Errorf("expected error message about element not existing, got %v", errs)
+	}
+}
+
+func TestValidate_ViewWildcardPatternsNoError(t *testing.T) {
+	m := buildValidModel()
+	m.Views["overview"] = View{
+		Title:   "Overview",
+		Include: []string{"*", "**", "foo.*"},
+		Exclude: []string{"bar.**"},
+	}
+
+	errs := Validate(m)
+	for _, e := range errs {
+		if strings.Contains(e.Path, "views.overview.include") || strings.Contains(e.Path, "views.overview.exclude") {
+			t.Errorf("wildcard patterns should not produce errors, got %v", e)
+		}
+	}
+}
+
+func TestValidate_ViewIncludeValidElement(t *testing.T) {
+	m := buildValidModel()
+	m.Views["overview"] = View{
+		Title:   "Overview",
+		Include: []string{"customer", "shop.api"},
+	}
+
+	errs := Validate(m)
+	for _, e := range errs {
+		if strings.Contains(e.Path, "views.overview.include") {
+			t.Errorf("valid element references should not produce errors, got %v", e)
+		}
+	}
+}
+
 // containsPath checks whether any error has the given path.
 func containsPath(errs []ValidationError, path string) bool {
 	for _, e := range errs {


### PR DESCRIPTION
## Summary
- Non-wildcard entries in view include/exclude that reference non-existent elements now produce validation errors
- Wildcard patterns (containing `*`) are skipped since they are patterns, not direct references

## Test plan
- [x] RED tests: non-existent refs in include/exclude produce errors
- [x] GREEN: validation added, tests pass
- [x] Wildcards do NOT trigger errors
- [x] `make test-race` passes

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)