### PR TITLE
fix: preserve relationship metadata on connector direction swap

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -26,11 +26,86 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResul
 		applyElementChange(ch, m, result)
 	}
 
+	// Detect direction-swap pairs (Deleted a→b + Added b→a) so we can
+	// update the relationship in-place and preserve metadata (#185).
+	swaps := detectRelSwaps(changes.DrawioRelationshipChanges)
+
 	for _, ch := range changes.DrawioRelationshipChanges {
+		if swaps[relSwapKey{ch.From, ch.To, ch.Type}] {
+			continue // handled as part of a swap pair
+		}
 		applyRelationshipChange(ch, m, result)
 	}
 
+	// Apply swaps: update direction in-place, preserving kind/label/description.
+	for _, sw := range collectSwapPairs(changes.DrawioRelationshipChanges) {
+		applyRelSwap(sw.from, sw.to, m, result)
+	}
+
 	return result
+}
+
+type relSwapKey struct {
+	from, to string
+	typ      ChangeType
+}
+
+type swapPair struct {
+	from, to string // new direction (from the Added change)
+}
+
+// detectRelSwaps returns a set of (from, to, type) triples that are part of
+// a direction-swap pair. A swap is a Deleted(a→b) paired with Added(b→a).
+func detectRelSwaps(changes []RelationshipChange) map[relSwapKey]bool {
+	deleted := make(map[[2]string]bool)
+	added := make(map[[2]string]bool)
+	for _, ch := range changes {
+		switch ch.Type {
+		case Deleted:
+			deleted[[2]string{ch.From, ch.To}] = true
+		case Added:
+			added[[2]string{ch.From, ch.To}] = true
+		}
+	}
+	result := make(map[relSwapKey]bool)
+	for pair := range deleted {
+		reverse := [2]string{pair[1], pair[0]}
+		if added[reverse] {
+			result[relSwapKey{pair[0], pair[1], Deleted}] = true
+			result[relSwapKey{pair[1], pair[0], Added}] = true
+		}
+	}
+	return result
+}
+
+// collectSwapPairs returns the new-direction pairs for detected swaps.
+func collectSwapPairs(changes []RelationshipChange) []swapPair {
+	swaps := detectRelSwaps(changes)
+	var pairs []swapPair
+	for key := range swaps {
+		if key.typ == Added {
+			pairs = append(pairs, swapPair{from: key.from, to: key.to})
+		}
+	}
+	return pairs
+}
+
+// applyRelSwap updates a relationship's direction in-place, preserving metadata.
+func applyRelSwap(newFrom, newTo string, m *model.BausteinsichtModel, result *ReverseResult) {
+	for i, r := range m.Relationships {
+		if r.From == newTo && r.To == newFrom {
+			m.Relationships[i].From = newFrom
+			m.Relationships[i].To = newTo
+			result.RelationshipsUpdated++
+			return
+		}
+	}
+	// Fallback: original already deleted somehow; create new.
+	m.Relationships = append(m.Relationships, model.Relationship{
+		From: newFrom,
+		To:   newTo,
+	})
+	result.RelationshipsCreated++
 }
 
 func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *ReverseResult) {

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -287,3 +287,52 @@ func TestApplyReverse_RelationshipAdded(t *testing.T) {
 		t.Errorf("expected RelationshipsCreated=1, got %d", r.RelationshipsCreated)
 	}
 }
+
+// TestApplyReverse_SwapConnectorDirectionPreservesMetadata verifies that
+// swapping a connector's source and target in draw.io preserves the
+// relationship's kind, label, and description (#185).
+func TestApplyReverse_SwapConnectorDirectionPreservesMetadata(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "system", Title: "A"},
+			"b": {Kind: "system", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Kind: "uses", Label: "important-label", Description: "important desc"},
+		},
+	}
+
+	// Simulate draw.io direction swap: old connector deleted, new one added with swapped endpoints.
+	cs := &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Deleted},
+			{From: "b", To: "a", Type: Added},
+		},
+	}
+
+	result := ApplyReverse(cs, m)
+
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
+	}
+	rel := m.Relationships[0]
+	if rel.From != "b" || rel.To != "a" {
+		t.Errorf("expected from=b, to=a; got from=%s, to=%s", rel.From, rel.To)
+	}
+	if rel.Kind != "uses" {
+		t.Errorf("expected kind=uses, got %q", rel.Kind)
+	}
+	if rel.Label != "important-label" {
+		t.Errorf("expected label=important-label, got %q", rel.Label)
+	}
+	if rel.Description != "important desc" {
+		t.Errorf("expected description='important desc', got %q", rel.Description)
+	}
+	// Should be an update, not a delete+create.
+	if result.RelationshipsDeleted != 0 {
+		t.Errorf("expected RelationshipsDeleted=0 (swap, not delete), got %d", result.RelationshipsDeleted)
+	}
+	if result.RelationshipsUpdated != 1 {
+		t.Errorf("expected RelationshipsUpdated=1, got %d", result.RelationshipsUpdated)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes data loss when swapping connector direction in draw.io (#185)
- Root cause: diff engine emits Delete + Add pair; the Add created a bare relationship without kind/label/description
- Fix: `ApplyReverse` detects swap pairs (Deleted a→b + Added b→a) and updates direction in-place, preserving all metadata

## Test plan
- [x] `TestApplyReverse_SwapConnectorDirectionPreservesMetadata` — verifies kind, label, description preserved
- [x] `go test -race ./...` — all tests pass

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)