### PR TITLE
fix: strip view prefix from cell IDs in reverse sync relationships

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -139,6 +139,16 @@ func stripScopedPrefix(cellID string) string {
 	return cellID
 }
 
+// resolveCellID maps a draw.io cell ID to a canonical element ID using the
+// cellToElem lookup table. If the cell ID is not in the table (e.g., because
+// the element was deleted), it falls back to stripping the scoped view prefix.
+func resolveCellID(cellID string, cellToElem map[string]string) string {
+	if elemID, ok := cellToElem[cellID]; ok {
+		return elemID
+	}
+	return stripScopedPrefix(cellID)
+}
+
 // buildCellIDToElemID builds a mapping from draw.io cell IDs to bausteinsicht
 // element IDs. When views are used, cell IDs are scoped (e.g., "context--customer")
 // while element IDs are un-scoped (e.g., "customer").
@@ -177,18 +187,8 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			// (e.g., "components--onlineshop.db" → "onlineshop.db") when
 			// the element was deleted and is no longer in cellToElem (#166).
 			// For legacy (non-view) documents the raw cell ID is used as-is.
-			from := fromCell
-			if elemID, ok := cellToElem[fromCell]; ok {
-				from = elemID
-			} else {
-				from = stripScopedPrefix(fromCell)
-			}
-			to := toCell
-			if elemID, ok := cellToElem[toCell]; ok {
-				to = elemID
-			} else {
-				to = stripScopedPrefix(toCell)
-			}
+			from := resolveCellID(fromCell, cellToElem)
+			to := resolveCellID(toCell, cellToElem)
 			// Extract the relationship index from the connector ID.
 			cellID := cell.SelectAttrValue("id", "")
 			index := parseConnectorIndex(cellID)

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -129,6 +129,16 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 	return result
 }
 
+// stripScopedPrefix removes the view prefix from a scoped cell ID.
+// Scoped cell IDs have the format "viewID--elemID" where "--" is the separator.
+// If the ID does not contain "--", it is returned unchanged (legacy documents).
+func stripScopedPrefix(cellID string) string {
+	if idx := strings.Index(cellID, "--"); idx >= 0 {
+		return cellID[idx+2:]
+	}
+	return cellID
+}
+
 // buildCellIDToElemID builds a mapping from draw.io cell IDs to bausteinsicht
 // element IDs. When views are used, cell IDs are scoped (e.g., "context--customer")
 // while element IDs are un-scoped (e.g., "customer").
@@ -163,14 +173,21 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 				continue
 			}
 			// Resolve scoped cell IDs to element IDs.
-			// Fall back to raw cell ID for legacy (non-view) documents.
+			// Fall back to stripping the view prefix from scoped cell IDs
+			// (e.g., "components--onlineshop.db" → "onlineshop.db") when
+			// the element was deleted and is no longer in cellToElem (#166).
+			// For legacy (non-view) documents the raw cell ID is used as-is.
 			from := fromCell
 			if elemID, ok := cellToElem[fromCell]; ok {
 				from = elemID
+			} else {
+				from = stripScopedPrefix(fromCell)
 			}
 			to := toCell
 			if elemID, ok := cellToElem[toCell]; ok {
 				to = elemID
+			} else {
+				to = stripScopedPrefix(toCell)
 			}
 			// Extract the relationship index from the connector ID.
 			cellID := cell.SelectAttrValue("id", "")

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
@@ -794,6 +795,116 @@ func TestDetectChanges_MultipleRelsSamePairLabelModified(t *testing.T) {
 	for _, ch := range cs.ModelRelationshipChanges {
 		if ch.From == "a" && ch.To == "b" && ch.Index == 0 && ch.Type == Modified {
 			t.Errorf("first relationship (index=0) should not be modified, got: %+v", ch)
+		}
+	}
+}
+
+// --- Scoped cell ID leak on element deletion (#166) ---
+
+func TestDetectChanges_DeletedElementConnectorUsesCanonicalIDs(t *testing.T) {
+	// Scenario: element "db" (scoped cell ID "components--onlineshop.db") was
+	// deleted from the draw.io document, but a connector referencing it via the
+	// scoped cell ID still exists. The connector's source/target should be
+	// resolved to canonical element IDs, not leaked as scoped cell IDs.
+	//
+	// Setup:
+	// - Model has elements "webapp" and "onlineshop.db" with a relationship.
+	// - State recorded the relationship from previous sync.
+	// - draw.io doc: "onlineshop.db" element was deleted, but a connector from
+	//   "components--webapp" to "components--onlineshop.db" remains.
+	//   "webapp" element still exists with bausteinsicht_id="webapp".
+	state := emptyState()
+	state.Elements["webapp"] = ElementState{Title: "WebApp", Kind: "container"}
+	state.Elements["onlineshop.db"] = ElementState{Title: "Database", Kind: "container"}
+	state.Relationships = []RelationshipState{
+		{From: "webapp", To: "onlineshop.db", Label: "reads"},
+	}
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"webapp": {Kind: "container", Title: "WebApp"},
+			"onlineshop": {Kind: "system", Title: "Onlineshop", Children: map[string]model.Element{
+				"db": {Kind: "container", Title: "Database"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "webapp", To: "onlineshop.db", Label: "reads"},
+		},
+	}
+
+	// Build draw.io doc manually: webapp exists (scoped), db is gone, connector remains.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-components", "Components View")
+	// webapp element with scoped cell ID
+	_ = page.CreateElement(drawio.ElementData{
+		ID:     "webapp",
+		CellID: "components--webapp",
+		Kind:   "container",
+		Title:  "WebApp",
+	}, "")
+	// Note: onlineshop.db element is NOT in the document (deleted).
+	// But the connector still references its scoped cell ID.
+	page.CreateConnector(drawio.ConnectorData{
+		From:      "webapp",
+		To:        "onlineshop.db",
+		SourceRef: "components--webapp",
+		TargetRef: "components--onlineshop.db",
+	}, "")
+
+	cs := DetectChanges(m, doc, state)
+
+	// Check all drawio relationship changes: none should contain scoped cell IDs.
+	for _, ch := range cs.DrawioRelationshipChanges {
+		if strings.Contains(ch.From, "--") {
+			t.Errorf("DrawioRelationshipChange.From contains scoped cell ID %q, expected canonical element ID", ch.From)
+		}
+		if strings.Contains(ch.To, "--") {
+			t.Errorf("DrawioRelationshipChange.To contains scoped cell ID %q, expected canonical element ID", ch.To)
+		}
+	}
+
+	// Also verify via ApplyReverse: if changes are applied, the model should
+	// not contain relationships with scoped cell IDs.
+	ApplyReverse(cs, m)
+	for _, rel := range m.Relationships {
+		if strings.Contains(rel.From, "--") {
+			t.Errorf("Model relationship From contains scoped cell ID %q after reverse sync", rel.From)
+		}
+		if strings.Contains(rel.To, "--") {
+			t.Errorf("Model relationship To contains scoped cell ID %q after reverse sync", rel.To)
+		}
+	}
+}
+
+func TestExtractDrawioRelationships_FallbackStripsViewPrefix(t *testing.T) {
+	// When a connector references a scoped cell ID that is NOT in the
+	// cellToElem map (e.g., because the element was deleted), the fallback
+	// should strip the view prefix ("viewID--") to recover the element ID.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-ctx", "Context View")
+	// Only "a" exists as an element. "b" was deleted.
+	_ = page.CreateElement(drawio.ElementData{
+		ID:     "a",
+		CellID: "ctx--a",
+		Kind:   "system",
+		Title:  "A",
+	}, "")
+	// Connector still references "ctx--b" which has no element in the doc.
+	page.CreateConnector(drawio.ConnectorData{
+		From:      "a",
+		To:        "b",
+		SourceRef: "ctx--a",
+		TargetRef: "ctx--b",
+	}, "")
+
+	rels := extractDrawioRelationships(doc)
+
+	for key, rel := range rels {
+		if strings.Contains(rel.From, "--") {
+			t.Errorf("relationship key=%s: From=%q contains scoped cell ID prefix", key, rel.From)
+		}
+		if strings.Contains(rel.To, "--") {
+			t.Errorf("relationship key=%s: To=%q contains scoped cell ID prefix", key, rel.To)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- When an element is deleted from draw.io, connectors referencing it via scoped cell IDs (e.g., `components--onlineshop.db`) could not be resolved through the `cellToElem` map, causing the raw scoped cell ID to leak into model relationships
- Added `stripScopedPrefix()` function that extracts the canonical element ID by removing the `viewID--` prefix when the `cellToElem` lookup fails
- Added two regression tests: one end-to-end test through `DetectChanges` + `ApplyReverse`, and one unit test for `extractDrawioRelationships` directly

## Test plan
- [x] New test `TestDetectChanges_DeletedElementConnectorUsesCanonicalIDs` verifies that deleting an element from draw.io does not leak scoped cell IDs into relationship changes or the model
- [x] New test `TestExtractDrawioRelationships_FallbackStripsViewPrefix` verifies the fallback path strips view prefixes from unresolvable cell IDs
- [x] Full test suite passes with race detector (`make test-race`)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)