### PR TITLE
fix: prevent duplicate strokeColor in element style

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -423,7 +423,7 @@ func applyElementAdded(
 		result.Warnings = append(result.Warnings, "no template style for kind: "+elem.Kind)
 	}
 
-	style := ts.Style + newElementMarker
+	style := mergeStyles(ts.Style, newElementMarker)
 
 	width := ts.Width
 	if width == 0 {
@@ -650,4 +650,53 @@ func reconcileOrphanedElements(
 		page.DeleteElement(id)
 		result.ElementsDeleted++
 	}
+}
+
+// mergeStyles merges overlay style properties into a base style string.
+// If both base and overlay define the same key (e.g., strokeColor), the
+// overlay value wins. This prevents duplicate keys in the style string (#187).
+func mergeStyles(base, overlay string) string {
+	if overlay == "" {
+		return base
+	}
+	if base == "" {
+		return overlay
+	}
+
+	// Parse overlay keys.
+	overlayKeys := make(map[string]string)
+	for _, part := range strings.Split(overlay, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if idx := strings.IndexByte(part, '='); idx > 0 {
+			overlayKeys[part[:idx]] = part
+		} else {
+			overlayKeys[part] = part
+		}
+	}
+
+	// Build result: base properties (skipping those overridden) + overlay.
+	var sb strings.Builder
+	for _, part := range strings.Split(base, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key := part
+		if idx := strings.IndexByte(part, '='); idx > 0 {
+			key = part[:idx]
+		}
+		if _, overridden := overlayKeys[key]; overridden {
+			continue
+		}
+		sb.WriteString(part)
+		sb.WriteByte(';')
+	}
+	for _, v := range overlayKeys {
+		sb.WriteString(v)
+		sb.WriteByte(';')
+	}
+	return sb.String()
 }

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -707,3 +707,22 @@ func TestApplyForward_MultipleRelsSamePairNoDuplicateConnectors(t *testing.T) {
 		t.Errorf("expected 0 connectors created, got %d", result.ConnectorsCreated)
 	}
 }
+
+func TestMergeStyles_NoDuplicateKeys(t *testing.T) {
+	base := "shape=mxgraph.c4.person2;strokeColor=#073B6F;fillColor=#08427B;"
+	overlay := "strokeColor=#FF0000;dashed=1;"
+	got := mergeStyles(base, overlay)
+	// strokeColor should appear exactly once (the overlay value wins).
+	if count := strings.Count(got, "strokeColor"); count != 1 {
+		t.Errorf("expected exactly 1 strokeColor, got %d in %q", count, got)
+	}
+	if !strings.Contains(got, "strokeColor=#FF0000") {
+		t.Errorf("expected overlay strokeColor=#FF0000 in %q", got)
+	}
+	if !strings.Contains(got, "dashed=1") {
+		t.Errorf("expected dashed=1 in %q", got)
+	}
+	if !strings.Contains(got, "shape=mxgraph.c4.person2") {
+		t.Errorf("expected shape preserved in %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes duplicate `strokeColor` properties in mxCell style attributes after sync (#187)
- Root cause: `newElementMarker` was concatenated directly to template style, duplicating keys
- Fix: new `mergeStyles()` function replaces existing keys with overlay values

## Test plan
- [x] `TestMergeStyles_NoDuplicateKeys` — verifies overlay key replaces base key
- [x] `go test -race ./...` — all tests pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)