### PR TITLE
fix: allow multiple relationships between same pair with different kinds

### DIFF
--- a/cmd/bausteinsicht/add_relationship.go
+++ b/cmd/bausteinsicht/add_relationship.go
@@ -68,8 +68,8 @@ func runAddRelationship(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, r := range m.Relationships {
-		if r.From == from && r.To == to {
-			return exitWithCode(fmt.Errorf("relationship %s -> %s already exists", from, to), 1)
+		if r.From == from && r.To == to && r.Kind == kind {
+			return exitWithCode(fmt.Errorf("relationship %s -> %s (kind %q) already exists", from, to, kind), 1)
 		}
 	}
 

--- a/cmd/bausteinsicht/add_relationship_test.go
+++ b/cmd/bausteinsicht/add_relationship_test.go
@@ -174,6 +174,7 @@ func TestAddRelationshipDuplicateBlocked(t *testing.T) {
 		"--model", modelPath,
 		"--from", "webshop.api",
 		"--to", "webshop.db",
+		"--kind", "uses",
 	})
 	if err := cmd1.Execute(); err != nil {
 		t.Fatalf("first add failed: %v", err)
@@ -184,6 +185,7 @@ func TestAddRelationshipDuplicateBlocked(t *testing.T) {
 		"--model", modelPath,
 		"--from", "webshop.api",
 		"--to", "webshop.db",
+		"--kind", "uses",
 		"--label", "also reads",
 	})
 	cmd2.SilenceErrors = true
@@ -191,7 +193,7 @@ func TestAddRelationshipDuplicateBlocked(t *testing.T) {
 	err := cmd2.Execute()
 
 	if err == nil {
-		t.Fatal("expected error for duplicate relationship, got nil")
+		t.Fatal("expected error for duplicate relationship (same from, to, kind), got nil")
 	}
 
 	// Verify the duplicate was NOT added.
@@ -201,6 +203,52 @@ func TestAddRelationshipDuplicateBlocked(t *testing.T) {
 	}
 	if len(m.Relationships) != 1 {
 		t.Errorf("expected 1 relationship (duplicate blocked), got %d", len(m.Relationships))
+	}
+}
+
+func TestAddRelationshipDifferentKindAllowed(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeRelTestModel(t, dir)
+
+	// Add first relationship with kind "uses".
+	cmd1 := NewRootCmd()
+	cmd1.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--kind", "uses",
+		"--label", "reads from",
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first add failed: %v", err)
+	}
+
+	// Add second relationship with different kind "depends_on" — should succeed.
+	cmd2 := NewRootCmd()
+	cmd2.SetArgs([]string{"add", "relationship",
+		"--model", modelPath,
+		"--from", "webshop.api",
+		"--to", "webshop.db",
+		"--kind", "depends_on",
+		"--label", "depends on",
+	})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("second add with different kind should succeed, got: %v", err)
+	}
+
+	// Verify both relationships exist.
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Relationships) != 2 {
+		t.Fatalf("expected 2 relationships, got %d", len(m.Relationships))
+	}
+	if m.Relationships[0].Kind != "uses" {
+		t.Errorf("expected first relationship kind 'uses', got %q", m.Relationships[0].Kind)
+	}
+	if m.Relationships[1].Kind != "depends_on" {
+		t.Errorf("expected second relationship kind 'depends_on', got %q", m.Relationships[1].Kind)
 	}
 }
 


### PR DESCRIPTION
## Summary
- The duplicate check in `add relationship` only compared `from` and `to`, rejecting valid cases where the same element pair has relationships of different kinds (e.g. "uses" and "depends_on")
- Fixed by adding `&& r.Kind == kind` to the duplicate check condition
- Updated error message to include the kind for clarity

## Test plan
- [x] Added `TestAddRelationshipDifferentKindAllowed` — adds two relationships between the same pair with different kinds, asserts both are saved
- [x] Updated `TestAddRelationshipDuplicateBlocked` — now uses explicit `--kind` to verify true duplicates (same from, to, AND kind) are still rejected
- [x] All existing tests pass with `make test-race`

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)