### PR TITLE
feat: add export command for diagram views

### DIFF
--- a/cmd/bausteinsicht/export.go
+++ b/cmd/bausteinsicht/export.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
+	"github.com/docToolchain/Bauteinsicht/internal/export"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export diagram views to PNG or SVG",
+		Long:  "Exports draw.io diagram pages to image files using the draw.io CLI.",
+		RunE:  runExport,
+	}
+	cmd.Flags().String("image-format", "png", "Image format: png or svg")
+	cmd.Flags().String("view", "", "Export only this view (by key)")
+	cmd.Flags().String("output", ".", "Output directory")
+	cmd.Flags().Bool("embed-diagram", false, "Embed draw.io XML source in output")
+	return cmd
+}
+
+type exportResultJSON struct {
+	Files   []string `json:"files"`
+	Errors  []string `json:"errors,omitempty"`
+	Success bool     `json:"success"`
+}
+
+func runExport(cmd *cobra.Command, _ []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+	verbose, _ := cmd.Flags().GetBool("verbose")
+	imageFormat, _ := cmd.Flags().GetString("image-format")
+	viewFilter, _ := cmd.Flags().GetString("view")
+	outputDir, _ := cmd.Flags().GetString("output")
+	embedDiagram, _ := cmd.Flags().GetBool("embed-diagram")
+
+	// Validate image format.
+	if imageFormat != "png" && imageFormat != "svg" {
+		return exitWithCode(fmt.Errorf("unsupported image format %q; use png or svg", imageFormat), 2)
+	}
+
+	// Auto-detect model file.
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	// Derive drawio path from model path.
+	dir := filepath.Dir(modelPath)
+	drawioPath := filepath.Join(dir, "architecture.drawio")
+
+	// Load model to get view keys.
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	if len(m.Views) == 0 {
+		return exitWithCode(fmt.Errorf("no views to export"), 2)
+	}
+
+	// If a specific view was requested, check it exists.
+	if viewFilter != "" {
+		if _, ok := m.Views[viewFilter]; !ok {
+			return exitWithCode(fmt.Errorf("view %q not found in model", viewFilter), 2)
+		}
+	}
+
+	// Load draw.io document to get page ordering.
+	doc, err := drawio.LoadDocument(drawioPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading draw.io file: %w", err), 2)
+	}
+
+	// Detect draw.io CLI binary.
+	binary, err := export.DetectDrawioBinary()
+	if err != nil {
+		return exitWithCode(err, 2)
+	}
+
+	if verbose && format != "json" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Using draw.io CLI: %s\n", binary)
+	}
+
+	// Ensure output directory exists.
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return exitWithCode(fmt.Errorf("creating output directory: %w", err), 2)
+	}
+
+	// Build the list of pages to export.
+	pages := doc.Pages()
+	type viewExport struct {
+		key       string
+		pageIndex int // 1-based
+	}
+	var exports []viewExport
+
+	for viewKey := range m.Views {
+		if viewFilter != "" && viewKey != viewFilter {
+			continue
+		}
+		pageID := "view-" + viewKey
+		for i, p := range pages {
+			if p.ID() == pageID {
+				exports = append(exports, viewExport{key: viewKey, pageIndex: i + 1})
+				break
+			}
+		}
+	}
+
+	if len(exports) == 0 {
+		return exitWithCode(fmt.Errorf("no matching pages found in draw.io file"), 2)
+	}
+
+	// Export each page.
+	var files []string
+	var exportErrors []string
+
+	for _, ex := range exports {
+		outFile := filepath.Join(outputDir, export.OutputFileName(ex.key, imageFormat))
+
+		if verbose && format != "json" {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Exporting view %q to %s\n", ex.key, outFile)
+		}
+
+		err := export.ExportPage(binary, export.ExportOptions{
+			Format:       imageFormat,
+			PageIndex:    ex.pageIndex,
+			OutputPath:   outFile,
+			EmbedDiagram: embedDiagram,
+			InputFile:    drawioPath,
+		})
+		if err != nil {
+			exportErrors = append(exportErrors, fmt.Sprintf("view %q: %v", ex.key, err))
+			continue
+		}
+		files = append(files, outFile)
+	}
+
+	// Output results.
+	if format == "json" {
+		result := exportResultJSON{
+			Files:   files,
+			Errors:  exportErrors,
+			Success: len(exportErrors) == 0,
+		}
+		out, _ := json.MarshalIndent(result, "", "  ")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+	} else {
+		for _, f := range files {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Exported: %s\n", f)
+		}
+		for _, e := range exportErrors {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "ERROR: %s\n", e)
+		}
+	}
+
+	if len(exportErrors) > 0 {
+		return exitWithCode(fmt.Errorf("%d export(s) failed", len(exportErrors)), 1)
+	}
+	return nil
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -44,6 +44,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newValidateCmd())
 	rootCmd.AddCommand(newAddCmd())
 	rootCmd.AddCommand(newWatchCmd())
+	rootCmd.AddCommand(newExportCmd())
 
 	return rootCmd
 }

--- a/docs/plans/2026-03-02-export-command-design.md
+++ b/docs/plans/2026-03-02-export-command-design.md
@@ -1,0 +1,66 @@
+# Design: `bausteinsicht export` command
+
+## Purpose
+
+Export draw.io diagram pages to PNG or SVG using the draw.io CLI. Exported files can be embedded in AsciiDoc/HTML/Markdown as rendered images, and if `--embed-diagram` is used, they can also be re-opened in draw.io for editing.
+
+## CLI Interface
+
+```
+bausteinsicht export [--format png|svg] [--view <key>] [--output <dir>] [--embed-diagram]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format` | `png` | Export format: `png` or `svg` |
+| `--view` | (all) | Export only one view by key |
+| `--output` | `.` | Output directory |
+| `--embed-diagram` | false | Embed draw.io XML source in output |
+
+Global flags `--model`, `--format` (text/json), `--verbose` also apply.
+
+Note: the export-specific `--format` flag shadows the global one. The command uses a local `--format` for the image format, while the global `--format` controls output messaging (text vs json).
+
+## Output Naming
+
+Files are named `architecture-<view-key>.<ext>`:
+- `architecture-context.png`
+- `architecture-containers.svg`
+
+## draw.io CLI Detection
+
+Checked in order:
+1. `drawio-export` (devcontainer wrapper with xvfb)
+2. `drawio` (native install)
+3. Error: "draw.io CLI not found. Install from https://www.drawio.com/"
+
+## Architecture
+
+### New files
+
+- `cmd/bausteinsicht/export.go` — Cobra command definition
+- `cmd/bausteinsicht/export_test.go` — Command-level tests
+- `internal/export/export.go` — Core export logic (CLI detection, argument building, execution)
+- `internal/export/export_test.go` — Unit tests
+
+### Flow
+
+1. Load model (to get view keys and titles)
+2. Load draw.io document (to get page count and IDs)
+3. Detect draw.io CLI binary
+4. For each view page, run: `<drawio-bin> --export --format <fmt> --page-index <N> --output <file> [--embed-diagram] architecture.drawio`
+5. Report results (files created, any errors)
+
+Page index is 1-based. Views are matched by page ID (`view-<key>`).
+
+### Error Handling
+
+- draw.io CLI not found: exit 2 with install hint
+- Export fails for one page: log error, continue with remaining pages, exit 1 at end
+- No views in model: exit 2 "no views to export"
+- `--view` key not found: exit 2 "view not found"
+
+## Testing Strategy
+
+- Unit tests: CLI detection logic (mock exec.LookPath), argument building, output path generation
+- Integration test: skip unless draw.io CLI is available (`testing.Short()` or env var)

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,61 @@
+// Package export handles exporting draw.io diagrams to PNG/SVG using the
+// draw.io CLI.
+package export
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+)
+
+// ExportOptions configures a single page export operation.
+type ExportOptions struct {
+	Format       string // "png" or "svg"
+	PageIndex    int    // 1-based page index
+	OutputPath   string // full path to output file
+	EmbedDiagram bool   // embed draw.io XML source in output
+	InputFile    string // path to the .drawio file
+}
+
+// DetectDrawioBinary finds the draw.io CLI binary. It checks for
+// "drawio-export" first (devcontainer wrapper with xvfb), then "drawio".
+func DetectDrawioBinary() (string, error) {
+	for _, name := range []string{"drawio-export", "drawio"} {
+		path, err := exec.LookPath(name)
+		if err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("draw.io CLI not found; install from https://www.drawio.com/")
+}
+
+// BuildExportArgs constructs the command-line arguments for a draw.io export.
+func BuildExportArgs(opts ExportOptions) []string {
+	args := []string{
+		"--export",
+		"--format", opts.Format,
+		"--page-index", strconv.Itoa(opts.PageIndex),
+		"--output", opts.OutputPath,
+	}
+	if opts.EmbedDiagram {
+		args = append(args, "--embed-diagram")
+	}
+	args = append(args, opts.InputFile)
+	return args
+}
+
+// OutputFileName returns the canonical output file name for a view export.
+func OutputFileName(viewKey, format string) string {
+	return fmt.Sprintf("architecture-%s.%s", viewKey, format)
+}
+
+// ExportPage runs the draw.io CLI to export a single page.
+func ExportPage(binary string, opts ExportOptions) error {
+	args := BuildExportArgs(opts)
+	cmd := exec.Command(binary, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("draw.io export failed: %w\nOutput: %s", err, string(output))
+	}
+	return nil
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,156 @@
+package export
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectDrawioBinary_FindsDrawioExport(t *testing.T) {
+	// Create a fake drawio-export in a temp dir.
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "drawio-export")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", dir+":"+origPath)
+
+	bin, err := DetectDrawioBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != fakeBin {
+		t.Errorf("expected %q, got %q", fakeBin, bin)
+	}
+}
+
+func TestDetectDrawioBinary_FallsBackToDrawio(t *testing.T) {
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "drawio")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Set PATH to only the temp dir so drawio-export is NOT found.
+	t.Setenv("PATH", dir)
+
+	bin, err := DetectDrawioBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != fakeBin {
+		t.Errorf("expected %q, got %q", fakeBin, bin)
+	}
+}
+
+func TestDetectDrawioBinary_ErrorWhenNotFound(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := DetectDrawioBinary()
+	if err == nil {
+		t.Error("expected error when no draw.io binary found")
+	}
+}
+
+func TestBuildExportArgs(t *testing.T) {
+	args := BuildExportArgs(ExportOptions{
+		Format:       "png",
+		PageIndex:    2,
+		OutputPath:   "/tmp/out.png",
+		EmbedDiagram: true,
+		InputFile:    "arch.drawio",
+	})
+
+	expected := []string{
+		"--export",
+		"--format", "png",
+		"--page-index", "2",
+		"--output", "/tmp/out.png",
+		"--embed-diagram",
+		"arch.drawio",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+func TestBuildExportArgs_WithoutEmbed(t *testing.T) {
+	args := BuildExportArgs(ExportOptions{
+		Format:       "svg",
+		PageIndex:    1,
+		OutputPath:   "/tmp/out.svg",
+		EmbedDiagram: false,
+		InputFile:    "arch.drawio",
+	})
+
+	for _, arg := range args {
+		if arg == "--embed-diagram" {
+			t.Error("--embed-diagram should not be present when EmbedDiagram is false")
+		}
+	}
+}
+
+func TestOutputFileName(t *testing.T) {
+	tests := []struct {
+		viewKey string
+		format  string
+		want    string
+	}{
+		{"context", "png", "architecture-context.png"},
+		{"containers", "svg", "architecture-containers.svg"},
+		{"my-view", "png", "architecture-my-view.png"},
+	}
+	for _, tt := range tests {
+		got := OutputFileName(tt.viewKey, tt.format)
+		if got != tt.want {
+			t.Errorf("OutputFileName(%q, %q) = %q, want %q", tt.viewKey, tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestExportPage_Integration(t *testing.T) {
+	// Skip if draw.io CLI is not available.
+	if _, err := exec.LookPath("drawio-export"); err != nil {
+		if _, err := exec.LookPath("drawio"); err != nil {
+			t.Skip("draw.io CLI not available, skipping integration test")
+		}
+	}
+
+	// We need a real drawio file to test with.
+	// Use the project's test data or init a fresh one.
+	drawioFile := filepath.Join("..", "..", "internal", "drawio", "testdata", "simple-diagram.drawio")
+	if _, err := os.Stat(drawioFile); err != nil {
+		t.Skipf("test drawio file not found: %v", err)
+	}
+
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "test-export.png")
+
+	bin, err := DetectDrawioBinary()
+	if err != nil {
+		t.Fatalf("DetectDrawioBinary: %v", err)
+	}
+
+	err = ExportPage(bin, ExportOptions{
+		Format:     "png",
+		PageIndex:  1,
+		OutputPath: outFile,
+		InputFile:  drawioFile,
+	})
+	if err != nil {
+		t.Fatalf("ExportPage: %v", err)
+	}
+
+	info, err := os.Stat(outFile)
+	if err != nil {
+		t.Fatalf("output file not found: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("output file is empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bausteinsicht export` command that exports draw.io diagram pages to PNG or SVG using the draw.io CLI
- Auto-detects `drawio-export` (devcontainer xvfb wrapper) or `drawio` binary
- Supports `--image-format`, `--view`, `--output`, and `--embed-diagram` flags
- JSON output format supported via global `--format json` flag

## New files
- `internal/export/export.go` — core export logic (CLI detection, argument building, page export)
- `internal/export/export_test.go` — unit tests + integration test
- `cmd/bausteinsicht/export.go` — Cobra command definition
- `docs/plans/2026-03-02-export-command-design.md` — design document

## Test plan
- [x] Unit tests for `DetectDrawioBinary` (finds drawio-export, falls back to drawio, errors when missing)
- [x] Unit tests for `BuildExportArgs` (with/without embed-diagram)
- [x] Unit tests for `OutputFileName`
- [x] Integration test with real draw.io CLI (skips when unavailable)
- [x] All existing tests pass
- [x] Race detector clean
- [x] golangci-lint clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)