### PR TITLE
fix: read technology from XML attribute in reverse sync

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -205,6 +205,10 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 			}
 			label := obj.SelectAttrValue("label", "")
 			title, technology, labelDesc := drawio.ParseLabel(label)
+			// Fall back to XML attribute if label doesn't contain technology (#186).
+			if technology == "" {
+				technology = obj.SelectAttrValue("technology", "")
+			}
 			tooltipDesc := obj.SelectAttrValue("tooltip", "")
 			description := tooltipDesc
 			if description == "" {

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -922,12 +922,14 @@ func TestDetectChanges_TechnologyFromXMLAttribute(t *testing.T) {
 	doc := drawio.NewDocument()
 	doc.AddPage("1", "Page 1")
 	page := doc.GetPage("1")
-	page.CreateElement(drawio.ElementData{
+	if err := page.CreateElement(drawio.ElementData{
 		ID:     "customer",
 		CellID: "customer",
 		Kind:   "actor",
 		Title:  "Customer",
-	}, "shape=actor;")
+	}, "shape=actor;"); err != nil {
+		t.Fatal(err)
+	}
 	// Simulate user adding technology attribute directly in XML.
 	elem := page.FindElement("customer")
 	if elem == nil {

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -908,3 +908,50 @@ func TestExtractDrawioRelationships_FallbackStripsViewPrefix(t *testing.T) {
 		}
 	}
 }
+
+// TestDetectChanges_TechnologyFromXMLAttribute verifies that when a user adds
+// a technology XML attribute to a draw.io element (without changing the label),
+// the reverse sync detects the change (#186).
+func TestDetectChanges_TechnologyFromXMLAttribute(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "actor", Title: "Customer"},
+		},
+	}
+
+	doc := drawio.NewDocument()
+	doc.AddPage("1", "Page 1")
+	page := doc.GetPage("1")
+	page.CreateElement(drawio.ElementData{
+		ID:     "customer",
+		CellID: "customer",
+		Kind:   "actor",
+		Title:  "Customer",
+	}, "shape=actor;")
+	// Simulate user adding technology attribute directly in XML.
+	elem := page.FindElement("customer")
+	if elem == nil {
+		t.Fatal("element not found")
+	}
+	elem.CreateAttr("technology", "Human")
+
+	lastState := &SyncState{
+		Elements: map[string]ElementState{
+			"customer": {Title: "Customer", Kind: "actor"},
+		},
+	}
+
+	cs := DetectChanges(m, doc, lastState, nil)
+
+	// Should detect a drawio-side technology change.
+	found := false
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.ID == "customer" && ch.Field == "technology" && ch.NewValue == "Human" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected drawio technology change for 'customer', got changes: %+v", cs.DrawioElementChanges)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes reverse sync not detecting technology added via XML attribute in draw.io (#186)
- Root cause: `extractDrawioElements` only read technology from `ParseLabel` (HTML label brackets), ignoring the `technology` XML attribute
- Fix: fall back to `technology` XML attribute when label doesn't contain technology

## Test plan
- [x] `TestDetectChanges_TechnologyFromXMLAttribute` — verifies technology detected from XML attribute
- [x] `go test -race ./...` — all tests pass

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)