### PR TITLE
fix: assign default kind to new elements from draw.io (#206)

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -160,12 +160,14 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, result *R
 				fmt.Sprintf("New element %q from draw.io skipped: ID already exists in model.", ch.ID))
 			return
 		}
+		kind := firstSpecKind(m)
 		m.Model[ch.ID] = model.Element{
+			Kind:  kind,
 			Title: ch.NewValue,
 		}
 		result.ElementsCreated++
 		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("New element %q added from draw.io — review and assign a meaningful ID if needed.", ch.ID))
+			fmt.Sprintf("New element %q added from draw.io (kind=%q) — review and assign a meaningful ID and kind.", ch.ID, kind))
 	}
 }
 
@@ -301,6 +303,21 @@ func deleteFromMap(elems map[string]model.Element, parts []string, fullID string
 	}
 	elems[key] = elem
 	return nil
+}
+
+// firstSpecKind returns the first element kind defined in the specification,
+// sorted alphabetically for determinism. Returns "" if no kinds are defined.
+func firstSpecKind(m *model.BausteinsichtModel) string {
+	if len(m.Specification.Elements) == 0 {
+		return ""
+	}
+	var best string
+	for k := range m.Specification.Elements {
+		if best == "" || k < best {
+			best = k
+		}
+	}
+	return best
 }
 
 // removeFromSlice returns a new slice with all occurrences of val removed.

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -485,3 +485,70 @@ func TestApplyReverse_NewElementCollidingIDSkipped(t *testing.T) {
 		t.Errorf("expected collision warning mentioning 'already exists', got: %v", result.Warnings)
 	}
 }
+
+// TestApplyReverse_NewElementGetsDefaultKind verifies that a new element
+// imported from draw.io receives a default kind from the specification
+// rather than an empty string (#206).
+func TestApplyReverse_NewElementGetsDefaultKind(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system":    {Notation: "System"},
+				"container": {Notation: "Container"},
+			},
+		},
+		Model: map[string]model.Element{},
+	}
+
+	cs := &ChangeSet{
+		DrawioElementChanges: []ElementChange{
+			{ID: "newservice", Type: Added, NewValue: "New Service"},
+		},
+	}
+
+	ApplyReverse(cs, m)
+
+	elem, ok := m.Model["newservice"]
+	if !ok {
+		t.Fatal("expected element 'newservice' to be added")
+	}
+	if elem.Kind == "" {
+		t.Error("expected non-empty kind on new element, got empty string")
+	}
+	// Should be one of the specification kinds.
+	if _, valid := m.Specification.Elements[elem.Kind]; !valid {
+		t.Errorf("expected kind to be a valid spec kind, got %q", elem.Kind)
+	}
+}
+
+// TestApplyReverse_NewElementWarningMentionsKind verifies that the warning
+// for a new element mentions the assigned kind (#206).
+func TestApplyReverse_NewElementWarningMentionsKind(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system": {Notation: "System"},
+			},
+		},
+		Model: map[string]model.Element{},
+	}
+
+	cs := &ChangeSet{
+		DrawioElementChanges: []ElementChange{
+			{ID: "svc", Type: Added, NewValue: "Service"},
+		},
+	}
+
+	result := ApplyReverse(cs, m)
+
+	var found bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "kind") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning to mention 'kind', got: %v", result.Warnings)
+	}
+}


### PR DESCRIPTION
## Summary
- New elements imported from draw.io now receive the first alphabetically-sorted kind from the specification
- Warning message now mentions the assigned kind so users know to review it

## Test plan
- [x] `TestApplyReverse_NewElementGetsDefaultKind` — verifies non-empty valid kind assigned
- [x] `TestApplyReverse_NewElementWarningMentionsKind` — verifies warning mentions "kind"
- [x] All existing tests pass

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)