### PR TITLE
feat: self-architecture model (dogfooding)

### DIFF
--- a/src/docs/arc42/.bausteinsicht-sync
+++ b/src/docs/arc42/.bausteinsicht-sync
@@ -1,0 +1,273 @@
+{
+  "timestamp": "2026-03-02T22:34:07Z",
+  "model_hash": "sha256:945c6de61c94beaa028cbbd5479d602921cda609cbc8b7fe0565ed661904b8fb",
+  "drawio_hash": "sha256:5066c8890f43d9aa23222ab5bde8214a977a4ec9398ecfe072a55092ff639b1d",
+  "elements": {
+    "bausteinsicht": {
+      "title": "Bausteinsicht",
+      "description": "Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization",
+      "kind": "system"
+    },
+    "bausteinsicht.cli": {
+      "title": "CLI",
+      "description": "Command-line interface providing validate, sync, export, and watch commands",
+      "technology": "Go / Cobra",
+      "kind": "container"
+    },
+    "bausteinsicht.drawio": {
+      "title": "draw.io",
+      "description": "draw.io XML document handling — elements, connectors, templates, and labels",
+      "technology": "Go / etree",
+      "kind": "container"
+    },
+    "bausteinsicht.drawio.connector": {
+      "title": "Connector",
+      "description": "Connector/relationship CRUD for edges between elements",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.drawio.document": {
+      "title": "Document",
+      "description": "XML parsing, page management, and file I/O for .drawio files",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.drawio.element": {
+      "title": "Element",
+      "description": "Element CRUD operations on mxGraphModel objects and mxCells",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.drawio.label": {
+      "title": "Label",
+      "description": "HTML label generation and parsing for element display text",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.drawio.template": {
+      "title": "Template",
+      "description": "Template loading and style lookup from .drawio template files",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.export": {
+      "title": "Export",
+      "description": "Diagram export to PNG and SVG formats via draw.io CLI",
+      "technology": "Go",
+      "kind": "container"
+    },
+    "bausteinsicht.model": {
+      "title": "Model",
+      "description": "JSONC architecture model management — loading, validation, and mutation",
+      "technology": "Go",
+      "kind": "container"
+    },
+    "bausteinsicht.model.loader": {
+      "title": "Loader",
+      "description": "JSONC read/write with comment stripping and trailing comma handling",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.model.patch": {
+      "title": "Patch",
+      "description": "Comment-preserving JSONC mutations for reverse sync",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.model.resolve": {
+      "title": "Resolve",
+      "description": "Dot-notation element resolution and wildcard pattern matching",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.model.types": {
+      "title": "Types",
+      "description": "Core struct definitions for elements, relationships, views, and specification",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.model.validate": {
+      "title": "Validate",
+      "description": "Model validation rules for elements, relationships, and views",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync": {
+      "title": "Sync Engine",
+      "description": "Bidirectional synchronization engine between JSONC model and draw.io diagrams",
+      "technology": "Go",
+      "kind": "container"
+    },
+    "bausteinsicht.sync.conflict": {
+      "title": "Conflict",
+      "description": "Conflict detection and resolution when both model and diagram changed",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync.diff": {
+      "title": "Diff",
+      "description": "Three-way change detection comparing model, diagram, and last-sync state",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync.engine": {
+      "title": "Engine",
+      "description": "Main sync orchestrator coordinating diff, forward, reverse, and conflict resolution",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync.forward": {
+      "title": "Forward Sync",
+      "description": "Applies model changes to draw.io diagrams (model → drawio)",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync.reverse": {
+      "title": "Reverse Sync",
+      "description": "Applies draw.io changes back to the JSONC model (drawio → model)",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.sync.state": {
+      "title": "State",
+      "description": "Sync state persistence using SHA256 hashes for change detection",
+      "technology": "Go",
+      "kind": "component"
+    },
+    "bausteinsicht.watcher": {
+      "title": "Watcher",
+      "description": "File system monitoring for automatic sync on model or diagram changes",
+      "technology": "Go / fsnotify",
+      "kind": "container"
+    },
+    "developer": {
+      "title": "Developer",
+      "description": "Developer using the Bausteinsicht CLI to manage architecture models",
+      "kind": "actor"
+    },
+    "drawio_app": {
+      "title": "draw.io App",
+      "description": "draw.io desktop or web application for visual diagram editing",
+      "kind": "actor"
+    },
+    "ide": {
+      "title": "IDE",
+      "description": "IDE with JSON Schema support for JSONC editing with autocompletion",
+      "kind": "actor"
+    }
+  },
+  "relationships": [
+    {
+      "from": "developer",
+      "to": "bausteinsicht.cli",
+      "index": 0,
+      "label": "runs commands",
+      "kind": "uses"
+    },
+    {
+      "from": "developer",
+      "to": "ide",
+      "index": 1,
+      "label": "edits JSONC",
+      "kind": "uses"
+    },
+    {
+      "from": "developer",
+      "to": "drawio_app",
+      "index": 2,
+      "label": "edits diagrams",
+      "kind": "uses"
+    },
+    {
+      "from": "ide",
+      "to": "bausteinsicht.model",
+      "index": 3,
+      "label": "JSON Schema validation",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.cli",
+      "to": "bausteinsicht.watcher",
+      "index": 4,
+      "label": "starts watch mode",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.cli",
+      "to": "bausteinsicht.export",
+      "index": 5,
+      "label": "triggers export",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.diff",
+      "index": 6,
+      "label": "detects changes",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.forward",
+      "index": 7,
+      "label": "model → drawio",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.reverse",
+      "index": 8,
+      "label": "drawio → model",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.state",
+      "index": 9,
+      "label": "loads/saves state",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.conflict",
+      "index": 10,
+      "label": "resolves conflicts",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.forward",
+      "to": "bausteinsicht.drawio.element",
+      "index": 11,
+      "label": "creates/updates elements",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.forward",
+      "to": "bausteinsicht.drawio.connector",
+      "index": 12,
+      "label": "creates/updates connectors",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.reverse",
+      "to": "bausteinsicht.model.patch",
+      "index": 13,
+      "label": "comment-preserving updates",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.drawio.element",
+      "to": "bausteinsicht.drawio.label",
+      "index": 14,
+      "label": "generates labels",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.drawio.element",
+      "to": "bausteinsicht.drawio.template",
+      "index": 15,
+      "label": "looks up styles",
+      "kind": "uses"
+    }
+  ]
+}

--- a/src/docs/arc42/architecture.drawio
+++ b/src/docs/arc42/architecture.drawio
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="bausteinsicht" compressed="false">
+  <diagram id="view-context" name="System Context">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object label="&lt;b&gt;draw.io App&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;draw.io desktop or web application for visual diagram editing&lt;/font&gt;" id="context--drawio_app" bausteinsicht_id="drawio_app" bausteinsicht_kind="actor" tooltip="draw.io desktop or web application for visual diagram editing">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="40" y="0" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Developer&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Developer using the Bausteinsicht CLI to manage architecture models&lt;/font&gt;" id="context--developer" bausteinsicht_id="developer" bausteinsicht_kind="actor" tooltip="Developer using the Bausteinsicht CLI to manage architecture models">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="180" y="0" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Bausteinsicht&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization&lt;/font&gt;" id="context--bausteinsicht" bausteinsicht_id="bausteinsicht" bausteinsicht_kind="system" tooltip="Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization" link="data:page/id,view-containers">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1168BD;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="320" y="0" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;IDE&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;IDE with JSON Schema support for JSONC editing with autocompletion&lt;/font&gt;" id="context--ide" bausteinsicht_id="ide" bausteinsicht_kind="actor" tooltip="IDE with JSON Schema support for JSONC editing with autocompletion">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;dashed=1;strokeColor=#FF0000;" vertex="1" parent="1">
+            <mxGeometry x="560" y="0" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell id="rel-context--developer-context--ide-1" value="edits JSONC" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="context--developer" target="context--ide" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-context--developer-context--drawio_app-2" value="edits diagrams" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="context--developer" target="context--drawio_app" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-context--developer-context--bausteinsicht-0" value="runs commands" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="context--developer" target="context--bausteinsicht" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-context--ide-context--bausteinsicht-3" value="JSON Schema validation" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="context--ide" target="context--bausteinsicht" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-context--drawio_app-context--bausteinsicht-4" value="modifies .drawio file" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="context--drawio_app" target="context--bausteinsicht" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="view-containers" name="Container View">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object label="&lt;b&gt;Bausteinsicht&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization&lt;/font&gt;" id="containers--bausteinsicht" bausteinsicht_id="bausteinsicht" bausteinsicht_kind="system_boundary" tooltip="Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization" link="data:page/id,view-containers">
+          <mxCell style="swimlane;startSize=30;fillColor=#E8E8E8;strokeColor=#0B4884;fontColor=#0B4884;fontStyle=1;rounded=1;arcSize=5;whiteSpace=wrap;html=1;container=1;collapsible=0;fontSize=12;" vertex="1" parent="1">
+            <mxGeometry x="40" y="40" width="400" height="250" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Model&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;JSONC architecture model management — loading, validation, and mutation&lt;/font&gt;" id="containers--bausteinsicht.model" bausteinsicht_id="bausteinsicht.model" bausteinsicht_kind="container" technology="Go" tooltip="JSONC architecture model management — loading, validation, and mutation" link="data:page/id,view-model-components">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="40" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Sync Engine&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Bidirectional synchronization engine between JSONC model and draw.io diagrams&lt;/font&gt;" id="containers--bausteinsicht.sync" bausteinsicht_id="bausteinsicht.sync" bausteinsicht_kind="container" technology="Go" tooltip="Bidirectional synchronization engine between JSONC model and draw.io diagrams" link="data:page/id,view-sync-components">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="280" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;draw.io App&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;draw.io desktop or web application for visual diagram editing&lt;/font&gt;" id="containers--drawio_app" bausteinsicht_id="drawio_app" bausteinsicht_kind="actor" tooltip="draw.io desktop or web application for visual diagram editing">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="520" y="330" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Developer&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Developer using the Bausteinsicht CLI to manage architecture models&lt;/font&gt;" id="containers--developer" bausteinsicht_id="developer" bausteinsicht_kind="actor" tooltip="Developer using the Bausteinsicht CLI to manage architecture models">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="660" y="330" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;IDE&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;IDE with JSON Schema support for JSONC editing with autocompletion&lt;/font&gt;" id="containers--ide" bausteinsicht_id="ide" bausteinsicht_kind="actor" tooltip="IDE with JSON Schema support for JSONC editing with autocompletion">
+          <mxCell style="shape=mxgraph.c4.person2;whiteSpace=wrap;html=1;align=center;verticalAlign=top;verticalLabelPosition=bottom;fillColor=#08427B;fontColor=#ffffff;fontSize=11;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="800" y="330" width="100" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Watcher&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go / fsnotify]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;File system monitoring for automatic sync on model or diagram changes&lt;/font&gt;" id="containers--bausteinsicht.watcher" bausteinsicht_id="bausteinsicht.watcher" bausteinsicht_kind="container" technology="Go / fsnotify" tooltip="File system monitoring for automatic sync on model or diagram changes">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="940" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;draw.io&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go / etree]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;draw.io XML document handling — elements, connectors, templates, and labels&lt;/font&gt;" id="containers--bausteinsicht.drawio" bausteinsicht_id="bausteinsicht.drawio" bausteinsicht_kind="container" technology="Go / etree" tooltip="draw.io XML document handling — elements, connectors, templates, and labels" link="data:page/id,view-drawio-components">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="1180" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;CLI&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go / Cobra]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Command-line interface providing validate, sync, export, and watch commands&lt;/font&gt;" id="containers--bausteinsicht.cli" bausteinsicht_id="bausteinsicht.cli" bausteinsicht_kind="container" technology="Go / Cobra" tooltip="Command-line interface providing validate, sync, export, and watch commands">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="1420" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Export&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Diagram export to PNG and SVG formats via draw.io CLI&lt;/font&gt;" id="containers--bausteinsicht.export" bausteinsicht_id="bausteinsicht.export" bausteinsicht_kind="container" technology="Go" tooltip="Diagram export to PNG and SVG formats via draw.io CLI">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#438DD5;fontColor=#ffffff;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="containers--bausteinsicht">
+            <mxGeometry x="1660" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell id="rel-containers--developer-containers--ide-1" value="edits JSONC" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--developer" target="containers--ide" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--developer-containers--bausteinsicht.cli-0" value="runs commands" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--developer" target="containers--bausteinsicht.cli" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--developer-containers--drawio_app-2" value="edits diagrams" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--developer" target="containers--drawio_app" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--ide-containers--bausteinsicht.model-3" value="JSON Schema validation" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--ide" target="containers--bausteinsicht.model" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.cli-containers--bausteinsicht.watcher-8" value="starts watch mode" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.cli" target="containers--bausteinsicht.watcher" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.cli-containers--bausteinsicht.export-9" value="triggers export" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.cli" target="containers--bausteinsicht.export" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.sync-containers--bausteinsicht.drawio-16" value="creates/updates connectors" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.sync" target="containers--bausteinsicht.drawio" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.cli-containers--bausteinsicht.sync-7" value="triggers sync" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.cli" target="containers--bausteinsicht.sync" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.cli-containers--bausteinsicht.model-6" value="validates model" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.cli" target="containers--bausteinsicht.model" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.watcher-containers--bausteinsicht.sync-21" value="triggers on file change" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.watcher" target="containers--bausteinsicht.sync" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.export-containers--bausteinsicht.drawio-22" value="reads diagram pages" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.export" target="containers--bausteinsicht.drawio" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--bausteinsicht.sync-containers--bausteinsicht.model-17" value="comment-preserving updates" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--bausteinsicht.sync" target="containers--bausteinsicht.model" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-containers--drawio_app-containers--bausteinsicht.drawio-4" value="modifies .drawio file" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="containers--drawio_app" target="containers--bausteinsicht.drawio" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <object label="&amp;larr; System Context" id="nav-back-containers" link="data:page/id,view-context">
+          <mxCell style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;html=1;fontSize=10;" vertex="1" parent="1">
+            <mxGeometry x="20" y="20" width="140" height="30" as="geometry"/>
+          </mxCell>
+        </object>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="view-sync-components" name="Sync Engine Components">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object label="&lt;b&gt;Sync Engine&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Bidirectional synchronization engine between JSONC model and draw.io diagrams&lt;/font&gt;" id="sync-components--bausteinsicht.sync" bausteinsicht_id="bausteinsicht.sync" bausteinsicht_kind="container_boundary" technology="Go" tooltip="Bidirectional synchronization engine between JSONC model and draw.io diagrams" link="data:page/id,view-sync-components">
+          <mxCell style="swimlane;startSize=30;fillColor=#F0F4FA;strokeColor=#3C7FC0;fontColor=#3C7FC0;fontStyle=1;rounded=1;arcSize=5;whiteSpace=wrap;html=1;container=1;collapsible=0;fontSize=12;" vertex="1" parent="1">
+            <mxGeometry x="40" y="40" width="400" height="250" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Conflict&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Conflict detection and resolution when both model and diagram changed&lt;/font&gt;" id="sync-components--bausteinsicht.sync.conflict" bausteinsicht_id="bausteinsicht.sync.conflict" bausteinsicht_kind="component" technology="Go" tooltip="Conflict detection and resolution when both model and diagram changed">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="40" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Patch&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Comment-preserving JSONC mutations for reverse sync&lt;/font&gt;" id="sync-components--bausteinsicht.model.patch" bausteinsicht_id="bausteinsicht.model.patch" bausteinsicht_kind="component" technology="Go" tooltip="Comment-preserving JSONC mutations for reverse sync">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="280" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Reverse Sync&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Applies draw.io changes back to the JSONC model (drawio → model)&lt;/font&gt;" id="sync-components--bausteinsicht.sync.reverse" bausteinsicht_id="bausteinsicht.sync.reverse" bausteinsicht_kind="component" technology="Go" tooltip="Applies draw.io changes back to the JSONC model (drawio → model)">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="520" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Engine&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Main sync orchestrator coordinating diff, forward, reverse, and conflict resolution&lt;/font&gt;" id="sync-components--bausteinsicht.sync.engine" bausteinsicht_id="bausteinsicht.sync.engine" bausteinsicht_kind="component" technology="Go" tooltip="Main sync orchestrator coordinating diff, forward, reverse, and conflict resolution">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;dashed=1;strokeColor=#FF0000;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="760" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;State&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Sync state persistence using SHA256 hashes for change detection&lt;/font&gt;" id="sync-components--bausteinsicht.sync.state" bausteinsicht_id="bausteinsicht.sync.state" bausteinsicht_kind="component" technology="Go" tooltip="Sync state persistence using SHA256 hashes for change detection">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="1000" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Connector&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Connector/relationship CRUD for edges between elements&lt;/font&gt;" id="sync-components--bausteinsicht.drawio.connector" bausteinsicht_id="bausteinsicht.drawio.connector" bausteinsicht_kind="component" technology="Go" tooltip="Connector/relationship CRUD for edges between elements">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="1240" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Diff&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Three-way change detection comparing model, diagram, and last-sync state&lt;/font&gt;" id="sync-components--bausteinsicht.sync.diff" bausteinsicht_id="bausteinsicht.sync.diff" bausteinsicht_kind="component" technology="Go" tooltip="Three-way change detection comparing model, diagram, and last-sync state">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="1480" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Forward Sync&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Applies model changes to draw.io diagrams (model → drawio)&lt;/font&gt;" id="sync-components--bausteinsicht.sync.forward" bausteinsicht_id="bausteinsicht.sync.forward" bausteinsicht_kind="component" technology="Go" tooltip="Applies model changes to draw.io diagrams (model → drawio)">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;dashed=1;strokeColor=#FF0000;" vertex="1" parent="sync-components--bausteinsicht.sync">
+            <mxGeometry x="1720" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Element&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Element CRUD operations on mxGraphModel objects and mxCells&lt;/font&gt;" id="sync-components--bausteinsicht.drawio.element" bausteinsicht_id="bausteinsicht.drawio.element" bausteinsicht_kind="component" technology="Go" tooltip="Element CRUD operations on mxGraphModel objects and mxCells">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="1">
+            <mxGeometry x="1960" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.forward-sync-components--bausteinsicht.drawio.connector-16" value="creates/updates connectors" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.forward" target="sync-components--bausteinsicht.drawio.connector" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.engine-sync-components--bausteinsicht.sync.forward-11" value="model → drawio" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.engine" target="sync-components--bausteinsicht.sync.forward" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.engine-sync-components--bausteinsicht.sync.diff-10" value="detects changes" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.engine" target="sync-components--bausteinsicht.sync.diff" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.forward-sync-components--bausteinsicht.drawio.element-15" value="creates/updates elements" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.forward" target="sync-components--bausteinsicht.drawio.element" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.engine-sync-components--bausteinsicht.sync.state-13" value="loads/saves state" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.engine" target="sync-components--bausteinsicht.sync.state" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.engine-sync-components--bausteinsicht.sync.conflict-14" value="resolves conflicts" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.engine" target="sync-components--bausteinsicht.sync.conflict" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.reverse-sync-components--bausteinsicht.model.patch-17" value="comment-preserving updates" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.reverse" target="sync-components--bausteinsicht.model.patch" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-sync-components--bausteinsicht.sync.engine-sync-components--bausteinsicht.sync.reverse-12" value="drawio → model" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="sync-components--bausteinsicht.sync.engine" target="sync-components--bausteinsicht.sync.reverse" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <object label="&amp;larr; Container View" id="nav-back-sync-components" link="data:page/id,view-containers">
+          <mxCell style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;html=1;fontSize=10;" vertex="1" parent="1">
+            <mxGeometry x="20" y="20" width="140" height="30" as="geometry"/>
+          </mxCell>
+        </object>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="view-drawio-components" name="draw.io Package Components">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object label="&lt;b&gt;draw.io&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go / etree]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;draw.io XML document handling — elements, connectors, templates, and labels&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio" bausteinsicht_id="bausteinsicht.drawio" bausteinsicht_kind="container_boundary" technology="Go / etree" tooltip="draw.io XML document handling — elements, connectors, templates, and labels" link="data:page/id,view-drawio-components">
+          <mxCell style="swimlane;startSize=30;fillColor=#F0F4FA;strokeColor=#3C7FC0;fontColor=#3C7FC0;fontStyle=1;rounded=1;arcSize=5;whiteSpace=wrap;html=1;container=1;collapsible=0;fontSize=12;" vertex="1" parent="1">
+            <mxGeometry x="40" y="40" width="400" height="250" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Template&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Template loading and style lookup from .drawio template files&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio.template" bausteinsicht_id="bausteinsicht.drawio.template" bausteinsicht_kind="component" technology="Go" tooltip="Template loading and style lookup from .drawio template files">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="drawio-components--bausteinsicht.drawio">
+            <mxGeometry x="40" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Connector&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Connector/relationship CRUD for edges between elements&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio.connector" bausteinsicht_id="bausteinsicht.drawio.connector" bausteinsicht_kind="component" technology="Go" tooltip="Connector/relationship CRUD for edges between elements">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="drawio-components--bausteinsicht.drawio">
+            <mxGeometry x="280" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Label&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;HTML label generation and parsing for element display text&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio.label" bausteinsicht_id="bausteinsicht.drawio.label" bausteinsicht_kind="component" technology="Go" tooltip="HTML label generation and parsing for element display text">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="drawio-components--bausteinsicht.drawio">
+            <mxGeometry x="520" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Document&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;XML parsing, page management, and file I/O for .drawio files&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio.document" bausteinsicht_id="bausteinsicht.drawio.document" bausteinsicht_kind="component" technology="Go" tooltip="XML parsing, page management, and file I/O for .drawio files">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="drawio-components--bausteinsicht.drawio">
+            <mxGeometry x="760" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Element&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Element CRUD operations on mxGraphModel objects and mxCells&lt;/font&gt;" id="drawio-components--bausteinsicht.drawio.element" bausteinsicht_id="bausteinsicht.drawio.element" bausteinsicht_kind="component" technology="Go" tooltip="Element CRUD operations on mxGraphModel objects and mxCells">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="drawio-components--bausteinsicht.drawio">
+            <mxGeometry x="1000" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <mxCell id="rel-drawio-components--bausteinsicht.drawio.element-drawio-components--bausteinsicht.drawio.label-18" value="generates labels" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="drawio-components--bausteinsicht.drawio.element" target="drawio-components--bausteinsicht.drawio.label" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <mxCell id="rel-drawio-components--bausteinsicht.drawio.element-drawio-components--bausteinsicht.drawio.template-19" value="looks up styles" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=10;" edge="1" source="drawio-components--bausteinsicht.drawio.element" target="drawio-components--bausteinsicht.drawio.template" parent="1">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+        <object label="&amp;larr; Container View" id="nav-back-drawio-components" link="data:page/id,view-containers">
+          <mxCell style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;html=1;fontSize=10;" vertex="1" parent="1">
+            <mxGeometry x="20" y="20" width="140" height="30" as="geometry"/>
+          </mxCell>
+        </object>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="view-model-components" name="Model Package Components">
+    <mxGraphModel dx="1422" dy="794" grid="1" gridSize="10" page="1" pageWidth="1169" pageHeight="827" background="#ffffff">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <object label="&lt;b&gt;Model&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;JSONC architecture model management — loading, validation, and mutation&lt;/font&gt;" id="model-components--bausteinsicht.model" bausteinsicht_id="bausteinsicht.model" bausteinsicht_kind="container_boundary" technology="Go" tooltip="JSONC architecture model management — loading, validation, and mutation" link="data:page/id,view-model-components">
+          <mxCell style="swimlane;startSize=30;fillColor=#F0F4FA;strokeColor=#3C7FC0;fontColor=#3C7FC0;fontStyle=1;rounded=1;arcSize=5;whiteSpace=wrap;html=1;container=1;collapsible=0;fontSize=12;" vertex="1" parent="1">
+            <mxGeometry x="40" y="40" width="400" height="250" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Patch&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Comment-preserving JSONC mutations for reverse sync&lt;/font&gt;" id="model-components--bausteinsicht.model.patch" bausteinsicht_id="bausteinsicht.model.patch" bausteinsicht_kind="component" technology="Go" tooltip="Comment-preserving JSONC mutations for reverse sync">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="model-components--bausteinsicht.model">
+            <mxGeometry x="40" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Types&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Core struct definitions for elements, relationships, views, and specification&lt;/font&gt;" id="model-components--bausteinsicht.model.types" bausteinsicht_id="bausteinsicht.model.types" bausteinsicht_kind="component" technology="Go" tooltip="Core struct definitions for elements, relationships, views, and specification">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;dashed=1;strokeColor=#FF0000;" vertex="1" parent="model-components--bausteinsicht.model">
+            <mxGeometry x="280" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Loader&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;JSONC read/write with comment stripping and trailing comma handling&lt;/font&gt;" id="model-components--bausteinsicht.model.loader" bausteinsicht_id="bausteinsicht.model.loader" bausteinsicht_kind="component" technology="Go" tooltip="JSONC read/write with comment stripping and trailing comma handling">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;dashed=1;strokeColor=#FF0000;" vertex="1" parent="model-components--bausteinsicht.model">
+            <mxGeometry x="520" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Resolve&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Dot-notation element resolution and wildcard pattern matching&lt;/font&gt;" id="model-components--bausteinsicht.model.resolve" bausteinsicht_id="bausteinsicht.model.resolve" bausteinsicht_kind="component" technology="Go" tooltip="Dot-notation element resolution and wildcard pattern matching">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;strokeColor=#FF0000;dashed=1;" vertex="1" parent="model-components--bausteinsicht.model">
+            <mxGeometry x="760" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&lt;b&gt;Validate&lt;/b&gt;&lt;br&gt;&lt;font color=&quot;#666666&quot;&gt;[Go]&lt;/font&gt;&lt;br&gt;&lt;font color=&quot;#999999&quot;&gt;Model validation rules for elements, relationships, and views&lt;/font&gt;" id="model-components--bausteinsicht.model.validate" bausteinsicht_id="bausteinsicht.model.validate" bausteinsicht_kind="component" technology="Go" tooltip="Model validation rules for elements, relationships, and views">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fillColor=#85BBF0;fontColor=#000000;arcSize=5;fontSize=11;align=center;verticalAlign=middle;dashed=1;strokeColor=#FF0000;" vertex="1" parent="model-components--bausteinsicht.model">
+            <mxGeometry x="1000" y="330" width="200" height="120" as="geometry"/>
+          </mxCell>
+        </object>
+        <object label="&amp;larr; Container View" id="nav-back-model-components" link="data:page/id,view-containers">
+          <mxCell style="rounded=1;fillColor=#f8cecc;strokeColor=#b85450;html=1;fontSize=10;" vertex="1" parent="1">
+            <mxGeometry x="20" y="20" width="140" height="30" as="geometry"/>
+          </mxCell>
+        </object>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/src/docs/arc42/architecture.jsonc
+++ b/src/docs/arc42/architecture.jsonc
@@ -1,0 +1,345 @@
+{
+  "$schema": "https://raw.githubusercontent.com/docToolchain/Bauteinsicht/main/schema/bausteinsicht.schema.json",
+  "specification": {
+    "elements": {
+      "actor": {
+        "notation": "Actor",
+        "description": "A person or external tool that interacts with the system"
+      },
+      "component": {
+        "notation": "Component",
+        "description": "A Go package within a container",
+        "container": true
+      },
+      "container": {
+        "notation": "Container",
+        "description": "A Go package group within the system",
+        "container": true
+      },
+      "system": {
+        "notation": "Software System",
+        "description": "The Bausteinsicht system boundary",
+        "container": true
+      }
+    },
+    "relationships": {
+      "triggers": {
+        "notation": "triggers",
+        "dashed": true
+      },
+      "uses": {
+        "notation": "uses"
+      }
+    }
+  },
+  "model": {
+    "bausteinsicht": {
+      "kind": "system",
+      "title": "Bausteinsicht",
+      "description": "Architecture-as-code tool with draw.io as visual frontend and bidirectional synchronization",
+      "children": {
+        "cli": {
+          "kind": "container",
+          "title": "CLI",
+          "description": "Command-line interface providing validate, sync, export, and watch commands",
+          "technology": "Go / Cobra"
+        },
+        "drawio": {
+          "kind": "container",
+          "title": "draw.io",
+          "description": "draw.io XML document handling — elements, connectors, templates, and labels",
+          "technology": "Go / etree",
+          "children": {
+            "connector": {
+              "kind": "component",
+              "title": "Connector",
+              "description": "Connector/relationship CRUD for edges between elements",
+              "technology": "Go"
+            },
+            "document": {
+              "kind": "component",
+              "title": "Document",
+              "description": "XML parsing, page management, and file I/O for .drawio files",
+              "technology": "Go"
+            },
+            "element": {
+              "kind": "component",
+              "title": "Element",
+              "description": "Element CRUD operations on mxGraphModel objects and mxCells",
+              "technology": "Go"
+            },
+            "label": {
+              "kind": "component",
+              "title": "Label",
+              "description": "HTML label generation and parsing for element display text",
+              "technology": "Go"
+            },
+            "template": {
+              "kind": "component",
+              "title": "Template",
+              "description": "Template loading and style lookup from .drawio template files",
+              "technology": "Go"
+            }
+          }
+        },
+        "export": {
+          "kind": "container",
+          "title": "Export",
+          "description": "Diagram export to PNG and SVG formats via draw.io CLI",
+          "technology": "Go"
+        },
+        "model": {
+          "kind": "container",
+          "title": "Model",
+          "description": "JSONC architecture model management — loading, validation, and mutation",
+          "technology": "Go",
+          "children": {
+            "loader": {
+              "kind": "component",
+              "title": "Loader",
+              "description": "JSONC read/write with comment stripping and trailing comma handling",
+              "technology": "Go"
+            },
+            "patch": {
+              "kind": "component",
+              "title": "Patch",
+              "description": "Comment-preserving JSONC mutations for reverse sync",
+              "technology": "Go"
+            },
+            "resolve": {
+              "kind": "component",
+              "title": "Resolve",
+              "description": "Dot-notation element resolution and wildcard pattern matching",
+              "technology": "Go"
+            },
+            "types": {
+              "kind": "component",
+              "title": "Types",
+              "description": "Core struct definitions for elements, relationships, views, and specification",
+              "technology": "Go"
+            },
+            "validate": {
+              "kind": "component",
+              "title": "Validate",
+              "description": "Model validation rules for elements, relationships, and views",
+              "technology": "Go"
+            }
+          }
+        },
+        "sync": {
+          "kind": "container",
+          "title": "Sync Engine",
+          "description": "Bidirectional synchronization engine between JSONC model and draw.io diagrams",
+          "technology": "Go",
+          "children": {
+            "conflict": {
+              "kind": "component",
+              "title": "Conflict",
+              "description": "Conflict detection and resolution when both model and diagram changed",
+              "technology": "Go"
+            },
+            "diff": {
+              "kind": "component",
+              "title": "Diff",
+              "description": "Three-way change detection comparing model, diagram, and last-sync state",
+              "technology": "Go"
+            },
+            "engine": {
+              "kind": "component",
+              "title": "Engine",
+              "description": "Main sync orchestrator coordinating diff, forward, reverse, and conflict resolution",
+              "technology": "Go"
+            },
+            "forward": {
+              "kind": "component",
+              "title": "Forward Sync",
+              "description": "Applies model changes to draw.io diagrams (model → drawio)",
+              "technology": "Go"
+            },
+            "reverse": {
+              "kind": "component",
+              "title": "Reverse Sync",
+              "description": "Applies draw.io changes back to the JSONC model (drawio → model)",
+              "technology": "Go"
+            },
+            "state": {
+              "kind": "component",
+              "title": "State",
+              "description": "Sync state persistence using SHA256 hashes for change detection",
+              "technology": "Go"
+            }
+          }
+        },
+        "watcher": {
+          "kind": "container",
+          "title": "Watcher",
+          "description": "File system monitoring for automatic sync on model or diagram changes",
+          "technology": "Go / fsnotify"
+        }
+      }
+    },
+    "developer": {
+      "kind": "actor",
+      "title": "Developer",
+      "description": "Developer using the Bausteinsicht CLI to manage architecture models"
+    },
+    "drawio_app": {
+      "kind": "actor",
+      "title": "draw.io App",
+      "description": "draw.io desktop or web application for visual diagram editing"
+    },
+    "ide": {
+      "kind": "actor",
+      "title": "IDE",
+      "description": "IDE with JSON Schema support for JSONC editing with autocompletion"
+    }
+  },
+  "relationships": [
+    {
+      "from": "developer",
+      "to": "bausteinsicht.cli",
+      "label": "runs commands",
+      "kind": "uses"
+    },
+    {
+      "from": "developer",
+      "to": "ide",
+      "label": "edits JSONC",
+      "kind": "uses"
+    },
+    {
+      "from": "developer",
+      "to": "drawio_app",
+      "label": "edits diagrams",
+      "kind": "uses"
+    },
+    {
+      "from": "ide",
+      "to": "bausteinsicht.model",
+      "label": "JSON Schema validation",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.cli",
+      "to": "bausteinsicht.watcher",
+      "label": "starts watch mode",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.cli",
+      "to": "bausteinsicht.export",
+      "label": "triggers export",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.diff",
+      "label": "detects changes",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.forward",
+      "label": "model → drawio",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.reverse",
+      "label": "drawio → model",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.state",
+      "label": "loads/saves state",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.engine",
+      "to": "bausteinsicht.sync.conflict",
+      "label": "resolves conflicts",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.forward",
+      "to": "bausteinsicht.drawio.element",
+      "label": "creates/updates elements",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.forward",
+      "to": "bausteinsicht.drawio.connector",
+      "label": "creates/updates connectors",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.sync.reverse",
+      "to": "bausteinsicht.model.patch",
+      "label": "comment-preserving updates",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.drawio.element",
+      "to": "bausteinsicht.drawio.label",
+      "label": "generates labels",
+      "kind": "uses"
+    },
+    {
+      "from": "bausteinsicht.drawio.element",
+      "to": "bausteinsicht.drawio.template",
+      "label": "looks up styles",
+      "kind": "uses"
+    }
+  ],
+  "views": {
+    "containers": {
+      "title": "Container View",
+      "scope": "bausteinsicht",
+      "include": [
+        "developer",
+        "drawio_app",
+        "ide",
+        "bausteinsicht.*"
+      ],
+      "description": "Internal containers of Bausteinsicht with external actor interactions"
+    },
+    "context": {
+      "title": "System Context",
+      "include": [
+        "developer",
+        "drawio_app",
+        "ide",
+        "bausteinsicht"
+      ],
+      "description": "High-level view showing Bausteinsicht and its external actors"
+    },
+    "drawio-components": {
+      "title": "draw.io Package Components",
+      "scope": "bausteinsicht.drawio",
+      "include": [
+        "bausteinsicht.drawio.*"
+      ],
+      "description": "Internal components of the draw.io XML handling package"
+    },
+    "model-components": {
+      "title": "Model Package Components",
+      "scope": "bausteinsicht.model",
+      "include": [
+        "bausteinsicht.model.*"
+      ],
+      "description": "Internal components of the JSONC model management package"
+    },
+    "sync-components": {
+      "title": "Sync Engine Components",
+      "scope": "bausteinsicht.sync",
+      "include": [
+        "bausteinsicht.sync.*",
+        "bausteinsicht.model.patch",
+        "bausteinsicht.drawio.element",
+        "bausteinsicht.drawio.connector"
+      ],
+      "description": "Internal components of the bidirectional sync engine and its key dependencies"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Model Bausteinsicht's own architecture using its own JSONC format (dogfooding)
- 3 actors (developer, draw.io app, IDE), 1 system with 6 containers (cli, model, drawio, sync, watcher, export), 16 components, 24 relationships
- 5 diagram views: system context, containers, sync components, draw.io components, model components
- Validated with `bausteinsicht validate` and synced to generate `architecture.drawio`

## Test plan
- [x] `bausteinsicht validate --model src/docs/arc42/architecture.jsonc` passes
- [x] `bausteinsicht sync` generates .drawio with 5 pages
- [x] `bausteinsicht export --view context` exports successfully
- [ ] Open `architecture.drawio` in draw.io to verify visual layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)