### PR TITLE
fix: remove orphaned view pages when view is deleted from model (#143)

### DIFF
--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -78,6 +78,9 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Remove orphaned view pages (views deleted or renamed in model). (#143)
+	bsync.RemoveOrphanedViewPages(doc, m)
+
 	// Run sync.
 	result := bsync.Run(m, doc, state, tmpl)
 

--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -428,6 +428,77 @@ func TestSyncPreservesUserAddedDrawioElement(t *testing.T) {
 	}
 }
 
+// TestSyncRemovesOrphanedViewPages verifies that when a view is removed from
+// the model, the corresponding draw.io page is also removed during sync.
+// Regression test for #143.
+func TestSyncRemovesOrphanedViewPages(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init the project.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// First sync to establish state.
+	captureStdout(t, func() {
+		cmd2 := NewRootCmd()
+		cmd2.SetArgs([]string{"sync"})
+		if err := cmd2.Execute(); err != nil {
+			t.Fatalf("first sync failed: %v", err)
+		}
+	})
+
+	// Verify the init template has a view and corresponding page.
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+	if len(m.Views) == 0 {
+		t.Skip("init template has no views; cannot test orphan removal")
+	}
+
+	// Count pages in the drawio file before removing a view.
+	drawioData, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pageCountBefore := strings.Count(string(drawioData), "<diagram ")
+
+	// Remove all views from the model except none (remove all).
+	m.Views = map[string]model.View{}
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save model: %v", err)
+	}
+
+	// Sync again — orphaned view pages should be removed.
+	captureStdout(t, func() {
+		cmd3 := NewRootCmd()
+		cmd3.SetArgs([]string{"sync"})
+		if err := cmd3.Execute(); err != nil {
+			t.Fatalf("second sync failed: %v", err)
+		}
+	})
+
+	// Read the draw.io file after sync.
+	afterSync, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pageCountAfter := strings.Count(string(afterSync), "<diagram ")
+
+	if pageCountAfter >= pageCountBefore {
+		t.Errorf("expected fewer pages after removing views: before=%d, after=%d",
+			pageCountBefore, pageCountAfter)
+	}
+}
+
 func TestSyncWithExplicitModelPath(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()

--- a/internal/drawio/document.go
+++ b/internal/drawio/document.go
@@ -147,6 +147,26 @@ func (d *Document) AddPage(id, name string) *Page {
 	return &Page{diagram: diagram}
 }
 
+// RemovePage removes the page (diagram element) with the given id from the document.
+// If no page with the given id exists, RemovePage is a no-op.
+func (d *Document) RemovePage(id string) {
+	root := d.tree.Root()
+	if root == nil {
+		return
+	}
+	for _, el := range root.SelectElements("diagram") {
+		if el.SelectAttrValue("id", "") == id {
+			root.RemoveChild(el)
+			return
+		}
+	}
+}
+
+// ID returns the id attribute of the page's diagram element.
+func (p *Page) ID() string {
+	return p.diagram.SelectAttrValue("id", "")
+}
+
 // Root returns the <root> element of the page for direct manipulation.
 func (p *Page) Root() *etree.Element {
 	model := p.diagram.FindElement("mxGraphModel")

--- a/internal/drawio/document_test.go
+++ b/internal/drawio/document_test.go
@@ -159,6 +159,66 @@ func TestLoadDocument_AcceptsValidDocument(t *testing.T) {
 	}
 }
 
+func TestRemovePage(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("p1", "Page 1")
+	doc.AddPage("p2", "Page 2")
+	doc.AddPage("p3", "Page 3")
+
+	if len(doc.Pages()) != 3 {
+		t.Fatalf("precondition: expected 3 pages, got %d", len(doc.Pages()))
+	}
+
+	doc.RemovePage("p2")
+
+	if len(doc.Pages()) != 2 {
+		t.Errorf("expected 2 pages after RemovePage, got %d", len(doc.Pages()))
+	}
+	if doc.GetPage("p2") != nil {
+		t.Error("page p2 should be removed")
+	}
+	if doc.GetPage("p1") == nil {
+		t.Error("page p1 should still exist")
+	}
+	if doc.GetPage("p3") == nil {
+		t.Error("page p3 should still exist")
+	}
+}
+
+func TestRemovePage_NonExistent(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("p1", "Page 1")
+
+	// Removing a non-existent page should be a no-op.
+	doc.RemovePage("does-not-exist")
+
+	if len(doc.Pages()) != 1 {
+		t.Errorf("expected 1 page (no-op), got %d", len(doc.Pages()))
+	}
+}
+
+func TestPageID(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	doc.AddPage("view-containers", "Container View")
+
+	pages := doc.Pages()
+	if len(pages) != 2 {
+		t.Fatalf("expected 2 pages, got %d", len(pages))
+	}
+
+	ids := make(map[string]bool)
+	for _, p := range pages {
+		ids[p.ID()] = true
+	}
+	if !ids["view-context"] {
+		t.Error("expected page with ID 'view-context'")
+	}
+	if !ids["view-containers"] {
+		t.Error("expected page with ID 'view-containers'")
+	}
+}
+
 func TestSaveDocument_Atomic(t *testing.T) {
 	doc := drawio.NewDocument()
 	doc.AddPage("p1", "Page 1")

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"strings"
+
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
@@ -63,6 +65,35 @@ func Run(
 	}
 
 	return result
+}
+
+// RemoveOrphanedViewPages removes pages from the draw.io document that were
+// created for views that no longer exist in the model. Pages are identified as
+// view-managed if their id starts with the "view-" prefix. Pages whose id does
+// not start with "view-" are preserved (e.g., default template pages).
+func RemoveOrphanedViewPages(doc *drawio.Document, m *model.BausteinsichtModel) {
+	// Build the set of expected view page IDs from the model.
+	expectedPages := make(map[string]bool, len(m.Views))
+	for viewID := range m.Views {
+		expectedPages["view-"+viewID] = true
+	}
+
+	// Iterate pages and collect orphaned view page IDs.
+	var orphans []string
+	for _, page := range doc.Pages() {
+		pageID := page.ID()
+		if !strings.HasPrefix(pageID, "view-") {
+			continue // Not a view-managed page; preserve it.
+		}
+		if !expectedPages[pageID] {
+			orphans = append(orphans, pageID)
+		}
+	}
+
+	// Remove orphaned pages.
+	for _, id := range orphans {
+		doc.RemovePage(id)
+	}
 }
 
 // filterConflictingDrawioChanges removes draw.io element changes for fields

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -208,6 +208,100 @@ func TestRun_ViewBasedSyncNoPhantomChanges(t *testing.T) {
 	}
 }
 
+// --- Test 5b: Orphaned view pages removed when view is deleted (#143) ---
+//
+// Round 1: model has 2 views → creates 2 pages.
+// Round 2: model has 1 view → orphaned page should be removed.
+
+func TestRun_OrphanedViewPageRemoved(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "container", Title: "Customer"},
+			"shop":     {Kind: "container", Title: "Shop"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"ctx":    {Title: "Context", Include: []string{"customer", "shop"}},
+			"detail": {Title: "Detail", Include: []string{"shop"}},
+		},
+	}
+
+	// Build doc with pages for both views.
+	doc := drawio.NewDocument()
+	doc.AddPage("view-ctx", "Context")
+	doc.AddPage("view-detail", "Detail")
+
+	state := emptyState()
+
+	// Round 1: forward sync populates both pages.
+	r1 := Run(m, doc, state, ts)
+	if r1.Forward.ElementsCreated < 2 {
+		t.Fatalf("round 1: expected at least 2 elements created, got %d", r1.Forward.ElementsCreated)
+	}
+
+	// Verify both pages exist.
+	if len(doc.Pages()) != 2 {
+		t.Fatalf("round 1: expected 2 pages, got %d", len(doc.Pages()))
+	}
+
+	// Round 2: remove the "detail" view from the model.
+	delete(m.Views, "detail")
+
+	// Remove the orphaned page — this is what the sync command should do.
+	// We call RemoveOrphanedViewPages to simulate the sync command behavior.
+	RemoveOrphanedViewPages(doc, m)
+
+	// The doc should now have only 1 page.
+	if len(doc.Pages()) != 1 {
+		t.Errorf("after removing orphaned pages: expected 1 page, got %d", len(doc.Pages()))
+	}
+
+	// The remaining page should be the "Context" page.
+	if doc.GetPage("view-ctx") == nil {
+		t.Error("context page should still exist")
+	}
+	if doc.GetPage("view-detail") != nil {
+		t.Error("detail page should be removed (orphaned)")
+	}
+}
+
+// --- Test 5c: Non-view pages preserved when removing orphans (#143) ---
+//
+// Verifies that pages not managed by bausteinsicht (e.g., default template
+// pages) are NOT removed when cleaning up orphaned view pages.
+
+func TestRun_NonViewPagesPreserved(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "container", Title: "Customer"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"ctx": {Title: "Context", Include: []string{"customer"}},
+		},
+	}
+
+	// Build doc with a default page (not a view page) and a view page.
+	doc := drawio.NewDocument()
+	doc.AddPage("default-page", "Welcome")
+	doc.AddPage("view-ctx", "Context")
+
+	RemoveOrphanedViewPages(doc, m)
+
+	// Both pages should still exist — the default page is not a view page.
+	if len(doc.Pages()) != 2 {
+		t.Errorf("expected 2 pages (default + view), got %d", len(doc.Pages()))
+	}
+	if doc.GetPage("default-page") == nil {
+		t.Error("default page should be preserved (not a view page)")
+	}
+	if doc.GetPage("view-ctx") == nil {
+		t.Error("context view page should be preserved")
+	}
+}
+
 // --- Test 6: Full round-trip ---
 //
 // Round 1: model has one element, doc is empty, state is empty → forward populates doc.


### PR DESCRIPTION
## Summary
- Adds `RemovePage(id)` and `Page.ID()` methods to the draw.io document API
- Adds `RemoveOrphanedViewPages()` to the sync engine that removes pages with `view-` prefix that have no matching model view
- Non-view pages (default template pages) are preserved

## Test plan
- [x] RED: unit tests for RemovePage, Page.ID, orphan removal, non-view preservation
- [x] GREEN: implementation in document.go, engine.go, sync.go
- [x] Integration test in sync_test.go
- [x] `make test-race` passes

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)