### PR TITLE
fix: verify export output file exists after draw.io CLI

### DIFF
--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -4,6 +4,7 @@ package export
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 )
@@ -56,6 +57,10 @@ func ExportPage(binary string, opts ExportOptions) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("draw.io export failed: %w\nOutput: %s", err, string(output))
+	}
+	// Verify the output file was actually created (#195).
+	if _, err := os.Stat(opts.OutputPath); err != nil {
+		return fmt.Errorf("draw.io CLI exited successfully but output file not created: %s", opts.OutputPath)
 	}
 	return nil
 }

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -113,6 +113,30 @@ func TestOutputFileName(t *testing.T) {
 	}
 }
 
+// TestExportPage_ErrorWhenOutputMissing verifies that ExportPage returns an
+// error when the draw.io CLI exits successfully but the output file does not
+// exist (e.g., permission denied on output directory). (#195)
+func TestExportPage_ErrorWhenOutputMissing(t *testing.T) {
+	// Create a fake "draw.io" binary that exits 0 but writes nothing.
+	dir := t.TempDir()
+	fakeBin := filepath.Join(dir, "drawio-fake")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	outFile := filepath.Join(dir, "should-not-exist.png")
+
+	err := ExportPage(fakeBin, ExportOptions{
+		Format:     "png",
+		PageIndex:  1,
+		OutputPath: outFile,
+		InputFile:  "/dev/null",
+	})
+	if err == nil {
+		t.Error("expected error when output file not created, got nil")
+	}
+}
+
 func TestExportPage_Integration(t *testing.T) {
 	// Skip if draw.io CLI is not available.
 	if _, err := exec.LookPath("drawio-export"); err != nil {


### PR DESCRIPTION
## Summary
- `ExportPage` now verifies the output file exists after draw.io CLI exits successfully
- Prevents silent failures when the output directory is unwritable (e.g., read-only permissions)

## Test plan
- [x] New test `TestExportPage_ErrorWhenOutputMissing` — fake binary exits 0 but writes nothing, ExportPage returns error
- [x] Existing `TestExportPage_Integration` still passes
- [x] `make test-race` all green

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)