### PR TITLE
fix: disambiguate connector IDs for multiple relationships (#142)

### DIFF
--- a/internal/drawio/connector.go
+++ b/internal/drawio/connector.go
@@ -13,11 +13,13 @@ type ConnectorData struct {
 	Label     string // display label on the connector
 	SourceRef string // source cell ID (defaults to From if empty)
 	TargetRef string // target cell ID (defaults to To if empty)
+	Index     int    // relationship index for disambiguation (0-based)
 }
 
 // connectorID returns the canonical ID for a connector between two elements.
-func connectorID(from, to string) string {
-	return fmt.Sprintf("rel-%s-%s", from, to)
+// The index disambiguates multiple relationships between the same pair.
+func connectorID(from, to string, index int) string {
+	return fmt.Sprintf("rel-%s-%s-%d", from, to, index)
 }
 
 // CreateConnector creates an edge mxCell connecting From to To.
@@ -38,7 +40,7 @@ func (p *Page) CreateConnector(data ConnectorData, style string) {
 	}
 
 	cell := root.CreateElement("mxCell")
-	cell.CreateAttr("id", connectorID(srcRef, tgtRef))
+	cell.CreateAttr("id", connectorID(srcRef, tgtRef, data.Index))
 	cell.CreateAttr("value", data.Label)
 	cell.CreateAttr("style", style)
 	cell.CreateAttr("edge", "1")
@@ -51,13 +53,13 @@ func (p *Page) CreateConnector(data ConnectorData, style string) {
 	geom.CreateAttr("as", "geometry")
 }
 
-// FindConnector returns the mxCell edge with id="rel-<from>-<to>", or nil.
-func (p *Page) FindConnector(from, to string) *etree.Element {
+// FindConnector returns the mxCell edge with id="rel-<from>-<to>-<index>", or nil.
+func (p *Page) FindConnector(from, to string, index int) *etree.Element {
 	root := p.Root()
 	if root == nil {
 		return nil
 	}
-	id := connectorID(from, to)
+	id := connectorID(from, to, index)
 	for _, cell := range root.SelectElements("mxCell") {
 		if cell.SelectAttrValue("id", "") == id {
 			return cell
@@ -82,8 +84,8 @@ func (p *Page) FindAllConnectors() []*etree.Element {
 }
 
 // UpdateConnectorLabel sets the value attribute on the connector between from and to.
-func (p *Page) UpdateConnectorLabel(from, to, label string) {
-	conn := p.FindConnector(from, to)
+func (p *Page) UpdateConnectorLabel(from, to string, index int, label string) {
+	conn := p.FindConnector(from, to, index)
 	if conn == nil {
 		return
 	}
@@ -95,13 +97,13 @@ func (p *Page) UpdateConnectorLabel(from, to, label string) {
 	}
 }
 
-// DeleteConnector removes the connector between from and to.
-func (p *Page) DeleteConnector(from, to string) {
+// DeleteConnector removes the connector between from and to at the given index.
+func (p *Page) DeleteConnector(from, to string, index int) {
 	root := p.Root()
 	if root == nil {
 		return
 	}
-	id := connectorID(from, to)
+	id := connectorID(from, to, index)
 	for _, cell := range root.SelectElements("mxCell") {
 		if cell.SelectAttrValue("id", "") == id {
 			root.RemoveChild(cell)

--- a/internal/drawio/connector_test.go
+++ b/internal/drawio/connector_test.go
@@ -28,8 +28,8 @@ func TestCreateConnector(t *testing.T) {
 	}
 
 	conn := cells[2]
-	if got := conn.SelectAttrValue("id", ""); got != "rel-customer-webshop.api" {
-		t.Errorf("id = %q, want %q", got, "rel-customer-webshop.api")
+	if got := conn.SelectAttrValue("id", ""); got != "rel-customer-webshop.api-0" {
+		t.Errorf("id = %q, want %q", got, "rel-customer-webshop.api-0")
 	}
 	if got := conn.SelectAttrValue("value", ""); got != "uses" {
 		t.Errorf("value = %q, want %q", got, "uses")
@@ -67,15 +67,15 @@ func TestFindConnector(t *testing.T) {
 	data := drawio.ConnectorData{From: "a", To: "b", Label: "link"}
 	p.CreateConnector(data, testStyle)
 
-	got := p.FindConnector("a", "b")
+	got := p.FindConnector("a", "b", 0)
 	if got == nil {
 		t.Fatal("FindConnector returned nil, expected element")
 	}
-	if got.SelectAttrValue("id", "") != "rel-a-b" {
+	if got.SelectAttrValue("id", "") != "rel-a-b-0" {
 		t.Errorf("unexpected id: %q", got.SelectAttrValue("id", ""))
 	}
 
-	if p.FindConnector("x", "y") != nil {
+	if p.FindConnector("x", "y", 0) != nil {
 		t.Error("FindConnector should return nil for non-existent connector")
 	}
 }
@@ -95,9 +95,9 @@ func TestUpdateConnectorLabel(t *testing.T) {
 	p := newTestPage(t)
 	p.CreateConnector(drawio.ConnectorData{From: "x", To: "y", Label: "old"}, testStyle)
 
-	p.UpdateConnectorLabel("x", "y", "new")
+	p.UpdateConnectorLabel("x", "y", 0, "new")
 
-	conn := p.FindConnector("x", "y")
+	conn := p.FindConnector("x", "y", 0)
 	if conn == nil {
 		t.Fatal("connector not found after update")
 	}
@@ -111,12 +111,12 @@ func TestDeleteConnector(t *testing.T) {
 	p.CreateConnector(drawio.ConnectorData{From: "a", To: "b"}, testStyle)
 	p.CreateConnector(drawio.ConnectorData{From: "c", To: "d"}, testStyle)
 
-	p.DeleteConnector("a", "b")
+	p.DeleteConnector("a", "b", 0)
 
-	if p.FindConnector("a", "b") != nil {
+	if p.FindConnector("a", "b", 0) != nil {
 		t.Error("deleted connector still found")
 	}
-	if p.FindConnector("c", "d") == nil {
+	if p.FindConnector("c", "d", 0) == nil {
 		t.Error("unrelated connector was removed")
 	}
 }
@@ -132,13 +132,64 @@ func TestDeleteConnectorsFor(t *testing.T) {
 
 	p.DeleteConnectorsFor("node1")
 
-	if p.FindConnector("node1", "node2") != nil {
+	if p.FindConnector("node1", "node2", 0) != nil {
 		t.Error("source connector should have been deleted")
 	}
-	if p.FindConnector("node3", "node1") != nil {
+	if p.FindConnector("node3", "node1", 0) != nil {
 		t.Error("target connector should have been deleted")
 	}
-	if p.FindConnector("nodeA", "nodeB") == nil {
+	if p.FindConnector("nodeA", "nodeB", 0) == nil {
 		t.Error("unrelated connector should remain")
+	}
+}
+
+// TestMultipleConnectorsSamePair verifies that multiple connectors between the
+// same pair of elements are stored separately using distinct indices. (#142)
+func TestMultipleConnectorsSamePair(t *testing.T) {
+	p := newTestPage(t)
+
+	// Create two connectors between A and B with different indices.
+	p.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "uses", Index: 0,
+	}, testStyle)
+	p.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "calls", Index: 1,
+	}, testStyle)
+
+	all := p.FindAllConnectors()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 connectors, got %d", len(all))
+	}
+
+	// Verify each connector has a distinct ID.
+	conn0 := p.FindConnector("a", "b", 0)
+	if conn0 == nil {
+		t.Fatal("connector index=0 not found")
+	}
+	if got := conn0.SelectAttrValue("id", ""); got != "rel-a-b-0" {
+		t.Errorf("connector 0 id = %q, want %q", got, "rel-a-b-0")
+	}
+	if got := conn0.SelectAttrValue("value", ""); got != "uses" {
+		t.Errorf("connector 0 value = %q, want %q", got, "uses")
+	}
+
+	conn1 := p.FindConnector("a", "b", 1)
+	if conn1 == nil {
+		t.Fatal("connector index=1 not found")
+	}
+	if got := conn1.SelectAttrValue("id", ""); got != "rel-a-b-1" {
+		t.Errorf("connector 1 id = %q, want %q", got, "rel-a-b-1")
+	}
+	if got := conn1.SelectAttrValue("value", ""); got != "calls" {
+		t.Errorf("connector 1 value = %q, want %q", got, "calls")
+	}
+
+	// Delete only index=0; index=1 should remain.
+	p.DeleteConnector("a", "b", 0)
+	if p.FindConnector("a", "b", 0) != nil {
+		t.Error("connector index=0 should be deleted")
+	}
+	if p.FindConnector("a", "b", 1) == nil {
+		t.Error("connector index=1 should remain after deleting index=0")
 	}
 }

--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -71,7 +71,12 @@ func validateElement(m *BausteinsichtModel, path string, elem Element) []Validat
 
 func validateRelationships(m *BausteinsichtModel) []ValidationError {
 	var errs []ValidationError
-	seen := make(map[string]int) // "from->to" → first index
+	// Track seen relationships keyed by "from->to->kind->label" to allow
+	// multiple relationships between the same pair with different kind or label. (#142)
+	type relSig struct {
+		from, to, kind, label string
+	}
+	seen := make(map[relSig]int) // signature → first index
 
 	for i, rel := range m.Relationships {
 		path := fmt.Sprintf("relationships[%d]", i)
@@ -97,15 +102,17 @@ func validateRelationships(m *BausteinsichtModel) []ValidationError {
 			}
 		}
 
-		// Detect duplicate from/to pairs. (#117)
-		key := rel.From + "->" + rel.To
-		if firstIdx, exists := seen[key]; exists {
+		// Detect fully duplicate relationships (same from, to, kind, and label). (#117, #142)
+		// Multiple relationships between the same pair are allowed if they
+		// differ in kind or label.
+		sig := relSig{from: rel.From, to: rel.To, kind: rel.Kind, label: rel.Label}
+		if firstIdx, exists := seen[sig]; exists {
 			errs = append(errs, ValidationError{
 				Path:    path,
 				Message: fmt.Sprintf("duplicate relationship %s → %s (first at relationships[%d])", rel.From, rel.To, firstIdx),
 			})
 		} else {
-			seen[key] = i
+			seen[sig] = i
 		}
 	}
 	return errs

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -170,6 +170,41 @@ func TestValidate_DuplicateRelationship(t *testing.T) {
 	}
 }
 
+// TestValidate_MultipleRelsSamePairDifferentLabel verifies that multiple
+// relationships between the same pair with different labels are allowed. (#142)
+func TestValidate_MultipleRelsSamePairDifferentLabel(t *testing.T) {
+	m := buildValidModel()
+	m.Relationships = []Relationship{
+		{From: "customer", To: "shop", Kind: "uses", Label: "browses"},
+		{From: "customer", To: "shop", Kind: "uses", Label: "buys from"},
+	}
+
+	errs := Validate(m)
+	for _, e := range errs {
+		if contains(e.Message, "duplicate") {
+			t.Errorf("should not report duplicate for different labels, got: %v", e)
+		}
+	}
+}
+
+// TestValidate_MultipleRelsSamePairDifferentKind verifies that multiple
+// relationships between the same pair with different kinds are allowed. (#142)
+func TestValidate_MultipleRelsSamePairDifferentKind(t *testing.T) {
+	m := buildValidModel()
+	m.Specification.Relationships["calls"] = RelationshipKind{Notation: "calls"}
+	m.Relationships = []Relationship{
+		{From: "customer", To: "shop", Kind: "uses"},
+		{From: "customer", To: "shop", Kind: "calls"},
+	}
+
+	errs := Validate(m)
+	for _, e := range errs {
+		if contains(e.Message, "duplicate") {
+			t.Errorf("should not report duplicate for different kinds, got: %v", e)
+		}
+	}
+}
+
 func TestValidate_EmptyElementID(t *testing.T) {
 	m := &BausteinsichtModel{
 		Specification: Specification{

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
@@ -29,6 +30,7 @@ type ElementChange struct {
 type RelationshipChange struct {
 	From     string
 	To       string
+	Index    int    // relationship array index for disambiguation
 	Type     ChangeType
 	Field    string // "label", "" for add/delete
 	OldValue string
@@ -53,8 +55,9 @@ type drawioElemSnapshot struct {
 }
 
 // relKey returns a canonical key for a relationship.
-func relKey(from, to string) string {
-	return from + ":" + to
+// The index disambiguates multiple relationships between the same pair.
+func relKey(from, to string, index int) string {
+	return fmt.Sprintf("%s:%s:%d", from, to, index)
 }
 
 // computeVisibleElements returns the set of element IDs that should be visible
@@ -169,11 +172,15 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			if elemID, ok := cellToElem[toCell]; ok {
 				to = elemID
 			}
-			key := relKey(from, to)
+			// Extract the relationship index from the connector ID.
+			cellID := cell.SelectAttrValue("id", "")
+			index := parseConnectorIndex(cellID)
+			key := relKey(from, to, index)
 			if _, exists := result[key]; !exists {
 				result[key] = RelationshipState{
 					From:  from,
 					To:    to,
+					Index: index,
 					Label: cell.SelectAttrValue("value", ""),
 				}
 			}
@@ -182,13 +189,34 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 	return result
 }
 
+// parseConnectorIndex extracts the index from a connector ID of the form
+// "rel-<from>-<to>-<index>". Returns 0 if the ID does not contain an index
+// (backward compatibility with old connector IDs "rel-<from>-<to>").
+func parseConnectorIndex(id string) int {
+	if !strings.HasPrefix(id, "rel-") {
+		return 0
+	}
+	// The index is the last segment after the last '-'.
+	lastDash := strings.LastIndex(id, "-")
+	if lastDash < 0 {
+		return 0
+	}
+	indexStr := id[lastDash+1:]
+	var index int
+	if _, err := fmt.Sscanf(indexStr, "%d", &index); err != nil {
+		return 0
+	}
+	return index
+}
+
 // buildModelRelMap converts model relationships to a map keyed by relKey.
 func buildModelRelMap(m *model.BausteinsichtModel) map[string]RelationshipState {
 	modelRels := make(map[string]RelationshipState, len(m.Relationships))
-	for _, r := range m.Relationships {
-		modelRels[relKey(r.From, r.To)] = RelationshipState{
+	for i, r := range m.Relationships {
+		modelRels[relKey(r.From, r.To, i)] = RelationshipState{
 			From:  r.From,
 			To:    r.To,
+			Index: i,
 			Label: r.Label,
 			Kind:  r.Kind,
 		}
@@ -311,7 +339,7 @@ func detectRelationshipChanges(
 ) {
 	lastRels := make(map[string]RelationshipState, len(lastState.Relationships))
 	for _, r := range lastState.Relationships {
-		lastRels[relKey(r.From, r.To)] = r
+		lastRels[relKey(r.From, r.To, r.Index)] = r
 	}
 
 	allKeys := unionRelKeys(modelRels, drawioRels, lastRels)
@@ -321,21 +349,21 @@ func detectRelationshipChanges(
 		dr, inDrawio := drawioRels[k]
 		lr, inLast := lastRels[k]
 
-		from, to := resolveRelFromTo(mr, lr, dr)
+		from, to, index := resolveRelFromTo(mr, lr, dr)
 
 		// Model side
 		switch {
 		case inModel && !inLast:
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Added, NewValue: mr.Label,
+				From: from, To: to, Index: index, Type: Added, NewValue: mr.Label,
 			})
 		case !inModel && inLast:
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Deleted,
+				From: from, To: to, Index: index, Type: Deleted,
 			})
 		case inModel && inLast && mr.Label != lr.Label:
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Modified, Field: "label",
+				From: from, To: to, Index: index, Type: Modified, Field: "label",
 				OldValue: lr.Label, NewValue: mr.Label,
 			})
 		}
@@ -350,15 +378,15 @@ func detectRelationshipChanges(
 				continue
 			}
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Added,
+				From: from, To: to, Index: index, Type: Added,
 			})
 		case !inDrawio && inLast:
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Deleted,
+				From: from, To: to, Index: index, Type: Deleted,
 			})
 		case inDrawio && inLast && dr.Label != lr.Label:
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Type: Modified, Field: "label",
+				From: from, To: to, Index: index, Type: Modified, Field: "label",
 				OldValue: lr.Label, NewValue: dr.Label,
 			})
 		}
@@ -406,14 +434,14 @@ func isLiftedRelationship(from, to string, modelRels map[string]RelationshipStat
 	return false
 }
 
-// resolveRelFromTo returns the from/to pair from the first non-empty source.
-func resolveRelFromTo(mr, lr, dr RelationshipState) (from, to string) {
-	from, to = mr.From, mr.To
+// resolveRelFromTo returns the from/to/index from the first non-empty source.
+func resolveRelFromTo(mr, lr, dr RelationshipState) (from, to string, index int) {
+	from, to, index = mr.From, mr.To, mr.Index
 	if from == "" {
-		from, to = lr.From, lr.To
+		from, to, index = lr.From, lr.To, lr.Index
 	}
 	if from == "" {
-		from, to = dr.From, dr.To
+		from, to, index = dr.From, dr.To, dr.Index
 	}
-	return from, to
+	return from, to, index
 }

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -723,3 +723,77 @@ func TestDetectChanges_NoViewsAllDeletionsDetected(t *testing.T) {
 			cs.DrawioElementChanges)
 	}
 }
+
+// --- Multiple relationships between same pair (#142) ---
+
+func TestDetectChanges_MultipleRelsSamePairBothAdded(t *testing.T) {
+	// Model has two relationships from A to B with different labels.
+	// State is empty (first sync). Both should be detected as Added.
+	state := emptyState()
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+			{From: "a", To: "b", Label: "calls"},
+		},
+	}
+	doc := emptyDoc()
+
+	cs := DetectChanges(m, doc, state)
+
+	addedCount := 0
+	for _, ch := range cs.ModelRelationshipChanges {
+		if ch.From == "a" && ch.To == "b" && ch.Type == Added {
+			addedCount++
+		}
+	}
+	if addedCount != 2 {
+		t.Errorf("expected 2 Added relationship changes for a→b, got %d: %+v",
+			addedCount, cs.ModelRelationshipChanges)
+	}
+}
+
+func TestDetectChanges_MultipleRelsSamePairLabelModified(t *testing.T) {
+	// State has two rels from A to B. Model modifies label of the second.
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "a", To: "b", Index: 0, Label: "uses"},
+		{From: "a", To: "b", Index: 1, Label: "calls"},
+	}
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+			{From: "a", To: "b", Label: "invokes"}, // changed from "calls"
+		},
+	}
+	doc := emptyDoc()
+
+	cs := DetectChanges(m, doc, state)
+
+	found := false
+	for _, ch := range cs.ModelRelationshipChanges {
+		if ch.From == "a" && ch.To == "b" && ch.Index == 1 &&
+			ch.Type == Modified && ch.Field == "label" &&
+			ch.OldValue == "calls" && ch.NewValue == "invokes" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected label modification for a→b index=1, got: %+v",
+			cs.ModelRelationshipChanges)
+	}
+
+	// The first relationship (index 0) should NOT be modified.
+	for _, ch := range cs.ModelRelationshipChanges {
+		if ch.From == "a" && ch.To == "b" && ch.Index == 0 && ch.Type == Modified {
+			t.Errorf("first relationship (index=0) should not be modified, got: %+v", ch)
+		}
+	}
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -345,3 +345,69 @@ func TestRun_FullRoundTrip(t *testing.T) {
 		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
 	}
 }
+
+// --- Test 7: Multiple relationships between same pair (#142) ---
+//
+// Verifies that two relationships from A to B with different labels both
+// survive a full sync round-trip and produce two distinct connectors.
+
+func TestRun_MultipleRelsSamePair(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+			{From: "a", To: "b", Label: "calls"},
+		},
+	}
+
+	doc := emptyDoc()
+	state := emptyState()
+
+	// Round 1: first sync populates an empty doc.
+	r1 := Run(m, doc, state, ts)
+	if r1.Forward.ElementsCreated != 2 {
+		t.Fatalf("round 1: expected 2 elements created, got %d", r1.Forward.ElementsCreated)
+	}
+	if r1.Forward.ConnectorsCreated != 2 {
+		t.Fatalf("round 1: expected 2 connectors created, got %d", r1.Forward.ConnectorsCreated)
+	}
+
+	// Verify both connectors exist on the page.
+	page := doc.Pages()[0]
+	conns := page.FindAllConnectors()
+	if len(conns) != 2 {
+		t.Fatalf("round 1: expected 2 connectors on page, got %d", len(conns))
+	}
+
+	// Build state after round 1.
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"a": {Title: "A", Kind: "container"},
+			"b": {Title: "B", Kind: "container"},
+		},
+		Relationships: []RelationshipState{
+			{From: "a", To: "b", Index: 0, Label: "uses"},
+			{From: "a", To: "b", Index: 1, Label: "calls"},
+		},
+	}
+
+	// Round 2: nothing changed — sync should be a complete no-op.
+	r2 := Run(m, doc, state1, ts)
+
+	if r2.Forward.ConnectorsCreated != 0 || r2.Forward.ConnectorsUpdated != 0 || r2.Forward.ConnectorsDeleted != 0 {
+		t.Errorf("round 2: expected no forward connector changes, got created=%d updated=%d deleted=%d",
+			r2.Forward.ConnectorsCreated, r2.Forward.ConnectorsUpdated, r2.Forward.ConnectorsDeleted)
+	}
+	if r2.Reverse.RelationshipsCreated != 0 || r2.Reverse.RelationshipsUpdated != 0 || r2.Reverse.RelationshipsDeleted != 0 {
+		t.Errorf("round 2: expected no reverse relationship changes, got created=%d updated=%d deleted=%d",
+			r2.Reverse.RelationshipsCreated, r2.Reverse.RelationshipsUpdated, r2.Reverse.RelationshipsDeleted)
+	}
+	if len(r2.Conflicts) != 0 {
+		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
+	}
+}

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -269,8 +269,8 @@ func applyChangesToPage(
 				// view's element filter, so we bypass lifting entirely.
 				fromRef := scopedCellID(viewID, ch.From)
 				toRef := scopedCellID(viewID, ch.To)
-				if page.FindConnector(fromRef, toRef) != nil {
-					page.DeleteConnector(fromRef, toRef)
+				if page.FindConnector(fromRef, toRef, ch.Index) != nil {
+					page.DeleteConnector(fromRef, toRef, ch.Index)
 					result.ConnectorsDeleted++
 				}
 			default:
@@ -290,17 +290,24 @@ func applyChangesToPage(
 				if pass == 1 && !isLifted {
 					continue // Second pass: only lifted relationships
 				}
-				lifted := RelationshipChange{From: from, To: to, Type: ch.Type, NewValue: ch.NewValue}
-				pairKey := from + "->" + to
+				lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue}
 				switch ch.Type {
 				case Added:
-					if liftedSeen[pairKey] {
-						continue
+					// Only deduplicate lifted relationships. When multiple
+					// child relationships (e.g., a.x→b.z and a.y→b.z) are
+					// lifted to the same parent pair (a→b), only one connector
+					// should be created. Direct (non-lifted) relationships
+					// with the same pair must not be deduplicated. (#142)
+					if isLifted {
+						pairKey := from + "->" + to
+						if liftedSeen[pairKey] {
+							continue
+						}
+						liftedSeen[pairKey] = true
 					}
-					liftedSeen[pairKey] = true
 					applyRelAdded(lifted, viewID, page, templates, result)
 				case Modified:
-					page.UpdateConnectorLabel(from, to, ch.NewValue)
+					page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
 					result.ConnectorsUpdated++
 				}
 			}
@@ -515,7 +522,7 @@ func applyRelAdded(
 	tgtRef := scopedCellID(viewID, ch.To)
 
 	// Skip if connector already exists to prevent duplicates. (#119)
-	if page.FindConnector(srcRef, tgtRef) != nil {
+	if page.FindConnector(srcRef, tgtRef, ch.Index) != nil {
 		return
 	}
 
@@ -526,6 +533,7 @@ func applyRelAdded(
 		Label:     ch.NewValue,
 		SourceRef: srcRef,
 		TargetRef: tgtRef,
+		Index:     ch.Index,
 	}
 	page.CreateConnector(data, style)
 	result.ConnectorsCreated++

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -268,7 +268,7 @@ func TestApplyForward_NewRelationship(t *testing.T) {
 	}
 
 	page := doc.Pages()[0]
-	if page.FindConnector("frontend", "backend") == nil {
+	if page.FindConnector("frontend", "backend", 0) == nil {
 		t.Fatal("connector 'frontend→backend' not found")
 	}
 }
@@ -591,5 +591,119 @@ func TestApplyForward_NoDuplicateElements(t *testing.T) {
 	// Should report 0 elements created (already exists).
 	if result.ElementsCreated != 0 {
 		t.Errorf("expected 0 elements created, got %d", result.ElementsCreated)
+	}
+}
+
+// TestApplyForward_MultipleRelationshipsSamePair verifies that two
+// relationships between the same pair of elements create two separate
+// connectors with distinct IDs. Regression test for #142.
+func TestApplyForward_MultipleRelationshipsSamePair(t *testing.T) {
+	doc := emptyDoc()
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+			{From: "a", To: "b", Label: "calls"},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "a", Type: Added},
+			{ID: "b", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "uses"},
+			{From: "a", To: "b", Index: 1, Type: Added, NewValue: "calls"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if result.ConnectorsCreated != 2 {
+		t.Fatalf("expected 2 connectors created, got %d", result.ConnectorsCreated)
+	}
+
+	page := doc.Pages()[0]
+	conns := page.FindAllConnectors()
+	if len(conns) != 2 {
+		t.Fatalf("expected 2 connectors on page, got %d", len(conns))
+	}
+
+	// Verify each connector has the correct label.
+	conn0 := page.FindConnector("a", "b", 0)
+	if conn0 == nil {
+		t.Fatal("connector index=0 not found")
+	}
+	if got := conn0.SelectAttrValue("value", ""); got != "uses" {
+		t.Errorf("connector 0 label = %q, want %q", got, "uses")
+	}
+
+	conn1 := page.FindConnector("a", "b", 1)
+	if conn1 == nil {
+		t.Fatal("connector index=1 not found")
+	}
+	if got := conn1.SelectAttrValue("value", ""); got != "calls" {
+		t.Errorf("connector 1 label = %q, want %q", got, "calls")
+	}
+}
+
+// TestApplyForward_MultipleRelsSamePairNoDuplicateConnectors verifies that
+// when connectors already exist for multiple relationships between the same
+// pair, forward sync does not create duplicates. Regression test for #142/#119.
+func TestApplyForward_MultipleRelsSamePairNoDuplicateConnectors(t *testing.T) {
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "b", CellID: "b", Kind: "container", Title: "B",
+	}, "")
+	// Pre-existing connectors.
+	page.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "uses",
+		SourceRef: "a", TargetRef: "b", Index: 0,
+	}, "endArrow=block;")
+	page.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "calls",
+		SourceRef: "a", TargetRef: "b", Index: 1,
+	}, "endArrow=block;")
+
+	if len(page.FindAllConnectors()) != 2 {
+		t.Fatalf("precondition: expected 2 connectors, got %d", len(page.FindAllConnectors()))
+	}
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+			{From: "a", To: "b", Label: "calls"},
+		},
+	}
+	ts := minimalTemplates(t)
+
+	// Simulate sync state deletion: both relationships appear as Added.
+	cs := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "uses"},
+			{From: "a", To: "b", Index: 1, Type: Added, NewValue: "calls"},
+		},
+	}
+
+	result := ApplyForward(cs, doc, ts, m)
+
+	if len(page.FindAllConnectors()) != 2 {
+		t.Errorf("expected 2 connectors (no duplicates), got %d", len(page.FindAllConnectors()))
+	}
+	if result.ConnectorsCreated != 0 {
+		t.Errorf("expected 0 connectors created, got %d", result.ConnectorsCreated)
 	}
 }

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -63,7 +63,7 @@ func TestApplyForward_ElementOnCorrectViewPage(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 
@@ -121,7 +121,7 @@ func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 
@@ -129,7 +129,7 @@ func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
 
 	// Context page: customer→webshop connector should exist (using scoped cell IDs).
 	contextPage := doc.GetPage("view-context")
-	if contextPage.FindConnector("context--customer", "context--webshop") == nil {
+	if contextPage.FindConnector("context--customer", "context--webshop", 0) == nil {
 		t.Error("expected connector customer→webshop on context page")
 	}
 
@@ -140,7 +140,7 @@ func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
 
 	// Container page: api→db connector should exist (using scoped cell IDs).
 	containerPage := doc.GetPage("view-containers")
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) == nil {
 		t.Error("expected connector api→db on container page")
 	}
 }
@@ -188,8 +188,8 @@ func TestApplyForward_RelationshipLifting(t *testing.T) {
 			{ID: "webshop.api", Type: Added},
 		},
 		ModelRelationshipChanges: []RelationshipChange{
-			{From: "customer", To: "webshop.frontend", Type: Added, NewValue: "uses"},
-			{From: "webshop.frontend", To: "webshop.api", Type: Added, NewValue: "calls"},
+			{From: "customer", To: "webshop.frontend", Index: 0, Type: Added, NewValue: "uses"},
+			{From: "webshop.frontend", To: "webshop.api", Index: 1, Type: Added, NewValue: "calls"},
 		},
 	}
 
@@ -225,7 +225,7 @@ func TestApplyForward_RelationshipLifting(t *testing.T) {
 	if containerPage == nil {
 		t.Fatal("container page not found")
 	}
-	if containerPage.FindConnector("containers--customer", "containers--webshop.frontend") == nil {
+	if containerPage.FindConnector("containers--customer", "containers--webshop.frontend", 0) == nil {
 		t.Error("expected original connector customer→webshop.frontend on container page")
 	}
 }
@@ -268,8 +268,8 @@ func TestApplyForward_RelationshipLiftingDedup(t *testing.T) {
 			{ID: "b.z", Type: Added},
 		},
 		ModelRelationshipChanges: []RelationshipChange{
-			{From: "a.x", To: "b.z", Type: Added, NewValue: "calls"},
-			{From: "a.y", To: "b.z", Type: Added, NewValue: "reads"},
+			{From: "a.x", To: "b.z", Index: 0, Type: Added, NewValue: "calls"},
+			{From: "a.y", To: "b.z", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 
@@ -384,7 +384,7 @@ func TestApplyForward_DeletedElementRemovedFromViewPages(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 	ApplyForward(csAdd, doc, ts, m)
@@ -413,7 +413,7 @@ func TestApplyForward_DeletedElementRemovedFromViewPages(t *testing.T) {
 			{ID: "webshop.db", Type: Deleted},
 		},
 		ModelRelationshipChanges: []RelationshipChange{
-			{From: "webshop.api", To: "webshop.db", Type: Deleted},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Deleted},
 		},
 	}
 	result := ApplyForward(csDel, doc, ts, m)
@@ -446,14 +446,14 @@ func TestApplyForward_DeletedRelationshipRemovedFromViewPages(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 	ApplyForward(csAdd, doc, ts, m)
 
 	// Verify connector exists before deletion.
 	containerPage := doc.GetPage("view-containers")
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) == nil {
 		t.Fatal("precondition: api→db connector should exist on container page")
 	}
 
@@ -464,13 +464,13 @@ func TestApplyForward_DeletedRelationshipRemovedFromViewPages(t *testing.T) {
 
 	csDel := &ChangeSet{
 		ModelRelationshipChanges: []RelationshipChange{
-			{From: "webshop.api", To: "webshop.db", Type: Deleted},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Deleted},
 		},
 	}
 	result := ApplyForward(csDel, doc, ts, m)
 
 	// The connector should be removed from the container page.
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) != nil {
 		t.Error("api→db connector should be removed from container page after deletion")
 	}
 
@@ -562,7 +562,7 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 	ApplyForward(csAdd, doc, ts, m)
@@ -575,7 +575,7 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 	if containerPage.FindElement("webshop.db") == nil {
 		t.Fatal("precondition: webshop.db should exist on container page")
 	}
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) == nil {
 		t.Fatal("precondition: api→db connector should exist on container page")
 	}
 
@@ -598,7 +598,7 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 	}
 
 	// Connectors referencing the excluded element should also be removed.
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) != nil {
 		t.Error("api→db connector should be removed after webshop.db is excluded from view")
 	}
 
@@ -639,7 +639,7 @@ func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
 		},
 		ModelRelationshipChanges: []RelationshipChange{
 			{From: "customer", To: "webshop", Type: Added, NewValue: "uses"},
-			{From: "webshop.api", To: "webshop.db", Type: Added, NewValue: "reads"},
+			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
 	ApplyForward(csAdd, doc, ts, m)
@@ -649,7 +649,7 @@ func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
 	if containerPage.FindElement("webshop.db") == nil {
 		t.Fatal("precondition: webshop.db should exist on container page")
 	}
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") == nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) == nil {
 		t.Fatal("precondition: api→db connector should exist on container page")
 	}
 
@@ -681,13 +681,13 @@ func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
 	}
 
 	// The connector referencing the deleted element should also be removed.
-	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db") != nil {
+	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) != nil {
 		t.Error("api→db connector should be removed when webshop.db is deleted")
 	}
 
 	// The customer→webshop connector on the context page should be unaffected.
 	contextPage := doc.GetPage("view-context")
-	if contextPage.FindConnector("context--customer", "context--webshop") == nil {
+	if contextPage.FindConnector("context--customer", "context--webshop", 0) == nil {
 		t.Error("customer→webshop connector on context page should be unaffected")
 	}
 

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -86,13 +86,25 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 	switch ch.Type {
 	case Modified:
 		updated := false
-		for i, r := range m.Relationships {
+		if ch.Index >= 0 && ch.Index < len(m.Relationships) {
+			r := m.Relationships[ch.Index]
 			if r.From == ch.From && r.To == ch.To {
 				if ch.Field == "label" {
-					m.Relationships[i].Label = ch.NewValue
+					m.Relationships[ch.Index].Label = ch.NewValue
 				}
 				updated = true
-				break
+			}
+		}
+		// Fallback: search by from/to if index does not match.
+		if !updated {
+			for i, r := range m.Relationships {
+				if r.From == ch.From && r.To == ch.To {
+					if ch.Field == "label" {
+						m.Relationships[i].Label = ch.NewValue
+					}
+					updated = true
+					break
+				}
 			}
 		}
 		if updated {
@@ -104,7 +116,17 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 
 	case Deleted:
 		before := len(m.Relationships)
-		m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
+		if ch.Index >= 0 && ch.Index < len(m.Relationships) {
+			r := m.Relationships[ch.Index]
+			if r.From == ch.From && r.To == ch.To {
+				m.Relationships = append(m.Relationships[:ch.Index], m.Relationships[ch.Index+1:]...)
+			} else {
+				// Fallback: filter by from/to.
+				m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
+			}
+		} else {
+			m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
+		}
 		if len(m.Relationships) < before {
 			result.RelationshipsDeleted++
 		}

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -34,6 +34,7 @@ type ElementState struct {
 type RelationshipState struct {
 	From  string `json:"from"`
 	To    string `json:"to"`
+	Index int    `json:"index"`
 	Label string `json:"label,omitempty"`
 	Kind  string `json:"kind,omitempty"`
 }
@@ -130,10 +131,11 @@ func BuildState(m *model.BausteinsichtModel, _ *drawio.Document, modelPath, draw
 	}
 
 	rels := make([]RelationshipState, 0, len(m.Relationships))
-	for _, r := range m.Relationships {
+	for i, r := range m.Relationships {
 		rels = append(rels, RelationshipState{
 			From:  r.From,
 			To:    r.To,
+			Index: i,
 			Label: r.Label,
 			Kind:  r.Kind,
 		})


### PR DESCRIPTION
## Summary
- Connector IDs now include a relationship index (`rel-{from}-{to}-{index}`) to prevent ID collisions when multiple relationships exist between the same element pair
- Duplicate relationship validation updated to use `(from, to, kind, label)` signature, allowing distinct relationships between the same pair
- Lifted-relationship deduplication no longer incorrectly suppresses direct relationships

Closes #142

## Test plan
- [x] Unit tests for index-based connector ID generation
- [x] Unit tests for multiple relationships between same pair in forward sync
- [x] Unit tests for duplicate detection with different kind/label combinations
- [x] `make test-race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)