### PR TITLE
fix: validate model before sync to catch invalid view patterns

### DIFF
--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -51,6 +51,16 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
 	}
 
+	// Validate model before syncing to catch invalid view include/exclude
+	// patterns and other consistency errors. Without this, typos like
+	// "customer." (trailing dot) silently remove elements from draw.io. (#176)
+	if validationErrs := model.Validate(m); len(validationErrs) > 0 {
+		for _, ve := range validationErrs {
+			fmt.Fprintln(os.Stderr, "ERROR:", ve)
+		}
+		return exitWithCode(fmt.Errorf("model validation failed with %d error(s); fix the model before syncing", len(validationErrs)), 1)
+	}
+
 	// Load draw.io document. If the file was deleted or is an empty mxfile
 	// (no diagram pages — e.g., after all views were removed), recreate it
 	// from the template and reset sync state so forward sync repopulates it

--- a/cmd/bausteinsicht/sync_test.go
+++ b/cmd/bausteinsicht/sync_test.go
@@ -916,3 +916,138 @@ func TestSyncRecreatesDeletedDrawioFileWithCustomTemplate(t *testing.T) {
 		t.Error("recreated drawio missing <mxfile> element")
 	}
 }
+
+// TestSyncAbortsOnInvalidIncludePattern verifies that sync returns an error
+// when the model contains a view with an include pattern that references a
+// non-existent element (e.g., "customer." with trailing dot). This prevents
+// silent element removal from draw.io pages. Regression test for #176.
+func TestSyncAbortsOnInvalidIncludePattern(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init project.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// First sync to establish baseline state.
+	captureStdout(t, func() {
+		cmd2 := NewRootCmd()
+		cmd2.SetArgs([]string{"sync"})
+		if err := cmd2.Execute(); err != nil {
+			t.Fatalf("first sync failed: %v", err)
+		}
+	})
+
+	// Corrupt the include pattern: "customer" → "customer." (trailing dot).
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+
+	// Find a view with includes and corrupt one.
+	var modified bool
+	for id, view := range m.Views {
+		for i, inc := range view.Include {
+			if !strings.Contains(inc, "*") {
+				view.Include[i] = inc + "." // trailing dot = invalid
+				m.Views[id] = view
+				modified = true
+				break
+			}
+		}
+		if modified {
+			break
+		}
+	}
+	if !modified {
+		t.Skip("no non-wildcard include pattern found in init template views")
+	}
+
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save model: %v", err)
+	}
+
+	// Sync should fail because of the invalid include pattern.
+	syncCmd := NewRootCmd()
+	syncCmd.SetArgs([]string{"sync"})
+	syncCmd.SilenceErrors = true
+	syncCmd.SilenceUsage = true
+
+	captureStdout(t, func() {
+		err = syncCmd.Execute()
+	})
+
+	if err == nil {
+		t.Fatal("expected sync to fail with invalid include pattern, but it succeeded")
+	}
+
+	// The error should mention validation.
+	if !strings.Contains(err.Error(), "validation") {
+		t.Errorf("expected error to mention 'validation', got: %v", err)
+	}
+}
+
+// TestSyncAbortsOnInvalidExcludePattern verifies that sync returns an error
+// when the model contains a view with an exclude pattern that references a
+// non-existent element. Regression test for #176.
+func TestSyncAbortsOnInvalidExcludePattern(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Init project.
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// First sync to establish baseline state.
+	captureStdout(t, func() {
+		cmd2 := NewRootCmd()
+		cmd2.SetArgs([]string{"sync"})
+		if err := cmd2.Execute(); err != nil {
+			t.Fatalf("first sync failed: %v", err)
+		}
+	})
+
+	// Add an invalid exclude pattern: "..." (just dots, non-existent element).
+	m, err := model.Load("architecture.jsonc")
+	if err != nil {
+		t.Fatalf("load model: %v", err)
+	}
+
+	for id, view := range m.Views {
+		view.Exclude = append(view.Exclude, "...")
+		m.Views[id] = view
+		break
+	}
+
+	if err := model.Save("architecture.jsonc", m); err != nil {
+		t.Fatalf("save model: %v", err)
+	}
+
+	// Sync should fail because of the invalid exclude pattern.
+	syncCmd := NewRootCmd()
+	syncCmd.SetArgs([]string{"sync"})
+	syncCmd.SilenceErrors = true
+	syncCmd.SilenceUsage = true
+
+	captureStdout(t, func() {
+		err = syncCmd.Execute()
+	})
+
+	if err == nil {
+		t.Fatal("expected sync to fail with invalid exclude pattern, but it succeeded")
+	}
+}


### PR DESCRIPTION
## Summary
- Sync now runs `model.Validate()` before applying changes, matching the behavior of the `validate` command
- If the model contains invalid view include/exclude patterns (e.g., `"customer."` with trailing dot, `"..."` just dots), sync aborts with validation errors instead of silently removing elements from draw.io pages
- Adds two regression tests: `TestSyncAbortsOnInvalidIncludePattern` and `TestSyncAbortsOnInvalidExcludePattern`

## Test plan
- [x] RED tests written first, confirmed failing before fix
- [x] GREEN after adding `model.Validate()` call in `runSync`
- [x] `go test -race ./...` passes
- [x] `go vet` and `staticcheck` clean

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)