### PR TITLE
fix: recover drawio file when all diagram pages were removed

### DIFF
--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
@@ -50,15 +51,21 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
 	}
 
-	// Load draw.io document. If the file was deleted, recreate it from the
-	// template and reset sync state so the forward sync repopulates it (#149).
+	// Load draw.io document. If the file was deleted or is an empty mxfile
+	// (no diagram pages — e.g., after all views were removed), recreate it
+	// from the template and reset sync state so forward sync repopulates it
+	// (#149, #175).
 	var recreated bool
 	doc, err := drawio.LoadDocument(drawioPath)
 	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
+		if !errors.Is(err, fs.ErrNotExist) && !isEmptyMxfileError(err) {
 			return exitWithCode(fmt.Errorf("loading draw.io file: %w", err), 2)
 		}
-		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: Draw.io file not found, recreating from template")
+		if errors.Is(err, fs.ErrNotExist) {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: Draw.io file not found, recreating from template")
+		} else {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "WARNING: Draw.io file has no diagram pages, recreating structure")
+		}
 		doc = drawio.NewDocument()
 		recreated = true
 	}
@@ -230,6 +237,13 @@ func saveModel(path string, m *model.BausteinsichtModel, result *bsync.SyncResul
 	}
 
 	return model.Save(path, m)
+}
+
+// isEmptyMxfileError returns true if the error indicates that the draw.io file
+// is a valid XML mxfile but contains no <diagram> elements. This happens when
+// all views are removed from the model and sync removes all diagram pages (#175).
+func isEmptyMxfileError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no <diagram> elements")
 }
 
 func printSyncSummary(s syncSummary) {

--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -771,6 +771,110 @@ func TestSyncRecreatesDeletedDrawioFile(t *testing.T) {
 	})
 }
 
+// TestSyncRecoversEmptyMxfile verifies that when all views are removed from the
+// model (causing sync to remove all diagram pages, leaving an empty <mxfile>),
+// a subsequent sync with views added back recovers by recreating the drawio
+// structure instead of failing permanently. Regression test for #175.
+func TestSyncRecoversEmptyMxfile(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init project.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// First sync to establish baseline state.
+	captureStdout(t, func() {
+		cmd2 := NewRootCmd()
+		cmd2.SetArgs([]string{"sync"})
+		if err := cmd2.Execute(); err != nil {
+			t.Fatalf("first sync failed: %v", err)
+		}
+	})
+
+	// Save the original model for later restoration.
+	originalModel, err := os.ReadFile("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("reading original model: %v", err)
+	}
+
+	// Remove all views AND elements from the model.
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+	if len(m.Views) == 0 {
+		t.Skip("init template has no views; cannot test empty mxfile recovery")
+	}
+
+	m.Views = map[string]model.View{}
+	m.Model = map[string]model.Element{}
+	m.Relationships = nil
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save emptied model: %v", err)
+	}
+
+	// Sync with empty model — this removes all view pages, leaving empty mxfile.
+	captureStdout(t, func() {
+		cmd3 := NewRootCmd()
+		cmd3.SetArgs([]string{"sync"})
+		if err := cmd3.Execute(); err != nil {
+			t.Fatalf("sync with empty model failed: %v", err)
+		}
+	})
+
+	// Verify the drawio file is now an empty mxfile (no diagrams).
+	drawioData, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatalf("reading drawio after empty sync: %v", err)
+	}
+	if strings.Contains(string(drawioData), "<diagram") {
+		t.Fatal("precondition: drawio should have no <diagram> elements after removing all views")
+	}
+
+	// Restore the original model with views and elements.
+	if err := os.WriteFile("architecture.jsonc", originalModel, 0644); err != nil {
+		t.Fatalf("restoring model: %v", err)
+	}
+
+	// Sync again — this should recover from the empty mxfile, NOT fail.
+	captureStdout(t, func() {
+		cmd4 := NewRootCmd()
+		cmd4.SetArgs([]string{"sync"})
+		if err := cmd4.Execute(); err != nil {
+			t.Fatalf("sync after restoring model failed (should recover empty mxfile): %v", err)
+		}
+	})
+
+	// Verify the drawio file was recovered and has content.
+	afterRecovery, err := os.ReadFile("architecture.drawio")
+	if err != nil {
+		t.Fatalf("reading drawio after recovery: %v", err)
+	}
+	if !strings.Contains(string(afterRecovery), "<diagram") {
+		t.Error("recovered drawio should contain <diagram> elements")
+	}
+	if !strings.Contains(string(afterRecovery), "Customer") {
+		t.Error("recovered drawio should contain model elements (e.g., Customer)")
+	}
+
+	// A subsequent sync should be a no-op.
+	captureStdout(t, func() {
+		cmd5 := NewRootCmd()
+		cmd5.SetArgs([]string{"sync"})
+		if err := cmd5.Execute(); err != nil {
+			t.Fatalf("follow-up sync after recovery failed: %v", err)
+		}
+	})
+}
+
 // TestSyncRecreatesDeletedDrawioFileWithCustomTemplate verifies that when the
 // draw.io file is deleted and a custom template path is specified, the file is
 // recreated using the custom template.

--- a/cmd/bausteinsicht/watch.go
+++ b/cmd/bausteinsicht/watch.go
@@ -98,16 +98,35 @@ func doSync(changedFile, modelPath, drawioPath, templatePath string) {
 		return
 	}
 
+	// Load draw.io document. If the file is an empty mxfile (no diagram
+	// pages — e.g., after all views were removed), recreate it and reset
+	// sync state (#175).
+	var watchRecreated bool
 	doc, err := drawio.LoadDocument(drawioPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR loading draw.io file: %v\n", err)
-		return
+		if isEmptyMxfileError(err) {
+			fmt.Fprintln(os.Stderr, "WARNING: Draw.io file has no diagram pages, recreating structure")
+			doc = drawio.NewDocument()
+			watchRecreated = true
+		} else {
+			fmt.Fprintf(os.Stderr, "ERROR loading draw.io file: %v\n", err)
+			return
+		}
 	}
 
-	state, err := bsync.LoadState(statePath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR loading sync state: %v\n", err)
-		return
+	var state *bsync.SyncState
+	if watchRecreated {
+		_ = os.Remove(statePath)
+		state = &bsync.SyncState{
+			Elements:      make(map[string]bsync.ElementState),
+			Relationships: []bsync.RelationshipState{},
+		}
+	} else {
+		state, err = bsync.LoadState(statePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR loading sync state: %v\n", err)
+			return
+		}
 	}
 
 	var tmpl *drawio.TemplateSet


### PR DESCRIPTION
## Summary

- When all views are removed from the model and `sync` runs, all diagram pages are removed leaving an empty `<mxfile>`. Subsequent syncs failed permanently with "not a valid draw.io file (no `<diagram>` elements)".
- The fix detects this specific error in both `sync` and `watch` commands, and treats it like a deleted file: creates a fresh document and resets sync state so forward sync can repopulate diagrams.
- This is consistent with the existing recovery for deleted drawio files (#149).

Closes #175

## Test plan

- [x] New test `TestSyncRecoversEmptyMxfile`: init, sync, remove all views/elements, sync (creates empty mxfile), restore model, sync again -- assert recovery succeeds
- [x] All existing tests pass (`make test-race`)
- [x] `go vet` and `staticcheck` pass with no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)