### PR TITLE
fix: warn when model elements are not visible in any view

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
@@ -57,7 +59,26 @@ func Run(
 	// Step 5: Reverse sync (draw.io → model).
 	result.Reverse = ApplyReverse(changes, m)
 
-	// Step 6: Collect all warnings.
+	// Step 6: Warn about model elements not visible in any view (#183).
+	if len(m.Views) > 0 {
+		visible := computeVisibleElements(m)
+		flat := model.FlattenElements(m)
+		var invisible []string
+		for id := range flat {
+			if visible != nil && !visible[id] {
+				invisible = append(invisible, id)
+			}
+		}
+		if len(invisible) > 0 {
+			sort.Strings(invisible)
+			for _, id := range invisible {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("Element %q exists in the model but is not visible in any view — add it to a view's include list", id))
+			}
+		}
+	}
+
+	// Step 7: Collect all warnings.
 	result.Warnings = append(result.Warnings, result.Forward.Warnings...)
 	result.Warnings = append(result.Warnings, result.Reverse.Warnings...)
 	for _, rc := range result.Conflicts {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -657,3 +657,72 @@ func TestRun_MultipleRelsSamePair(t *testing.T) {
 		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
 	}
 }
+
+// --- Test: Sync warns when model elements aren't visible in any view (#183) ---
+//
+// Model has 3 elements: "a", "b", "c".
+// View only includes "a" and "b".
+// After sync, result.Warnings should contain a warning about "c" not being
+// visible in any view.
+
+func TestRun_WarnsAboutInvisibleElements(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+			"c": {Kind: "container", Title: "C"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"v1": {Title: "V1", Include: []string{"a", "b"}},
+		},
+	}
+
+	doc := drawio.NewDocument()
+	doc.AddPage("view-v1", "V1")
+	state := emptyState()
+
+	result := Run(m, doc, state, ts)
+
+	// Elements "a" and "b" should be created on the page.
+	if result.Forward.ElementsCreated != 2 {
+		t.Errorf("expected 2 elements created, got %d", result.Forward.ElementsCreated)
+	}
+
+	// There should be a warning about "c" not being visible in any view.
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "c") && strings.Contains(w, "not visible") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about element 'c' not visible in any view, got warnings: %v", result.Warnings)
+	}
+}
+
+// Test: No warning about invisible elements when model has no views.
+func TestRun_NoWarningWithoutViews(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+		},
+		Relationships: []model.Relationship{},
+	}
+
+	doc := emptyDoc()
+	state := emptyState()
+
+	result := Run(m, doc, state, ts)
+
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "not visible") {
+			t.Errorf("unexpected visibility warning without views: %s", w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Sync engine now warns when model elements exist but aren't included in any view's `include` filter
- Addresses the confusing UX where `add element` followed by `sync` reports "Already in sync" without explaining why the element doesn't appear in the diagram
- Root cause was NOT that `add element` updates sync state (it doesn't) — elements simply weren't in any view's include list

## Test plan
- [x] New test: `TestRun_WarnsAboutInvisibleElements` — verifies warning for invisible element
- [x] New test: `TestRun_NoWarningWithoutViews` — no false warning in no-views mode
- [x] `make test-race` passes

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)