### PR TITLE
fix: prevent element deletion when adding/renaming views

### DIFF
--- a/cmd/bausteinsicht/init.go
+++ b/cmd/bausteinsicht/init.go
@@ -76,7 +76,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		doc.AddPage("view-"+viewID, view.Title)
 	}
 
-	_ = sync.Run(m, doc, emptyState, tmpl)
+	_ = sync.Run(m, doc, emptyState, tmpl, nil)
 
 	// Save generated draw.io file.
 	if err := drawio.SaveDocument(defaultDrawioFile, doc); err != nil {

--- a/cmd/bausteinsicht/sync.go
+++ b/cmd/bausteinsicht/sync.go
@@ -117,11 +117,15 @@ func runSync(cmd *cobra.Command, _ []string) error {
 			len(flat), len(m.Relationships), len(m.Views))
 	}
 
-	// Ensure pages exist for all views.
+	// Ensure pages exist for all views; track which pages are newly created
+	// so the sync engine can avoid treating their missing elements as deletions
+	// (#184, #188, #189).
+	newPageIDs := make(map[string]bool)
 	for viewID, view := range m.Views {
 		pageID := "view-" + viewID
 		if doc.GetPage(pageID) == nil {
 			doc.AddPage(pageID, view.Title)
+			newPageIDs[pageID] = true
 		}
 	}
 
@@ -129,7 +133,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	bsync.RemoveOrphanedViewPages(doc, m)
 
 	// Run sync.
-	result := bsync.Run(m, doc, state, tmpl)
+	result := bsync.Run(m, doc, state, tmpl, newPageIDs)
 
 	// Save updated model: use PatchSave to preserve JSONC comments and key
 	// ordering when possible, fall back to full Save for structural changes.

--- a/cmd/bausteinsicht/watch.go
+++ b/cmd/bausteinsicht/watch.go
@@ -140,15 +140,20 @@ func doSync(changedFile, modelPath, drawioPath, templatePath string) {
 		return
 	}
 
-	// Ensure pages exist for all views.
+	// Ensure pages exist for all views; track new pages (#184, #188, #189).
+	newPageIDs := make(map[string]bool)
 	for viewID, view := range m.Views {
 		pageID := "view-" + viewID
 		if doc.GetPage(pageID) == nil {
 			doc.AddPage(pageID, view.Title)
+			newPageIDs[pageID] = true
 		}
 	}
 
-	result := bsync.Run(m, doc, state, tmpl)
+	// Remove orphaned view pages (views deleted or renamed in model). (#143)
+	bsync.RemoveOrphanedViewPages(doc, m)
+
+	result := bsync.Run(m, doc, state, tmpl, newPageIDs)
 
 	if err := saveModel(modelPath, m, result); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR saving model: %v\n", err)

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -132,15 +132,59 @@ func computeVisibleRelationships(m *model.BausteinsichtModel) map[string]bool {
 	return visible
 }
 
+// computeNewPageOnlyElements returns the set of element IDs that are visible
+// exclusively on newly created view pages (not on any pre-existing page).
+// Elements on new pages should not be treated as "deleted from draw.io" because
+// they simply haven't been forward-synced to those pages yet (#184, #188, #189).
+func computeNewPageOnlyElements(m *model.BausteinsichtModel, newPageIDs map[string]bool) map[string]bool {
+	if len(newPageIDs) == 0 || len(m.Views) == 0 {
+		return nil
+	}
+
+	// Compute elements visible on existing (non-new) pages.
+	existingPageElems := make(map[string]bool)
+	for viewID, view := range m.Views {
+		pageID := "view-" + viewID
+		if newPageIDs[pageID] {
+			continue // Skip new pages.
+		}
+		v := view
+		resolved, _ := model.ResolveView(m, &v)
+		for _, id := range resolved {
+			existingPageElems[id] = true
+		}
+		if view.Scope != "" {
+			existingPageElems[view.Scope] = true
+		}
+	}
+
+	// Find elements that are visible but ONLY on new pages.
+	allVisible := computeVisibleElements(m)
+	if allVisible == nil {
+		return nil
+	}
+	newOnly := make(map[string]bool)
+	for id := range allVisible {
+		if !existingPageElems[id] {
+			newOnly[id] = true
+		}
+	}
+	return newOnly
+}
+
 // DetectChanges performs a three-way diff between the model, draw.io document,
 // and the last known sync state.
-func DetectChanges(m *model.BausteinsichtModel, doc *drawio.Document, lastState *SyncState) *ChangeSet {
+// newPageIDs is the set of page IDs that were just created (not yet populated
+// by forward sync). Elements expected only on new pages are excluded from
+// draw.io-side deletion detection (#184, #188, #189).
+func DetectChanges(m *model.BausteinsichtModel, doc *drawio.Document, lastState *SyncState, newPageIDs map[string]bool) *ChangeSet {
 	cs := &ChangeSet{}
 
 	flatModel := model.FlattenElements(m)
 	drawioElems := extractDrawioElements(doc)
 	visibleElems := computeVisibleElements(m)
-	detectElementChanges(cs, flatModel, drawioElems, lastState, visibleElems)
+	newPageOnly := computeNewPageOnlyElements(m, newPageIDs)
+	detectElementChanges(cs, flatModel, drawioElems, lastState, visibleElems, newPageOnly)
 
 	modelRels := buildModelRelMap(m)
 	drawioRels := extractDrawioRelationships(doc)
@@ -292,12 +336,16 @@ func buildModelRelMap(m *model.BausteinsichtModel) map[string]RelationshipState 
 // detectElementChanges performs three-way comparison for elements.
 // visibleElems is the set of element IDs visible across all views. If nil,
 // all elements are considered visible (no views defined).
+// newPageOnly is the set of elements visible ONLY on newly created pages
+// (not yet populated by forward sync). These are excluded from draw.io-side
+// deletion detection (#184, #188, #189).
 func detectElementChanges(
 	cs *ChangeSet,
 	flatModel map[string]*model.Element,
 	drawioElems map[string]drawioElemSnapshot,
 	lastState *SyncState,
 	visibleElems map[string]bool,
+	newPageOnly map[string]bool,
 ) {
 	allIDs := unionElementIDs(flatModel, drawioElems, lastState)
 
@@ -327,7 +375,12 @@ func detectElementChanges(
 			// Only treat as deleted if the element should be visible on at least one
 			// view page. Elements not in any view's resolved set are simply filtered
 			// out and their absence from draw.io is expected, not a deletion. (#108, #118)
+			// Also skip elements that are only expected on newly created pages — those
+			// pages haven't been populated by forward sync yet (#184, #188, #189).
 			if visibleElems == nil || visibleElems[id] {
+				if newPageOnly != nil && newPageOnly[id] {
+					continue
+				}
 				cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Deleted})
 			}
 		case inDrawio && inLast:

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -65,7 +65,7 @@ func TestDetectChanges_NoChanges(t *testing.T) {
 	m := simpleModel("app", "App", "Desc", "Go")
 	doc := docWithElem("app", "App", "Go", "Desc")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	if len(cs.ModelElementChanges) != 0 {
 		t.Errorf("expected no model element changes, got %d", len(cs.ModelElementChanges))
@@ -83,7 +83,7 @@ func TestDetectChanges_ModelAddedElement(t *testing.T) {
 	m := simpleModel("app", "App", "", "")
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	if len(cs.ModelElementChanges) != 1 {
 		t.Fatalf("expected 1 model element change, got %d", len(cs.ModelElementChanges))
@@ -99,7 +99,7 @@ func TestDetectChanges_ModelModifiedTitle(t *testing.T) {
 	m := simpleModel("app", "NewTitle", "", "")
 	doc := docWithElem("app", "OldTitle", "", "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelElementChanges {
@@ -121,7 +121,7 @@ func TestDetectChanges_ModelDeletedElement(t *testing.T) {
 	m := emptyModel()
 	doc := docWithElem("app", "App", "", "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelElementChanges {
@@ -139,7 +139,7 @@ func TestDetectChanges_DrawioModifiedTitle(t *testing.T) {
 	m := simpleModel("app", "OldTitle", "", "")
 	doc := docWithElem("app", "NewTitle", "", "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.DrawioElementChanges {
@@ -161,7 +161,7 @@ func TestDetectChanges_ConflictBothModifiedSameField(t *testing.T) {
 	m := simpleModel("app", "ModelTitle", "", "")
 	doc := docWithElem("app", "DrawioTitle", "", "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, c := range cs.Conflicts {
@@ -182,7 +182,7 @@ func TestDetectChanges_NoDuplicateConflictWhenDifferentFields(t *testing.T) {
 	m := simpleModel("app", "NewTitle", "OldDesc", "")
 	doc := docWithElem("app", "OldTitle", "", "NewDesc")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	if len(cs.Conflicts) != 0 {
 		t.Errorf("expected no conflicts for different-field changes, got: %+v", cs.Conflicts)
@@ -220,7 +220,7 @@ func TestDetectChanges_RelationshipAdded(t *testing.T) {
 	}
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelRelationshipChanges {
@@ -244,7 +244,7 @@ func TestDetectChanges_RelationshipModifiedLabel(t *testing.T) {
 	}
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelRelationshipChanges {
@@ -269,7 +269,7 @@ func TestDetectChanges_RelationshipDeleted(t *testing.T) {
 	}
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelRelationshipChanges {
@@ -289,7 +289,7 @@ func TestDetectChanges_DrawioRelationshipAdded(t *testing.T) {
 	page := doc.AddPage("p1", "Page 1")
 	page.CreateConnector(drawio.ConnectorData{From: "x", To: "y", Label: "uses"}, "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.DrawioRelationshipChanges {
@@ -353,7 +353,7 @@ func TestDetectChanges_ScopedConnectorsMappedToElementIDs(t *testing.T) {
 	// draw.io has scoped cell IDs (e.g., context--customer) on connectors.
 	doc := docWithScopedConnector("context", "customer", "webshop", "uses")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	// There should be NO drawio relationship changes — the connector represents
 	// the same relationship as in state, just with scoped cell IDs.
@@ -403,7 +403,7 @@ func TestDetectChanges_ScopedConnectorsMultipleViews(t *testing.T) {
 		}, "")
 	}
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	if len(cs.DrawioRelationshipChanges) != 0 {
 		t.Errorf("expected no drawio relationship changes for multi-view scoped connectors, got %d: %+v",
@@ -455,7 +455,7 @@ func TestDetectChanges_LiftedConnectorIgnored(t *testing.T) {
 		TargetRef: "ctx--shop",
 	}, "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	// The lifted connector (customer → shop) should NOT appear as a new
 	// drawio relationship, because it's a visual representation of an
@@ -491,7 +491,7 @@ func TestDetectChanges_TooltipChangeDetected(t *testing.T) {
 		}
 	}
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	// Should detect a drawio-side description change from "Old Desc" to "New Desc"
 	found := false
@@ -520,7 +520,7 @@ func TestDetectChanges_ModelModifiedKind(t *testing.T) {
 	m := simpleModelWithKind("app", "App", "Desc", "Go", "component")
 	doc := docWithElem("app", "App", "Go", "Desc")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelElementChanges {
@@ -557,7 +557,7 @@ func TestDetectChanges_ScopedConnectorLabelChange(t *testing.T) {
 
 	doc := docWithScopedConnector("ctx", "a", "b", "calls")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.DrawioRelationshipChanges {
@@ -625,7 +625,7 @@ func TestDetectChanges_ElementNotOnViewNotTreatedAsDeleted(t *testing.T) {
 	state := stateWithElems("a", "b", "c")
 	doc := docWithElems("a", "b")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	for _, ch := range cs.DrawioElementChanges {
 		if ch.ID == "c" && ch.Type == Deleted {
@@ -653,7 +653,7 @@ func TestDetectChanges_ExcludedElementNotTreatedAsDeleted(t *testing.T) {
 	state := stateWithElems("a", "b")
 	doc := docWithElems("a")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	for _, ch := range cs.DrawioElementChanges {
 		if ch.ID == "b" && ch.Type == Deleted {
@@ -681,7 +681,7 @@ func TestDetectChanges_TrueDeletionStillDetected(t *testing.T) {
 	state := stateWithElems("a", "b")
 	doc := docWithElems("a")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.DrawioElementChanges {
@@ -711,7 +711,7 @@ func TestDetectChanges_NoViewsAllDeletionsDetected(t *testing.T) {
 	state := stateWithElems("a", "b")
 	doc := docWithElems("a")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.DrawioElementChanges {
@@ -743,7 +743,7 @@ func TestDetectChanges_MultipleRelsSamePairBothAdded(t *testing.T) {
 	}
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	addedCount := 0
 	for _, ch := range cs.ModelRelationshipChanges {
@@ -776,7 +776,7 @@ func TestDetectChanges_MultipleRelsSamePairLabelModified(t *testing.T) {
 	}
 	doc := emptyDoc()
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	found := false
 	for _, ch := range cs.ModelRelationshipChanges {
@@ -851,7 +851,7 @@ func TestDetectChanges_DeletedElementConnectorUsesCanonicalIDs(t *testing.T) {
 		TargetRef: "components--onlineshop.db",
 	}, "")
 
-	cs := DetectChanges(m, doc, state)
+	cs := DetectChanges(m, doc, state, nil)
 
 	// Check all drawio relationship changes: none should contain scoped cell IDs.
 	for _, ch := range cs.DrawioRelationshipChanges {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -33,11 +33,14 @@ func Run(
 	doc *drawio.Document,
 	lastState *SyncState,
 	templates *drawio.TemplateSet,
+	newPageIDs map[string]bool,
 ) *SyncResult {
 	result := &SyncResult{}
 
 	// Step 1: Detect changes from both sides.
-	changes := DetectChanges(m, doc, lastState)
+	// Pass newPageIDs so that elements expected only on newly created pages
+	// are not mistakenly treated as "deleted from draw.io" (#184, #188, #189).
+	changes := DetectChanges(m, doc, lastState, newPageIDs)
 
 	// Step 2: Resolve conflicts.
 	if len(changes.Conflicts) > 0 {
@@ -54,7 +57,10 @@ func Run(
 	result.Changes = changes
 
 	// Step 4: Forward sync (model → draw.io).
-	result.Forward = ApplyForward(changes, doc, templates, m)
+	// Pass newPageIDs so that newly created view pages get fully populated
+	// with their resolved elements, even if those elements aren't in the
+	// ChangeSet as "Added" (because they're already in the sync state).
+	result.Forward = ApplyForward(changes, doc, templates, m, newPageIDs)
 
 	// Step 5: Reverse sync (draw.io → model).
 	result.Reverse = ApplyReverse(changes, m)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -16,7 +16,7 @@ func TestRun_NoChanges(t *testing.T) {
 	state := stateWithElem("api", "API", "A service", "Go")
 	ts := minimalTemplates(t)
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	if result.Forward.ElementsCreated != 0 {
 		t.Errorf("expected 0 elements created, got %d", result.Forward.ElementsCreated)
@@ -40,7 +40,7 @@ func TestRun_ModelAddedElement(t *testing.T) {
 	state := emptyState()
 	ts := minimalTemplates(t)
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	if result.Forward.ElementsCreated != 1 {
 		t.Errorf("expected 1 element created, got %d", result.Forward.ElementsCreated)
@@ -78,7 +78,7 @@ func TestRun_DrawioModifiedTitle(t *testing.T) {
 	state := stateWithElem("api", "Old Title", "", "")
 	ts := minimalTemplates(t)
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	if result.Reverse.ElementsUpdated != 1 {
 		t.Errorf("expected 1 element updated in reverse, got %d", result.Reverse.ElementsUpdated)
@@ -106,7 +106,7 @@ func TestRun_ConflictModelWins(t *testing.T) {
 	state := stateWithElem("api", "Old Title", "", "")
 	ts := minimalTemplates(t)
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	if len(result.Conflicts) != 1 {
 		t.Fatalf("expected 1 conflict, got %d", len(result.Conflicts))
@@ -165,7 +165,7 @@ func TestRun_ViewBasedSyncNoPhantomChanges(t *testing.T) {
 	state := emptyState()
 
 	// Round 1: forward sync populates the doc.
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated != 2 {
 		t.Fatalf("round 1: expected 2 elements created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -185,7 +185,7 @@ func TestRun_ViewBasedSyncNoPhantomChanges(t *testing.T) {
 	}
 
 	// Round 2: nothing changed — sync should be a complete no-op.
-	r2 := Run(m, doc, state1, ts)
+	r2 := Run(m, doc, state1, ts, nil)
 
 	if r2.Forward.ElementsCreated != 0 || r2.Forward.ElementsUpdated != 0 || r2.Forward.ElementsDeleted != 0 {
 		t.Errorf("round 2: expected no forward element changes, got created=%d updated=%d deleted=%d",
@@ -236,7 +236,7 @@ func TestRun_OrphanedViewPageRemoved(t *testing.T) {
 	state := emptyState()
 
 	// Round 1: forward sync populates both pages.
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated < 2 {
 		t.Fatalf("round 1: expected at least 2 elements created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -316,7 +316,7 @@ func TestRun_FullRoundTrip(t *testing.T) {
 	doc := emptyDoc()
 	state := emptyState()
 
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated != 1 {
 		t.Fatalf("round 1: expected 1 element created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -334,7 +334,7 @@ func TestRun_FullRoundTrip(t *testing.T) {
 	updated.Title = "Service v2"
 	m.Model["svc"] = updated
 
-	r2 := Run(m, doc, state1, ts)
+	r2 := Run(m, doc, state1, ts, nil)
 	if r2.Forward.ElementsUpdated != 1 {
 		t.Errorf("round 2: expected 1 element updated, got %d", r2.Forward.ElementsUpdated)
 	}
@@ -381,7 +381,7 @@ func TestRun_ViewFilterChangeDoesNotDeleteModelElements(t *testing.T) {
 	state := emptyState()
 
 	// --- Round 1: initial sync with include ["**"] ---
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated < 3 {
 		t.Fatalf("round 1: expected at least 3 elements created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -401,7 +401,7 @@ func TestRun_ViewFilterChangeDoesNotDeleteModelElements(t *testing.T) {
 	// --- Round 2: narrow the view filter to ["webshop.*"] ---
 	m.Views["main"] = model.View{Title: "Main", Include: []string{"webshop.*"}}
 
-	r2 := Run(m, doc, state1, ts)
+	r2 := Run(m, doc, state1, ts, nil)
 
 	// Forward sync should remove customer from the page (reconcileViewPage).
 	// That's expected and correct.
@@ -461,7 +461,7 @@ func TestRun_ViewFilterChangeDoesNotDeleteRelationships(t *testing.T) {
 	state := emptyState()
 
 	// --- Round 1: initial sync with include ["**"] ---
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated < 3 {
 		t.Fatalf("round 1: expected at least 3 elements created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -485,7 +485,7 @@ func TestRun_ViewFilterChangeDoesNotDeleteRelationships(t *testing.T) {
 	// This removes customer from the page AND its connector customer→webshop.
 	m.Views["main"] = model.View{Title: "Main", Include: []string{"webshop.*"}}
 
-	r2 := Run(m, doc, state1, ts)
+	r2 := Run(m, doc, state1, ts, nil)
 
 	// Forward sync should remove customer and the connector from the page.
 
@@ -502,7 +502,7 @@ func TestRun_ViewFilterChangeDoesNotDeleteRelationships(t *testing.T) {
 	}
 
 	// --- Round 3: sync again — the connector is gone from draw.io ---
-	r3 := Run(m, doc, state2, ts)
+	r3 := Run(m, doc, state2, ts, nil)
 
 	// CRITICAL: customer must still be in the model.
 	if _, ok := m.Model["customer"]; !ok {
@@ -575,7 +575,7 @@ func TestRun_UserDeletionInDrawioStillWorksWithViews(t *testing.T) {
 	page.DeleteElement("customer")
 
 	// Run sync — reverse should detect and apply the deletion.
-	r := Run(m, doc, state, ts)
+	r := Run(m, doc, state, ts, nil)
 
 	// customer should be deleted from the model (user intended this).
 	if _, ok := m.Model["customer"]; ok {
@@ -615,7 +615,7 @@ func TestRun_MultipleRelsSamePair(t *testing.T) {
 	state := emptyState()
 
 	// Round 1: first sync populates an empty doc.
-	r1 := Run(m, doc, state, ts)
+	r1 := Run(m, doc, state, ts, nil)
 	if r1.Forward.ElementsCreated != 2 {
 		t.Fatalf("round 1: expected 2 elements created, got %d", r1.Forward.ElementsCreated)
 	}
@@ -643,7 +643,7 @@ func TestRun_MultipleRelsSamePair(t *testing.T) {
 	}
 
 	// Round 2: nothing changed — sync should be a complete no-op.
-	r2 := Run(m, doc, state1, ts)
+	r2 := Run(m, doc, state1, ts, nil)
 
 	if r2.Forward.ConnectorsCreated != 0 || r2.Forward.ConnectorsUpdated != 0 || r2.Forward.ConnectorsDeleted != 0 {
 		t.Errorf("round 2: expected no forward connector changes, got created=%d updated=%d deleted=%d",
@@ -684,7 +684,7 @@ func TestRun_WarnsAboutInvisibleElements(t *testing.T) {
 	doc.AddPage("view-v1", "V1")
 	state := emptyState()
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	// Elements "a" and "b" should be created on the page.
 	if result.Forward.ElementsCreated != 2 {
@@ -718,11 +718,187 @@ func TestRun_NoWarningWithoutViews(t *testing.T) {
 	doc := emptyDoc()
 	state := emptyState()
 
-	result := Run(m, doc, state, ts)
+	result := Run(m, doc, state, ts, nil)
 
 	for _, w := range result.Warnings {
 		if strings.Contains(w, "not visible") {
 			t.Errorf("unexpected visibility warning without views: %s", w)
 		}
+	}
+}
+
+// --- Test: Adding a new view doesn't delete elements from model (#184) ---
+//
+// Round 1: model has "a" and "b", view v1 includes only "a".
+// Round 2: add view v2 that includes "b".
+// Element "b" should NOT be deleted from the model.
+
+func TestRun_AddingNewViewDoesNotDeleteElements(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"v1": {Title: "V1", Include: []string{"a"}},
+		},
+	}
+
+	doc := drawio.NewDocument()
+	doc.AddPage("view-v1", "V1")
+	state := emptyState()
+
+	// Round 1: forward sync populates v1 with "a".
+	r1 := Run(m, doc, state, ts, nil)
+	if r1.Forward.ElementsCreated != 1 {
+		t.Fatalf("round 1: expected 1 element created, got %d", r1.Forward.ElementsCreated)
+	}
+
+	// Build state after round 1.
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"a": {Title: "A", Kind: "container"},
+			"b": {Title: "B", Kind: "container"},
+		},
+		Relationships: []RelationshipState{},
+	}
+
+	// Round 2: add view v2 that includes "b".
+	m.Views["v2"] = model.View{Title: "V2", Include: []string{"b"}}
+	newPage := doc.AddPage("view-v2", "V2")
+	_ = newPage
+
+	newPageIDs := map[string]bool{"view-v2": true}
+	r2 := Run(m, doc, state1, ts, newPageIDs)
+
+	// Element "b" should NOT be deleted by reverse sync.
+	if r2.Reverse.ElementsDeleted != 0 {
+		t.Errorf("round 2: expected 0 reverse deletions, got %d", r2.Reverse.ElementsDeleted)
+	}
+
+	// Element "b" should be created on v2 by forward sync.
+	if r2.Forward.ElementsCreated < 1 {
+		t.Errorf("round 2: expected at least 1 forward creation (b on v2), got %d", r2.Forward.ElementsCreated)
+	}
+
+	// Model should still have "b".
+	if _, ok := m.Model["b"]; !ok {
+		t.Errorf("element 'b' was deleted from model — data loss!")
+	}
+}
+
+// --- Test: Renaming a view key doesn't delete elements (#189) ---
+//
+// Round 1: view "all" includes "a".
+// Round 2: view "all" renamed to "overview" (same include).
+// Element "a" should NOT be deleted.
+
+func TestRun_RenamingViewDoesNotDeleteElements(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"all": {Title: "All", Include: []string{"a"}},
+		},
+	}
+
+	doc := drawio.NewDocument()
+	doc.AddPage("view-all", "All")
+	state := emptyState()
+
+	// Round 1: forward sync populates view "all" with "a".
+	r1 := Run(m, doc, state, ts, nil)
+	if r1.Forward.ElementsCreated != 1 {
+		t.Fatalf("round 1: expected 1 element created, got %d", r1.Forward.ElementsCreated)
+	}
+
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"a": {Title: "A", Kind: "container"},
+		},
+		Relationships: []RelationshipState{},
+	}
+
+	// Round 2: rename view "all" → "overview".
+	delete(m.Views, "all")
+	m.Views["overview"] = model.View{Title: "Overview", Include: []string{"a"}}
+
+	// Remove orphaned page and add new one (simulating what sync.go does).
+	RemoveOrphanedViewPages(doc, m)
+	doc.AddPage("view-overview", "Overview")
+
+	newPageIDs := map[string]bool{"view-overview": true}
+	r2 := Run(m, doc, state1, ts, newPageIDs)
+
+	// "a" should NOT be deleted.
+	if r2.Reverse.ElementsDeleted != 0 {
+		t.Errorf("round 2: expected 0 reverse deletions, got %d", r2.Reverse.ElementsDeleted)
+	}
+
+	if _, ok := m.Model["a"]; !ok {
+		t.Errorf("element 'a' was deleted from model — data loss!")
+	}
+}
+
+// --- Test: New view pages get populated (#188) ---
+//
+// After adding a new view and syncing, the new page should contain elements.
+
+func TestRun_NewViewPageGetsPopulated(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"v1": {Title: "V1", Include: []string{"a"}},
+		},
+	}
+
+	doc := drawio.NewDocument()
+	doc.AddPage("view-v1", "V1")
+	state := emptyState()
+
+	// Round 1: populate v1.
+	r1 := Run(m, doc, state, ts, nil)
+	_ = r1
+
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"a": {Title: "A", Kind: "container"},
+			"b": {Title: "B", Kind: "container"},
+		},
+		Relationships: []RelationshipState{},
+	}
+
+	// Round 2: add v2.
+	m.Views["v2"] = model.View{Title: "V2", Include: []string{"b"}}
+	doc.AddPage("view-v2", "V2")
+
+	newPageIDs := map[string]bool{"view-v2": true}
+	r2 := Run(m, doc, state1, ts, newPageIDs)
+
+	// "b" should be created on v2.
+	if r2.Forward.ElementsCreated < 1 {
+		t.Errorf("expected at least 1 forward creation, got %d", r2.Forward.ElementsCreated)
+	}
+
+	// Verify "b" is actually on v2 page.
+	v2Page := doc.GetPage("view-v2")
+	if v2Page == nil {
+		t.Fatal("v2 page not found")
+	}
+	if v2Page.FindElement("b") == nil {
+		t.Error("element 'b' not found on v2 page")
 	}
 }

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -35,6 +35,7 @@ func ApplyForward(
 	doc *drawio.Document,
 	templates *drawio.TemplateSet,
 	m *model.BausteinsichtModel,
+	newPageIDs map[string]bool,
 ) *ForwardResult {
 	result := &ForwardResult{}
 	flat := model.FlattenElements(m)
@@ -44,7 +45,7 @@ func ApplyForward(
 		return result
 	}
 
-	applyForwardPerView(cs, doc, templates, flat, m, result)
+	applyForwardPerView(cs, doc, templates, flat, m, newPageIDs, result)
 	return result
 }
 
@@ -71,12 +72,14 @@ func applyForwardToPage(
 }
 
 // applyForwardPerView iterates over model views and applies changes per page.
+// newPageIDs identifies pages that were just created and need full population.
 func applyForwardPerView(
 	cs *ChangeSet,
 	doc *drawio.Document,
 	templates *drawio.TemplateSet,
 	flat map[string]*model.Element,
 	m *model.BausteinsichtModel,
+	newPageIDs map[string]bool,
 	result *ForwardResult,
 ) {
 	for viewID, view := range m.Views {
@@ -108,9 +111,42 @@ func applyForwardPerView(
 
 		applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, result)
 
+		// For newly created pages, populate all resolved elements that aren't
+		// already on the page. This handles the case where elements exist in
+		// the sync state but haven't been rendered to this new page yet
+		// (#184, #188, #189).
+		if newPageIDs[pageID] {
+			populateNewPage(page, viewID, scopeID, templates, flat, elemSet, result)
+		}
+
 		// Reconciliation: remove elements on the page that are no longer
 		// in the resolved view (e.g., after exclude list changes). #102
 		reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
+	}
+}
+
+// populateNewPage creates elements on a newly created view page for all
+// elements in the view's resolved set that aren't already present.
+// This ensures new pages are fully populated even when the elements are
+// already in the sync state and thus not in the ChangeSet as "Added".
+func populateNewPage(
+	page *drawio.Page,
+	viewID string,
+	scopeID string,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	elemSet map[string]bool,
+	result *ForwardResult,
+) {
+	pl := computePlacement(page)
+	for id := range elemSet {
+		if id == scopeID {
+			continue // Scope boundary handled separately.
+		}
+		if page.FindElement(id) != nil {
+			continue // Already created by applyChangesToPage.
+		}
+		applyElementAdded(id, viewID, scopeID, page, templates, flat, &pl, result)
 	}
 }
 

--- a/internal/sync/forward_scoped_ids_test.go
+++ b/internal/sync/forward_scoped_ids_test.go
@@ -44,7 +44,7 @@ func TestApplyForward_ScopedIDs(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	contextPage := doc.GetPage("view-context")
 	containerPage := doc.GetPage("view-containers")
@@ -110,7 +110,7 @@ func TestApplyForward_ScopedConnectorRefs(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	page := doc.GetPage("view-containers")
 

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -110,7 +110,7 @@ func TestApplyForward_ElementKindChanged(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsUpdated != 1 {
 		t.Fatalf("expected 1 element updated, got %d", result.ElementsUpdated)
@@ -151,7 +151,7 @@ func TestApplyForward_NewElement(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsCreated != 1 {
 		t.Fatalf("expected 1 element created, got %d", result.ElementsCreated)
@@ -176,7 +176,7 @@ func TestApplyForward_NewElementVisualMarker(t *testing.T) {
 	cs := &ChangeSet{
 		ModelElementChanges: []ElementChange{{ID: "api", Type: Added}},
 	}
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	page := doc.Pages()[0]
 	obj := page.FindElement("api")
@@ -208,7 +208,7 @@ func TestApplyForward_UpdatedTitle(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsUpdated != 1 {
 		t.Fatalf("expected 1 element updated, got %d", result.ElementsUpdated)
@@ -237,7 +237,7 @@ func TestApplyForward_DeletedElement(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsDeleted != 1 {
 		t.Fatalf("expected 1 element deleted, got %d", result.ElementsDeleted)
@@ -261,7 +261,7 @@ func TestApplyForward_NewRelationship(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ConnectorsCreated != 1 {
 		t.Fatalf("expected 1 connector created, got %d", result.ConnectorsCreated)
@@ -292,7 +292,7 @@ func TestApplyForward_MultipleNewElementsNoOverlap(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsCreated != 2 {
 		t.Fatalf("expected 2 elements created, got %d", result.ElementsCreated)
@@ -313,7 +313,7 @@ func TestApplyForward_NoPageWarning(t *testing.T) {
 	m := emptyModel()
 	cs := &ChangeSet{}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if len(result.Warnings) == 0 {
 		t.Fatal("expected a warning for document with no pages")
@@ -420,7 +420,7 @@ func TestApplyForward_EmptyModelRemovesElements(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsDeleted != 2 {
 		t.Errorf("expected 2 elements deleted, got %d", result.ElementsDeleted)
@@ -454,7 +454,7 @@ func TestApplyForward_NoViewsReconciliation(t *testing.T) {
 	ts := minimalTemplates(t)
 	cs := &ChangeSet{} // No changes — but orphan should still be cleaned up.
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	// "a" should be preserved.
 	if page.FindElement("a") == nil {
@@ -505,7 +505,7 @@ func TestApplyForward_NoDuplicateConnectors(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	// Should NOT create a duplicate connector.
 	connectors := page.FindAllConnectors()
@@ -548,7 +548,7 @@ func TestApplyForward_SelfReferencingRelationship(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ConnectorsCreated < 1 {
 		t.Errorf("expected at least 1 connector for self-referencing relationship, got %d", result.ConnectorsCreated)
@@ -574,7 +574,7 @@ func TestApplyForward_NoDuplicateElements(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	// Should NOT create a duplicate — skip existing element.
 	page := doc.Pages()[0]
@@ -622,7 +622,7 @@ func TestApplyForward_MultipleRelationshipsSamePair(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ConnectorsCreated != 2 {
 		t.Fatalf("expected 2 connectors created, got %d", result.ConnectorsCreated)
@@ -698,7 +698,7 @@ func TestApplyForward_MultipleRelsSamePairNoDuplicateConnectors(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if len(page.FindAllConnectors()) != 2 {
 		t.Errorf("expected 2 connectors (no duplicates), got %d", len(page.FindAllConnectors()))

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -67,7 +67,7 @@ func TestApplyForward_ElementOnCorrectViewPage(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	// Context view should have customer and webshop.
 	contextPage := doc.GetPage("view-context")
@@ -125,7 +125,7 @@ func TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	// Context page: customer→webshop connector should exist (using scoped cell IDs).
 	contextPage := doc.GetPage("view-context")
@@ -193,7 +193,7 @@ func TestApplyForward_RelationshipLifting(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	// Context page: customer → webshop.frontend should be lifted to customer → webshop
 	contextPage := doc.GetPage("view-context")
@@ -273,7 +273,7 @@ func TestApplyForward_RelationshipLiftingDedup(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	contextPage := doc.GetPage("view-context")
 	conns := contextPage.FindAllConnectors()
@@ -317,7 +317,7 @@ func TestApplyForward_ScopeBoundingBox(t *testing.T) {
 		},
 	}
 
-	ApplyForward(cs, doc, ts, m)
+	ApplyForward(cs, doc, ts, m, nil)
 
 	page := doc.GetPage("view-containers")
 	if page == nil {
@@ -387,7 +387,7 @@ func TestApplyForward_DeletedElementRemovedFromViewPages(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
-	ApplyForward(csAdd, doc, ts, m)
+	ApplyForward(csAdd, doc, ts, m, nil)
 
 	// Verify db exists on container page before deletion.
 	containerPage := doc.GetPage("view-containers")
@@ -416,7 +416,7 @@ func TestApplyForward_DeletedElementRemovedFromViewPages(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Deleted},
 		},
 	}
-	result := ApplyForward(csDel, doc, ts, m)
+	result := ApplyForward(csDel, doc, ts, m, nil)
 
 	// The element should be removed from the container page.
 	if containerPage.FindElement("webshop.db") != nil {
@@ -449,7 +449,7 @@ func TestApplyForward_DeletedRelationshipRemovedFromViewPages(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
-	ApplyForward(csAdd, doc, ts, m)
+	ApplyForward(csAdd, doc, ts, m, nil)
 
 	// Verify connector exists before deletion.
 	containerPage := doc.GetPage("view-containers")
@@ -467,7 +467,7 @@ func TestApplyForward_DeletedRelationshipRemovedFromViewPages(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Deleted},
 		},
 	}
-	result := ApplyForward(csDel, doc, ts, m)
+	result := ApplyForward(csDel, doc, ts, m, nil)
 
 	// The connector should be removed from the container page.
 	if containerPage.FindConnector("containers--webshop.api", "containers--webshop.db", 1) != nil {
@@ -496,7 +496,7 @@ func TestApplyForward_ScopeBoundaryUpdatedOnModify(t *testing.T) {
 			{ID: "webshop.db", Type: Added},
 		},
 	}
-	ApplyForward(csAdd, doc, ts, m)
+	ApplyForward(csAdd, doc, ts, m, nil)
 
 	// Verify boundary exists with original title.
 	containerPage := doc.GetPage("view-containers")
@@ -525,7 +525,7 @@ func TestApplyForward_ScopeBoundaryUpdatedOnModify(t *testing.T) {
 			{ID: "webshop", Type: Modified},
 		},
 	}
-	result := ApplyForward(csMod, doc, ts, m)
+	result := ApplyForward(csMod, doc, ts, m, nil)
 
 	// The boundary label on the containers page should reflect the new technology.
 	boundary = containerPage.FindElement("webshop")
@@ -565,7 +565,7 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
-	ApplyForward(csAdd, doc, ts, m)
+	ApplyForward(csAdd, doc, ts, m, nil)
 
 	// Verify preconditions: webshop.db is on the container page with a connector.
 	containerPage := doc.GetPage("view-containers")
@@ -590,7 +590,7 @@ func TestExcludeRemovesElementFromPage(t *testing.T) {
 
 	// Empty ChangeSet: no model changes, only view exclude changed.
 	csEmpty := &ChangeSet{}
-	result := ApplyForward(csEmpty, doc, ts, m)
+	result := ApplyForward(csEmpty, doc, ts, m, nil)
 
 	// The excluded element should be removed from the page.
 	if containerPage.FindElement("webshop.db") != nil {
@@ -642,7 +642,7 @@ func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
 			{From: "webshop.api", To: "webshop.db", Index: 1, Type: Added, NewValue: "reads"},
 		},
 	}
-	ApplyForward(csAdd, doc, ts, m)
+	ApplyForward(csAdd, doc, ts, m, nil)
 
 	// Verify preconditions on the container page.
 	containerPage := doc.GetPage("view-containers")
@@ -673,7 +673,7 @@ func TestApplyForward_DeleteElementRemovesConnectors(t *testing.T) {
 		// No ModelRelationshipChanges — the element deletion should
 		// clean up connectors referencing the deleted element.
 	}
-	result := ApplyForward(csDel, doc, ts, m)
+	result := ApplyForward(csDel, doc, ts, m, nil)
 
 	// The element should be removed.
 	if containerPage.FindElement("webshop.db") != nil {
@@ -713,7 +713,7 @@ func TestApplyForward_NoViewsFallback(t *testing.T) {
 		},
 	}
 
-	result := ApplyForward(cs, doc, ts, m)
+	result := ApplyForward(cs, doc, ts, m, nil)
 
 	if result.ElementsCreated != 1 {
 		t.Fatalf("expected 1 element created, got %d", result.ElementsCreated)


### PR DESCRIPTION
## Summary
- Fixes element deletion when adding a new view (#184, #188) or renaming an existing view (#189)
- Root cause: reverse sync treated elements not yet rendered on newly created pages as "user deleted from draw.io"
- Tracks newly created page IDs through the sync pipeline to skip false deletions and populate new pages

## Test plan
- [x] `TestRun_AddingNewViewDoesNotDeleteElements` — adding v2 with include ["b"] doesn't delete "b"
- [x] `TestRun_RenamingViewDoesNotDeleteElements` — renaming view key preserves elements  
- [x] `TestRun_NewViewPageGetsPopulated` — new view page gets its resolved elements rendered
- [x] `go test -race ./...` — all tests pass

Closes #184
Closes #188
Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)