### PR TITLE
fix: import new elements drawn in draw.io (#196)

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -185,6 +185,7 @@ func DetectChanges(m *model.BausteinsichtModel, doc *drawio.Document, lastState 
 	visibleElems := computeVisibleElements(m)
 	newPageOnly := computeNewPageOnlyElements(m, newPageIDs)
 	detectElementChanges(cs, flatModel, drawioElems, lastState, visibleElems, newPageOnly)
+	detectUnmanagedDrawioElements(cs, doc)
 
 	modelRels := buildModelRelMap(m)
 	drawioRels := extractDrawioRelationships(doc)
@@ -223,6 +224,56 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 		}
 	}
 	return result
+}
+
+// detectUnmanagedDrawioElements finds shapes in draw.io that have no
+// bausteinsicht_id attribute and emits Added element changes for them.
+// This allows reverse sync to import new elements drawn by the user (#196).
+func detectUnmanagedDrawioElements(cs *ChangeSet, doc *drawio.Document) {
+	for _, page := range doc.Pages() {
+		root := page.Root()
+		if root == nil {
+			continue
+		}
+		for _, obj := range root.SelectElements("object") {
+			if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+				continue // managed element, already handled
+			}
+			// Skip navigation buttons created by forward sync.
+			objID := obj.SelectAttrValue("id", "")
+			if strings.HasPrefix(objID, "nav-back-") {
+				continue
+			}
+			// Check that it wraps a vertex cell (not a connector).
+			cell := obj.SelectElement("mxCell")
+			if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
+				continue
+			}
+			label := obj.SelectAttrValue("label", "")
+			if label == "" {
+				continue
+			}
+			title, _, _ := drawio.ParseLabel(label)
+			id := sanitizeID(title)
+			if id == "" {
+				continue
+			}
+			cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{
+				ID:       id,
+				Type:     Added,
+				NewValue: title,
+			})
+		}
+	}
+}
+
+// sanitizeID converts a title to a lowercase, hyphen-separated ID suitable
+// for use as a model element key.
+func sanitizeID(title string) string {
+	title = strings.TrimSpace(title)
+	title = strings.ToLower(title)
+	title = strings.ReplaceAll(title, " ", "-")
+	return title
 }
 
 // stripScopedPrefix removes the view prefix from a scoped cell ID.

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -152,8 +152,15 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *R
 			fmt.Sprintf("Element %q was deleted in draw.io and removed from model", ch.ID))
 
 	case Added:
+		if m.Model == nil {
+			m.Model = make(map[string]model.Element)
+		}
+		m.Model[ch.ID] = model.Element{
+			Title: ch.NewValue,
+		}
+		result.ElementsCreated++
 		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("New element %q detected in draw.io. Add it to the model to keep it synchronized.", ch.ID))
+			fmt.Sprintf("New element %q added from draw.io — review and assign a meaningful ID if needed.", ch.ID))
 	}
 }
 

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docToolchain/Bauteinsicht/internal/drawio"
 	"github.com/docToolchain/Bauteinsicht/internal/model"
 )
 
@@ -142,16 +143,13 @@ func TestApplyReverse_AddedElementWarning(t *testing.T) {
 	if len(r.Warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d: %v", len(r.Warnings), r.Warnings)
 	}
-	// The warning should include the element ID and mention the model. (#115)
+	// The warning should include the element ID. (#115, #196)
 	w := r.Warnings[0]
 	if !strings.Contains(w, `"unknown"`) {
 		t.Errorf("expected warning to include element ID %q, got: %s", "unknown", w)
 	}
-	if !strings.Contains(w, "model") {
-		t.Errorf("expected warning to mention 'model', got: %s", w)
-	}
-	if r.ElementsCreated != 0 {
-		t.Errorf("expected ElementsCreated=0, got %d", r.ElementsCreated)
+	if r.ElementsCreated != 1 {
+		t.Errorf("expected ElementsCreated=1, got %d", r.ElementsCreated)
 	}
 }
 
@@ -334,5 +332,110 @@ func TestApplyReverse_SwapConnectorDirectionPreservesMetadata(t *testing.T) {
 	}
 	if result.RelationshipsUpdated != 1 {
 		t.Errorf("expected RelationshipsUpdated=1, got %d", result.RelationshipsUpdated)
+	}
+}
+
+// TestDetectChanges_NewElementFromDrawio verifies that a new shape added in
+// draw.io (without bausteinsicht_id) is detected as an Added element change. (#196)
+func TestDetectChanges_NewElementFromDrawio(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system": {Notation: "System"},
+			},
+		},
+		Model: map[string]model.Element{
+			"existing": {Kind: "system", Title: "Existing"},
+		},
+		Views: map[string]model.View{
+			"context": {Title: "System Context", Include: []string{"existing"}},
+		},
+	}
+
+	// Create a drawio doc with the existing element plus a new unmanaged shape.
+	doc := drawio.NewDocument()
+	doc.AddPage("view-context", "System Context")
+	page := doc.GetPage("view-context")
+	if err := page.CreateElement(drawio.ElementData{
+		ID: "existing", CellID: "context--existing",
+		Kind: "system", Title: "Existing",
+	}, "shape=test;"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a new shape WITHOUT bausteinsicht_id — simulates user drawing in draw.io.
+	root := page.Root()
+	obj := root.CreateElement("object")
+	obj.CreateAttr("label", "New Service")
+	obj.CreateAttr("id", "new-shape-1")
+	cell := obj.CreateElement("mxCell")
+	cell.CreateAttr("style", "rounded=1;")
+	cell.CreateAttr("vertex", "1")
+	cell.CreateAttr("parent", "1")
+
+	lastState := &SyncState{
+		Elements: map[string]ElementState{
+			"existing": {Title: "Existing"},
+		},
+	}
+
+	cs := DetectChanges(m, doc, lastState, nil)
+
+	// Should detect the new element as a drawio Added change.
+	var found bool
+	for _, ch := range cs.DrawioElementChanges {
+		if ch.Type == Added && ch.NewValue == "New Service" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected Added change for new drawio element 'New Service', got changes: %+v", cs.DrawioElementChanges)
+	}
+}
+
+// TestApplyReverse_NewElementFromDrawio verifies that a new element detected
+// from draw.io is added to the model with an auto-generated ID. (#196)
+func TestApplyReverse_NewElementFromDrawio(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system": {Notation: "System"},
+			},
+		},
+		Model: map[string]model.Element{
+			"existing": {Kind: "system", Title: "Existing"},
+		},
+	}
+
+	cs := &ChangeSet{
+		DrawioElementChanges: []ElementChange{
+			{
+				ID:       "newservice",
+				Type:     Added,
+				NewValue: "New Service",
+			},
+		},
+	}
+
+	result := ApplyReverse(cs, m)
+
+	// The new element should be added to the model.
+	if _, ok := m.Model["newservice"]; !ok {
+		t.Error("expected element 'newservice' to be added to model")
+	}
+	if result.ElementsCreated != 1 {
+		t.Errorf("expected ElementsCreated=1, got %d", result.ElementsCreated)
+	}
+	// Should warn the user to assign a meaningful ID.
+	var hasWarning bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "newservice") {
+			hasWarning = true
+			break
+		}
+	}
+	if !hasWarning {
+		t.Error("expected warning about the auto-generated ID")
 	}
 }


### PR DESCRIPTION
## Summary
- DetectChanges now scans for unmanaged `<object>` shapes (without `bausteinsicht_id`) and emits `Added` element changes
- ApplyReverse inserts new elements into the model with an auto-generated ID derived from the label
- Back-navigation buttons (`nav-back-*`) are excluded from detection
- Warns user to review auto-generated IDs

## Test plan
- [x] `TestDetectChanges_NewElementFromDrawio` — verifies detection of new draw.io shapes
- [x] `TestApplyReverse_NewElementFromDrawio` — verifies element added to model with warning
- [x] Updated `TestApplyReverse_AddedElementWarning` to match new behavior
- [x] All existing tests pass
- [x] Race detector clean

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)