### PR TITLE
fix: reject null JSON root as invalid model

### DIFF
--- a/internal/model/loader.go
+++ b/internal/model/loader.go
@@ -16,6 +16,14 @@ func Load(path string) (*BausteinsichtModel, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 	clean := StripJSONC(data)
+
+	// Reject null JSON root — json.Unmarshal silently accepts "null"
+	// and produces a zero-value struct, which passes validation vacuously.
+	trimmed := strings.TrimSpace(string(clean))
+	if trimmed == "null" || trimmed == "" {
+		return nil, fmt.Errorf("parsing %s: model file is empty or contains a null JSON root", path)
+	}
+
 	var m BausteinsichtModel
 	if err := json.Unmarshal(clean, &m); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", path, err)

--- a/internal/model/loader_test.go
+++ b/internal/model/loader_test.go
@@ -242,3 +242,16 @@ func TestLoad_ModelWithBOM(t *testing.T) {
 		t.Error("expected non-empty model")
 	}
 }
+
+func TestLoad_NullJSONRoot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "null-model.jsonc")
+	if err := os.WriteFile(path, []byte("null"), 0644); err != nil {
+		t.Fatalf("failed to write null model: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected error for null JSON root, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes `bausteinsicht validate` silently accepting `null` as a valid model file
- Adds an explicit check in `Load()` to reject null/empty JSON before unmarshaling
- Adds a test case `TestLoad_NullJSONRoot` to verify the fix

Closes #165

## Test plan
- [x] New test `TestLoad_NullJSONRoot` confirms `Load()` returns an error for `null` JSON
- [x] All existing tests pass with `make test-race`
- [x] `go vet` and `staticcheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)