### PR TITLE
fix: handle zero-byte sync state file gracefully

### DIFF
--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -53,6 +53,14 @@ func LoadState(path string) (*SyncState, error) {
 		return nil, fmt.Errorf("LoadState %q: %w", path, err)
 	}
 
+	// Treat a zero-byte file as empty/missing state (e.g. truncated write).
+	if len(data) == 0 {
+		return &SyncState{
+			Elements:      make(map[string]ElementState),
+			Relationships: []RelationshipState{},
+		}, nil
+	}
+
 	var state SyncState
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("LoadState %q: %w", path, err)

--- a/internal/sync/state_test.go
+++ b/internal/sync/state_test.go
@@ -26,6 +26,30 @@ func TestLoadState_MissingFileReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestLoadState_ZeroByteFileReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bausteinsicht-sync")
+
+	// Create a zero-byte file (simulates truncated/corrupt sync state).
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("expected no error for zero-byte file, got: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if len(state.Elements) != 0 {
+		t.Errorf("expected empty elements, got %d", len(state.Elements))
+	}
+	if len(state.Relationships) != 0 {
+		t.Errorf("expected empty relationships, got %d", len(state.Relationships))
+	}
+}
+
 func TestSaveLoadState_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".bausteinsicht-sync")


### PR DESCRIPTION
## Summary
- Treat a zero-byte `.bausteinsicht-sync` file the same as a missing file, returning an empty `SyncState` instead of failing with a JSON parse error
- Prevents the CLI from erroring out when the sync state file has been truncated (e.g. interrupted write)
- Adds a dedicated test `TestLoadState_ZeroByteFileReturnsEmpty` following TDD (red-green)

Closes #169

## Test plan
- [x] New test `TestLoadState_ZeroByteFileReturnsEmpty` creates a zero-byte file and verifies `LoadState` returns empty state without error
- [x] All existing tests pass with `make test-race` (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)