### PR TITLE
fix: prevent reverse sync from deleting lifted relationships (#223)

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -606,6 +606,14 @@ func detectRelationshipChanges(
 			if visibleRels != nil && !visibleRels[k] {
 				continue
 			}
+			// Skip if a lifted version of this relationship exists in draw.io.
+			// When a view lifts endpoints (e.g., cli→model.loader becomes
+			// cli→model), the connector has different keys but still represents
+			// this relationship. Without this check, the original relationship
+			// would be incorrectly deleted (#223).
+			if hasLiftedConnectorInDrawio(from, to, drawioRels) {
+				continue
+			}
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
 				From: from, To: to, Index: index, Type: Deleted,
 			})
@@ -659,6 +667,22 @@ func isLiftedRelationship(from, to string, modelRels map[string]RelationshipStat
 		// Both endpoints lifted
 		if mr.From != from && mr.To != to &&
 			strings.HasPrefix(mr.From, from+".") && strings.HasPrefix(mr.To, to+".") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasLiftedConnectorInDrawio returns true if a connector in drawioRels is a
+// lifted version of the relationship from→to. This is the inverse of
+// isLiftedRelationship: here we check if the drawio connector endpoints are
+// ancestors of the model relationship endpoints.
+// For example, model has cli→model.loader but drawio has cli→model (lifted).
+func hasLiftedConnectorInDrawio(from, to string, drawioRels map[string]RelationshipState) bool {
+	for _, dr := range drawioRels {
+		fromMatch := dr.From == from || (dr.From != from && strings.HasPrefix(from, dr.From+"."))
+		toMatch := dr.To == to || (dr.To != to && strings.HasPrefix(to, dr.To+"."))
+		if fromMatch && toMatch && (dr.From != from || dr.To != to) {
 			return true
 		}
 	}

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -468,6 +468,121 @@ func TestDetectChanges_LiftedConnectorIgnored(t *testing.T) {
 	}
 }
 
+// TestDetectChanges_LiftedConnectorNotDeletedFromModel verifies that when a
+// relationship exists in the model with deep endpoints (e.g., cli → model.loader)
+// but the draw.io connector uses lifted endpoints (cli → model), the reverse
+// sync does NOT treat the original relationship as deleted (#223).
+func TestDetectChanges_LiftedConnectorNotDeletedFromModel(t *testing.T) {
+	// Model has a deep relationship: cli → model.loader (index 5)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"cli": {Kind: "container", Title: "CLI"},
+			"model": {Kind: "container", Title: "Model", Children: map[string]model.Element{
+				"loader": {Kind: "component", Title: "Loader"},
+			}},
+		},
+		Relationships: []model.Relationship{
+			{From: "cli", To: "model.loader", Label: "loads JSONC", Kind: "uses"},
+		},
+		Views: map[string]model.View{
+			"containers": {
+				Title:   "Container View",
+				Scope:   "",
+				Include: []string{"cli", "model"},
+			},
+		},
+	}
+
+	// Sync state records the original relationship.
+	state := emptyState()
+	state.Elements["cli"] = ElementState{Title: "CLI", Kind: "container"}
+	state.Elements["model"] = ElementState{Title: "Model", Kind: "container"}
+	state.Elements["model.loader"] = ElementState{Title: "Loader", Kind: "component"}
+	state.Relationships = []RelationshipState{
+		{From: "cli", To: "model.loader", Index: 0, Label: "loads JSONC", Kind: "uses"},
+	}
+
+	// Draw.io has the connector with LIFTED endpoints (cli → model)
+	// because the containers view doesn't include model.loader.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-containers", "Container View")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "cli", CellID: "containers--cli", Kind: "container", Title: "CLI",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "model", CellID: "containers--model", Kind: "container", Title: "Model",
+	}, "")
+	page.CreateConnector(drawio.ConnectorData{
+		From: "cli", To: "model",
+		Label:     "loads JSONC",
+		SourceRef: "containers--cli",
+		TargetRef: "containers--model",
+		Index:     0,
+	}, "")
+
+	cs := DetectChanges(m, doc, state, nil)
+
+	// The original relationship (cli → model.loader) must NOT be marked as
+	// deleted from draw.io. The lifted connector (cli → model) represents it.
+	for _, ch := range cs.DrawioRelationshipChanges {
+		if ch.From == "cli" && ch.To == "model.loader" && ch.Type == Deleted {
+			t.Errorf("CRITICAL: relationship cli→model.loader should not be deleted when a lifted connector cli→model exists (#223), got: %+v",
+				cs.DrawioRelationshipChanges)
+		}
+	}
+}
+
+// TestDetectChanges_RealDeletionStillWorksWithLiftedCheck ensures that a genuine
+// user deletion (connector removed from draw.io, no lifted version exists) is
+// still detected after the #223 fix.
+func TestDetectChanges_RealDeletionStillWorksWithLiftedCheck(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"cli":   {Kind: "container", Title: "CLI"},
+			"model": {Kind: "container", Title: "Model"},
+		},
+		Relationships: []model.Relationship{
+			{From: "cli", To: "model", Label: "uses", Kind: "uses"},
+		},
+		Views: map[string]model.View{
+			"containers": {
+				Title:   "Container View",
+				Include: []string{"cli", "model"},
+			},
+		},
+	}
+
+	state := emptyState()
+	state.Elements["cli"] = ElementState{Title: "CLI", Kind: "container"}
+	state.Elements["model"] = ElementState{Title: "Model", Kind: "container"}
+	state.Relationships = []RelationshipState{
+		{From: "cli", To: "model", Index: 0, Label: "uses", Kind: "uses"},
+	}
+
+	// Draw.io has the elements but the user deleted the connector.
+	doc := drawio.NewDocument()
+	page := doc.AddPage("view-containers", "Container View")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "cli", CellID: "containers--cli", Kind: "container", Title: "CLI",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "model", CellID: "containers--model", Kind: "container", Title: "Model",
+	}, "")
+	// No connector — user deleted it.
+
+	cs := DetectChanges(m, doc, state, nil)
+
+	found := false
+	for _, ch := range cs.DrawioRelationshipChanges {
+		if ch.From == "cli" && ch.To == "model" && ch.Type == Deleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected real user deletion cli→model to be detected, but it was not")
+	}
+}
+
 func TestDetectChanges_TooltipChangeDetected(t *testing.T) {
 	// Sync state has element with description "Old Desc"
 	state := stateWithElem("app", "App", "Old Desc", "Go")


### PR DESCRIPTION
## Summary

- Fixes #223: reverse sync incorrectly deleted relationships when their draw.io connector used lifted endpoints
- When `cli→model.loader` is rendered as `cli→model` (lifted) on a view page, the connector key mismatch caused the original relationship to be marked as deleted
- Added `hasLiftedConnectorInDrawio()` to detect when a lifted version of a connector exists before marking deletion

## Changes

- `internal/sync/diff.go`: Added `hasLiftedConnectorInDrawio()` function and integrated it into the `!inDrawio && inLast` deletion check
- `internal/sync/diff_test.go`: Added two tests — one for the bug fix (lifted connector preserves original relationship) and one ensuring real user deletions still work

## Test plan

- [x] `TestDetectChanges_LiftedConnectorNotDeletedFromModel` — verifies the bug is fixed
- [x] `TestDetectChanges_RealDeletionStillWorksWithLiftedCheck` — verifies real deletions still work
- [x] All existing tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)