### PR TITLE
fix: implement --verbose flag for validate and sync commands (#144)

### DIFF
--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -74,8 +74,8 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	// Verbose output goes to stderr so it doesn't interfere with JSON on stdout.
 	if verbose && format != "json" {
 		flat := model.FlattenElements(m)
-		fmt.Fprintf(cmd.ErrOrStderr(), "Syncing model: %s\n", modelPath)
-		fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Syncing model: %s\n", modelPath)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
 			len(flat), len(m.Relationships), len(m.Views))
 	}
 
@@ -115,17 +115,17 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	// Verbose post-sync details to stderr.
 	if verbose && format != "json" {
 		if result.Forward != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Forward sync: %d elements created, %d updated, %d deleted; %d connectors created, %d updated, %d deleted\n",
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Forward sync: %d elements created, %d updated, %d deleted; %d connectors created, %d updated, %d deleted\n",
 				result.Forward.ElementsCreated, result.Forward.ElementsUpdated, result.Forward.ElementsDeleted,
 				result.Forward.ConnectorsCreated, result.Forward.ConnectorsUpdated, result.Forward.ConnectorsDeleted)
 		}
 		if result.Reverse != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Reverse sync: %d elements created, %d updated, %d deleted; %d relationships created, %d updated, %d deleted\n",
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Reverse sync: %d elements created, %d updated, %d deleted; %d relationships created, %d updated, %d deleted\n",
 				result.Reverse.ElementsCreated, result.Reverse.ElementsUpdated, result.Reverse.ElementsDeleted,
 				result.Reverse.RelationshipsCreated, result.Reverse.RelationshipsUpdated, result.Reverse.RelationshipsDeleted)
 		}
 		if len(result.Conflicts) > 0 {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Conflicts resolved: %d (model wins)\n", len(result.Conflicts))
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Conflicts resolved: %d (model wins)\n", len(result.Conflicts))
 		}
 	}
 

--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -26,6 +26,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	format, _ := cmd.Flags().GetString("format")
 	modelPath, _ := cmd.Flags().GetString("model")
 	templatePath, _ := cmd.Flags().GetString("template")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	// Auto-detect model file.
 	if modelPath == "" {
@@ -70,6 +71,14 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		return exitWithCode(fmt.Errorf("loading template: %w", err), 2)
 	}
 
+	// Verbose output goes to stderr so it doesn't interfere with JSON on stdout.
+	if verbose && format != "json" {
+		flat := model.FlattenElements(m)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Syncing model: %s\n", modelPath)
+		fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
+			len(flat), len(m.Relationships), len(m.Views))
+	}
+
 	// Ensure pages exist for all views.
 	for viewID, view := range m.Views {
 		pageID := "view-" + viewID
@@ -101,6 +110,23 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	}
 	if err := bsync.SaveState(statePath, newState); err != nil {
 		return exitWithCode(fmt.Errorf("saving sync state: %w", err), 2)
+	}
+
+	// Verbose post-sync details to stderr.
+	if verbose && format != "json" {
+		if result.Forward != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Forward sync: %d elements created, %d updated, %d deleted; %d connectors created, %d updated, %d deleted\n",
+				result.Forward.ElementsCreated, result.Forward.ElementsUpdated, result.Forward.ElementsDeleted,
+				result.Forward.ConnectorsCreated, result.Forward.ConnectorsUpdated, result.Forward.ConnectorsDeleted)
+		}
+		if result.Reverse != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Reverse sync: %d elements created, %d updated, %d deleted; %d relationships created, %d updated, %d deleted\n",
+				result.Reverse.ElementsCreated, result.Reverse.ElementsUpdated, result.Reverse.ElementsDeleted,
+				result.Reverse.RelationshipsCreated, result.Reverse.RelationshipsUpdated, result.Reverse.RelationshipsDeleted)
+		}
+		if len(result.Conflicts) > 0 {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Conflicts resolved: %d (model wins)\n", len(result.Conflicts))
+		}
 	}
 
 	// Print warnings to stderr.

--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"strings"
@@ -496,6 +497,139 @@ func TestSyncRemovesOrphanedViewPages(t *testing.T) {
 	if pageCountAfter >= pageCountBefore {
 		t.Errorf("expected fewer pages after removing views: before=%d, after=%d",
 			pageCountBefore, pageCountAfter)
+	}
+}
+
+func TestSync_Verbose_PrintsSyncDetails(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init first.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Add an element so the next sync has something to do.
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{"add", "element", "--id", "verbose_test_svc", "--kind", "system", "--title", "Verbose Test Service"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("add element failed: %v", err)
+	}
+
+	// Add element to the context view.
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+	if v, ok := m.Views["context"]; ok {
+		v.Include = append(v.Include, "verbose_test_svc")
+		m.Views["context"] = v
+	}
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save model: %v", err)
+	}
+
+	// Sync with --verbose; capture stderr via cmd.SetErr.
+	syncCmd := NewRootCmd()
+	errBuf := new(bytes.Buffer)
+	syncCmd.SetErr(errBuf)
+	syncCmd.SetArgs([]string{"sync", "--verbose"})
+
+	captureStdout(t, func() {
+		if err := syncCmd.Execute(); err != nil {
+			t.Fatalf("sync failed: %v", err)
+		}
+	})
+
+	stderr := errBuf.String()
+
+	if !strings.Contains(stderr, "Syncing model:") {
+		t.Errorf("verbose sync should print 'Syncing model:', got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "elements") {
+		t.Errorf("verbose sync should mention element counts, got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "relationships") {
+		t.Errorf("verbose sync should mention relationship counts, got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "views") {
+		t.Errorf("verbose sync should mention view counts, got stderr=%q", stderr)
+	}
+	// Post-sync details should also be present.
+	if !strings.Contains(stderr, "Forward sync:") {
+		t.Errorf("verbose sync should print 'Forward sync:' details, got stderr=%q", stderr)
+	}
+}
+
+func TestSync_Verbose_NotShownWithoutFlag(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init first.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Sync without --verbose.
+	syncCmd := NewRootCmd()
+	errBuf := new(bytes.Buffer)
+	syncCmd.SetErr(errBuf)
+	syncCmd.SetArgs([]string{"sync"})
+
+	captureStdout(t, func() {
+		if err := syncCmd.Execute(); err != nil {
+			t.Fatalf("sync failed: %v", err)
+		}
+	})
+
+	stderr := errBuf.String()
+	if strings.Contains(stderr, "Syncing model:") {
+		t.Errorf("verbose output should NOT appear without --verbose, got stderr=%q", stderr)
+	}
+}
+
+func TestSync_Verbose_SuppressedWithJSONFormat(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init first.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Sync with --verbose --format json.
+	syncCmd := NewRootCmd()
+	errBuf := new(bytes.Buffer)
+	syncCmd.SetErr(errBuf)
+	syncCmd.SetArgs([]string{"sync", "--verbose", "--format", "json"})
+
+	captureStdout(t, func() {
+		if err := syncCmd.Execute(); err != nil {
+			t.Fatalf("sync failed: %v", err)
+		}
+	})
+
+	stderr := errBuf.String()
+	if strings.Contains(stderr, "Syncing model:") {
+		t.Errorf("verbose output should be suppressed with --format json, got stderr=%q", stderr)
 	}
 }
 

--- a/cmd/bausteinsicht/validate.go
+++ b/cmd/bausteinsicht/validate.go
@@ -50,8 +50,8 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	// Verbose output goes to stderr so it doesn't interfere with JSON on stdout.
 	if verbose && format != "json" {
 		flat := model.FlattenElements(m)
-		fmt.Fprintf(cmd.ErrOrStderr(), "Validating model: %s\n", modelPath)
-		fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Validating model: %s\n", modelPath)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
 			len(flat), len(m.Relationships), len(m.Views))
 	}
 

--- a/cmd/bausteinsicht/validate.go
+++ b/cmd/bausteinsicht/validate.go
@@ -32,6 +32,7 @@ func newValidateCmd() *cobra.Command {
 func runValidate(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 	modelPath, _ := cmd.Flags().GetString("model")
+	verbose, _ := cmd.Flags().GetBool("verbose")
 
 	if modelPath == "" {
 		detected, err := model.AutoDetect(".")
@@ -44,6 +45,14 @@ func runValidate(cmd *cobra.Command, args []string) error {
 	m, err := model.Load(modelPath)
 	if err != nil {
 		return exitWithCode(err, 2)
+	}
+
+	// Verbose output goes to stderr so it doesn't interfere with JSON on stdout.
+	if verbose && format != "json" {
+		flat := model.FlattenElements(m)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Validating model: %s\n", modelPath)
+		fmt.Fprintf(cmd.ErrOrStderr(), "  %d elements, %d relationships, %d views\n",
+			len(flat), len(m.Relationships), len(m.Views))
 	}
 
 	errs := model.Validate(m)

--- a/cmd/bausteinsicht/validate_test.go
+++ b/cmd/bausteinsicht/validate_test.go
@@ -205,3 +205,86 @@ func TestValidate_AutoDetect_NoFile(t *testing.T) {
 		t.Errorf("expected exit code 2, got %d", ee.code)
 	}
 }
+
+// executeValidateCmdSplit runs the validate command and captures stdout and
+// stderr into separate buffers so verbose output (written to stderr) can be
+// verified independently.
+func executeValidateCmdSplit(args ...string) (stdout, stderr string, err error) {
+	cmd := NewRootCmd()
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+func TestValidate_Verbose_PrintsModelPathAndElementCount(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := executeValidateCmdSplit("validate", "--model", modelPath, "--verbose")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(stderr, "Validating model:") {
+		t.Errorf("verbose output should contain 'Validating model:', got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, modelPath) {
+		t.Errorf("verbose output should contain model path %q, got stderr=%q", modelPath, stderr)
+	}
+	if !strings.Contains(stderr, "elements") {
+		t.Errorf("verbose output should mention element count, got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "relationships") {
+		t.Errorf("verbose output should mention relationship count, got stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "views") {
+		t.Errorf("verbose output should mention view count, got stderr=%q", stderr)
+	}
+}
+
+func TestValidate_Verbose_NotShownWithoutFlag(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stderr, err := executeValidateCmdSplit("validate", "--model", modelPath)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if strings.Contains(stderr, "Validating model:") {
+		t.Errorf("verbose output should NOT appear without --verbose flag, got stderr=%q", stderr)
+	}
+}
+
+func TestValidate_Verbose_SuppressedWithJSONFormat(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(modelPath, templates.SampleModel, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, err := executeValidateCmdSplit("validate", "--model", modelPath, "--verbose", "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if strings.Contains(stderr, "Validating model:") {
+		t.Errorf("verbose output should be suppressed with --format json, got stderr=%q", stderr)
+	}
+
+	// JSON output should still be valid.
+	var result validateResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, stdout)
+	}
+}


### PR DESCRIPTION
## Summary
- Reads `--verbose` flag in validate and sync commands
- Outputs model path, element/relationship/view counts to stderr
- Sync also prints forward/reverse sync details after completion
- Verbose output suppressed when `--format json` is active

## Test plan
- [x] RED: 6 tests for verbose output presence/absence
- [x] GREEN: verbose output implemented
- [x] `make test-race` passes

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)