### PR TITLE
fix: direct relationship suppresses duplicate lifted connector

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -334,11 +334,18 @@ func applyChangesToPage(
 					// lifted to the same parent pair (a→b), only one connector
 					// should be created. Direct (non-lifted) relationships
 					// with the same pair must not be deduplicated. (#142)
+					pairKey := from + "->" + to
 					if isLifted {
-						pairKey := from + "->" + to
+						// Skip lifted relationships when a direct relationship
+						// or another lifted relationship already covers this
+						// pair. (#142, #197)
 						if liftedSeen[pairKey] {
 							continue
 						}
+						liftedSeen[pairKey] = true
+					} else {
+						// Record direct relationships so lifted ones targeting
+						// the same pair are suppressed in pass 1. (#197)
 						liftedSeen[pairKey] = true
 					}
 					applyRelAdded(lifted, viewID, page, templates, result)

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -284,6 +284,61 @@ func TestApplyForward_RelationshipLiftingDedup(t *testing.T) {
 	}
 }
 
+// TestApplyForward_DirectRelSuppressesLifted verifies that when a direct
+// relationship a→b exists AND a child relationship a→b.c lifts to a→b,
+// only one connector is created (the direct one wins). (#197)
+func TestApplyForward_DirectRelSuppressesLifted(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "system", Title: "A"},
+			"b": {Kind: "system", Title: "B", Children: map[string]model.Element{
+				"c": {Kind: "container", Title: "C"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "direct", Kind: "uses"},
+			{From: "a", To: "b.c", Label: "indirect", Kind: "uses"},
+		},
+		Views: map[string]model.View{
+			"overview": {
+				Title:   "Overview",
+				Include: []string{"a", "b"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "a", Type: Added},
+			{ID: "b", Type: Added},
+			{ID: "b.c", Type: Added},
+		},
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "direct"},
+			{From: "a", To: "b.c", Index: 1, Type: Added, NewValue: "indirect"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m, nil)
+
+	page := doc.GetPage("view-overview")
+	conns := page.FindAllConnectors()
+
+	if len(conns) != 1 {
+		t.Errorf("expected 1 connector (direct suppresses lifted), got %d", len(conns))
+	}
+	if len(conns) == 1 {
+		label := conns[0].SelectAttrValue("value", "")
+		if label != "direct" {
+			t.Errorf("expected connector label %q, got %q", "direct", label)
+		}
+	}
+}
+
 // TestApplyForward_ScopeBoundingBox verifies that the scope element of a view
 // is rendered as a boundary/swimlane on the page, with children nested inside.
 func TestApplyForward_ScopeBoundingBox(t *testing.T) {


### PR DESCRIPTION
## Summary
- When both a direct relationship `a→b` and a liftable `a→b.c` (lifts to `a→b`) exist, only one connector is now rendered
- Direct relationships are recorded in `liftedSeen` during pass 0 so lifted duplicates are skipped in pass 1

## Test plan
- [x] New test `TestApplyForward_DirectRelSuppressesLifted` — verifies only 1 connector with label "direct"
- [x] Existing `TestApplyForward_RelationshipLiftingDedup` still passes (lifted-vs-lifted dedup)
- [x] `make test-race` all green

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)