### PR TITLE
feat: add drill-down navigation links and back-navigation buttons

### DIFF
--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/beevik/etree"
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
@@ -82,6 +83,15 @@ func applyForwardPerView(
 	newPageIDs map[string]bool,
 	result *ForwardResult,
 ) {
+	// Build drill-down link map: elementID → "data:page/id,view-<viewID>"
+	// An element gets a link when a view's scope matches that element.
+	drillDownLinks := make(map[string]string)
+	for vID, v := range m.Views {
+		if v.Scope != "" {
+			drillDownLinks[v.Scope] = "data:page/id,view-" + vID
+		}
+	}
+
 	for viewID, view := range m.Views {
 		pageID := "view-" + viewID
 		page := doc.GetPage(pageID)
@@ -122,6 +132,14 @@ func applyForwardPerView(
 		// Reconciliation: remove elements on the page that are no longer
 		// in the resolved view (e.g., after exclude list changes). #102
 		reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
+
+		// Set drill-down links on elements that have a detail view. (#198)
+		applyDrillDownLinks(page, drillDownLinks)
+
+		// Create back-navigation button on detail views (views with scope). (#198)
+		if scopeID != "" {
+			createBackNavButton(page, viewID, scopeID, m)
+		}
 	}
 }
 
@@ -706,4 +724,94 @@ func mergeStyles(base, overlay string) string {
 		sb.WriteByte(';')
 	}
 	return sb.String()
+}
+
+// applyDrillDownLinks sets the link attribute on elements that have a detail
+// view (a view whose scope matches the element's bausteinsicht_id). (#198)
+func applyDrillDownLinks(page *drawio.Page, links map[string]string) {
+	for _, obj := range page.FindAllElements() {
+		bid := obj.SelectAttrValue("bausteinsicht_id", "")
+		if link, ok := links[bid]; ok {
+			setAttrOn(obj, "link", link)
+		}
+	}
+}
+
+// setAttrOn sets or creates an attribute on an etree element.
+func setAttrOn(el *etree.Element, key, value string) {
+	for i, a := range el.Attr {
+		if a.Key == key {
+			el.Attr[i].Value = value
+			return
+		}
+	}
+	el.CreateAttr(key, value)
+}
+
+// createBackNavButton adds a small navigation button to a detail view page
+// that links back to the parent view. The parent view is the one that
+// contains the scope element. (#198)
+func createBackNavButton(
+	page *drawio.Page,
+	viewID string,
+	scopeID string,
+	m *model.BausteinsichtModel,
+) {
+	navCellID := "nav-back-" + viewID
+
+	// Don't create if already exists.
+	root := page.Root()
+	if root == nil {
+		return
+	}
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("id", "") == navCellID {
+			return
+		}
+	}
+
+	// Find the parent view: a view that includes the scope element.
+	var parentViewID string
+	var parentTitle string
+	for vID, v := range m.Views {
+		if vID == viewID {
+			continue
+		}
+		viewCopy := v
+		resolved, err := model.ResolveView(m, &viewCopy)
+		if err != nil {
+			continue
+		}
+		for _, id := range resolved {
+			if id == scopeID {
+				parentViewID = vID
+				parentTitle = v.Title
+				break
+			}
+		}
+		if parentViewID != "" {
+			break
+		}
+	}
+
+	if parentViewID == "" {
+		return // No parent view found.
+	}
+
+	obj := root.CreateElement("object")
+	obj.CreateAttr("label", "&larr; "+parentTitle)
+	obj.CreateAttr("id", navCellID)
+	obj.CreateAttr("link", "data:page/id,view-"+parentViewID)
+
+	cell := obj.CreateElement("mxCell")
+	cell.CreateAttr("style", "rounded=1;fillColor=#f8cecc;strokeColor=#b85450;html=1;fontSize=10;")
+	cell.CreateAttr("vertex", "1")
+	cell.CreateAttr("parent", "1")
+
+	geo := cell.CreateElement("mxGeometry")
+	geo.CreateAttr("x", "20")
+	geo.CreateAttr("y", "20")
+	geo.CreateAttr("width", "140")
+	geo.CreateAttr("height", "30")
+	geo.CreateAttr("as", "geometry")
 }

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
@@ -777,5 +778,123 @@ func TestApplyForward_NoViewsFallback(t *testing.T) {
 	page := doc.Pages()[0]
 	if page.FindElement("api") == nil {
 		t.Error("expected 'api' on first page when no views defined")
+	}
+}
+
+// TestApplyForward_DrillDownNavigationLinks verifies that elements with a
+// detail view (a view whose scope matches the element) get a link attribute
+// pointing to that view's page. (#198)
+func TestApplyForward_DrillDownNavigationLinks(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	doc.AddPage("view-containers", "Container View")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"customer": {Kind: "actor", Title: "Customer"},
+			"shop": {Kind: "system", Title: "Shop", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API"},
+			}},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"customer", "shop"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "shop",
+				Include: []string{"customer", "shop.*"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "customer", Type: Added},
+			{ID: "shop", Type: Added},
+			{ID: "shop.api", Type: Added},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m, nil)
+
+	// "shop" on context page should have a link to the containers view.
+	contextPage := doc.GetPage("view-context")
+	shopElem := contextPage.FindElement("shop")
+	if shopElem == nil {
+		t.Fatal("shop element not found on context page")
+	}
+	link := shopElem.SelectAttrValue("link", "")
+	if link != "data:page/id,view-containers" {
+		t.Errorf("expected link %q on shop, got %q", "data:page/id,view-containers", link)
+	}
+
+	// "customer" should NOT have a link (no view scoped to customer).
+	custElem := contextPage.FindElement("customer")
+	if custElem == nil {
+		t.Fatal("customer element not found on context page")
+	}
+	custLink := custElem.SelectAttrValue("link", "")
+	if custLink != "" {
+		t.Errorf("expected no link on customer, got %q", custLink)
+	}
+}
+
+// TestApplyForward_BackNavigationButton verifies that detail views (views with
+// a scope) get a back-navigation button linking to the parent view. (#198)
+func TestApplyForward_BackNavigationButton(t *testing.T) {
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	doc.AddPage("view-containers", "Container View")
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"shop": {Kind: "system", Title: "Shop", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API"},
+			}},
+		},
+		Relationships: []model.Relationship{},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"shop"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "shop",
+				Include: []string{"shop.*"},
+			},
+		},
+	}
+
+	cs := &ChangeSet{
+		ModelElementChanges: []ElementChange{
+			{ID: "shop", Type: Added},
+			{ID: "shop.api", Type: Added},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m, nil)
+
+	// The containers page should have a back-navigation button.
+	containerPage := doc.GetPage("view-containers")
+	root := containerPage.Root()
+	var navFound bool
+	for _, obj := range root.SelectElements("object") {
+		if strings.Contains(obj.SelectAttrValue("id", ""), "nav-back") {
+			navFound = true
+			navLink := obj.SelectAttrValue("link", "")
+			if !strings.Contains(navLink, "data:page/id,view-") {
+				t.Errorf("expected navigation link on back button, got %q", navLink)
+			}
+			break
+		}
+	}
+	if !navFound {
+		t.Error("expected back-navigation button on containers page")
 	}
 }


### PR DESCRIPTION
## Summary
- Elements with a detail view (a view whose scope matches the element) now get a `link="data:page/id,view-<viewID>"` attribute for clickable drill-down navigation in draw.io
- Detail views (views with a scope) get a back-navigation button (pink pill) linking back to the parent view where the scope element is visible
- Back-navigation buttons are idempotent — not recreated if already present

## Test plan
- [x] `TestApplyForward_DrillDownNavigationLinks` — verifies shop gets link to containers view, customer has no link
- [x] `TestApplyForward_BackNavigationButton` — verifies containers page gets a `nav-back-*` button with page link
- [x] All existing tests pass — `make test-race` all green

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)