### PR TITLE
feat: add export-table command for AsciiDoc/Markdown tables (#222)

### DIFF
--- a/cmd/bausteinsicht/export_table.go
+++ b/cmd/bausteinsicht/export_table.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/docToolchain/Bauteinsicht/internal/table"
+	"github.com/spf13/cobra"
+)
+
+func newExportTableCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export-table",
+		Short: "Export element attributes as AsciiDoc or Markdown table",
+		Long:  "Exports view elements as a table with columns: Element, Kind, Technology, Description.",
+		RunE:  runExportTable,
+	}
+
+	cmd.Flags().String("view", "", "Export only this view (by key)")
+	cmd.Flags().String("table-format", "adoc", "Table format: adoc or md")
+	cmd.Flags().String("output", "", "Output directory (default: stdout)")
+	cmd.Flags().Bool("combined", false, "Export all elements across all views (deduplicated)")
+
+	return cmd
+}
+
+func runExportTable(cmd *cobra.Command, _ []string) error {
+	modelPath, _ := cmd.Flags().GetString("model")
+	viewKey, _ := cmd.Flags().GetString("view")
+	tableFormat, _ := cmd.Flags().GetString("table-format")
+	outputDir, _ := cmd.Flags().GetString("output")
+	combined, _ := cmd.Flags().GetBool("combined")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	var f table.Format
+	switch tableFormat {
+	case "adoc":
+		f = table.AsciiDoc
+	case "md":
+		f = table.Markdown
+	default:
+		return exitWithCode(fmt.Errorf("unknown table format %q: valid values are \"adoc\" and \"md\"", tableFormat), 2)
+	}
+
+	var result string
+	var filename string
+
+	switch {
+	case combined:
+		result, err = table.FormatCombined(m, f)
+		filename = "elements." + tableFormat
+	case viewKey != "":
+		result, err = table.FormatView(m, viewKey, f)
+		filename = viewKey + "-elements." + tableFormat
+	default:
+		result, err = table.FormatAllViews(m, f)
+		filename = "all-views-elements." + tableFormat
+	}
+	if err != nil {
+		return exitWithCode(err, 1)
+	}
+
+	if outputDir == "" {
+		fmt.Fprint(cmd.OutOrStdout(), result)
+		return nil
+	}
+
+	outPath := filepath.Join(outputDir, filename)
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return exitWithCode(fmt.Errorf("creating output directory: %w", err), 2)
+	}
+	if err := os.WriteFile(outPath, []byte(result), 0644); err != nil {
+		return exitWithCode(fmt.Errorf("writing output: %w", err), 2)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Exported: %s\n", outPath)
+	return nil
+}

--- a/cmd/bausteinsicht/export_table.go
+++ b/cmd/bausteinsicht/export_table.go
@@ -75,7 +75,7 @@ func runExportTable(cmd *cobra.Command, _ []string) error {
 	}
 
 	if outputDir == "" {
-		fmt.Fprint(cmd.OutOrStdout(), result)
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), result)
 		return nil
 	}
 
@@ -87,6 +87,6 @@ func runExportTable(cmd *cobra.Command, _ []string) error {
 		return exitWithCode(fmt.Errorf("writing output: %w", err), 2)
 	}
 
-	fmt.Fprintf(cmd.ErrOrStderr(), "Exported: %s\n", outPath)
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Exported: %s\n", outPath)
 	return nil
 }

--- a/cmd/bausteinsicht/export_table_test.go
+++ b/cmd/bausteinsicht/export_table_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const exportTableTestModel = `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "System", "container": true},
+      "container": {"notation": "Container"},
+      "actor": {"notation": "Actor"}
+    }
+  },
+  "model": {
+    "user": {"kind": "actor", "title": "User", "description": "End user"},
+    "shop": {"kind": "system", "title": "Shop", "description": "E-commerce", "children": {
+      "api": {"kind": "container", "title": "API", "description": "REST backend", "technology": "Go"}
+    }}
+  },
+  "relationships": [],
+  "views": {
+    "context": {
+      "title": "System Context",
+      "include": ["user", "shop"]
+    },
+    "containers": {
+      "title": "Container View",
+      "scope": "shop",
+      "include": ["user", "shop.*"]
+    }
+  }
+}`
+
+func writeExportTableModel(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(p, []byte(exportTableTestModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestExportTable_AsciiDocToStdout(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	out, err := executeRootCmd("export-table", "--model", modelPath, "--view", "containers", "--table-format", "adoc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "|===") {
+		t.Error("expected AsciiDoc table delimiter")
+	}
+	if !strings.Contains(out, "API") {
+		t.Error("expected element 'API' in output")
+	}
+	if !strings.Contains(out, "Container View") {
+		t.Error("expected view title")
+	}
+}
+
+func TestExportTable_MarkdownToStdout(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	out, err := executeRootCmd("export-table", "--model", modelPath, "--view", "context", "--table-format", "md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "| Element") {
+		t.Error("expected Markdown table header")
+	}
+	if !strings.Contains(out, "Shop") {
+		t.Error("expected element 'Shop' in output")
+	}
+}
+
+func TestExportTable_AllViewsToStdout(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	out, err := executeRootCmd("export-table", "--model", modelPath, "--table-format", "adoc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "System Context") {
+		t.Error("expected 'System Context' view title")
+	}
+	if !strings.Contains(out, "Container View") {
+		t.Error("expected 'Container View' view title")
+	}
+}
+
+func TestExportTable_CombinedToStdout(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	out, err := executeRootCmd("export-table", "--model", modelPath, "--combined", "--table-format", "adoc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "All Elements") {
+		t.Error("expected 'All Elements' title")
+	}
+	if !strings.Contains(out, "API") {
+		t.Error("expected 'API' in combined output")
+	}
+}
+
+func TestExportTable_WriteToFile(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+	outDir := t.TempDir()
+
+	_, err := executeRootCmd("export-table", "--model", modelPath, "--view", "containers", "--table-format", "adoc", "--output", outDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outPath := filepath.Join(outDir, "containers-elements.adoc")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("expected output file: %v", err)
+	}
+	if !strings.Contains(string(data), "API") {
+		t.Error("expected 'API' in output file")
+	}
+}
+
+func TestExportTable_InvalidView(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	_, err := executeRootCmd("export-table", "--model", modelPath, "--view", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent view")
+	}
+}
+
+func TestExportTable_InvalidFormat(t *testing.T) {
+	modelPath := writeExportTableModel(t)
+
+	_, err := executeRootCmd("export-table", "--model", modelPath, "--table-format", "csv")
+	if err == nil {
+		t.Error("expected error for invalid table format")
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -45,6 +45,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newAddCmd())
 	rootCmd.AddCommand(newWatchCmd())
 	rootCmd.AddCommand(newExportCmd())
+	rootCmd.AddCommand(newExportTableCmd())
 
 	return rootCmd
 }

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -1,0 +1,174 @@
+package table
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// Format represents the output format for table export.
+type Format int
+
+const (
+	AsciiDoc Format = iota
+	Markdown
+)
+
+type row struct {
+	ID          string
+	Title       string
+	Kind        string
+	Technology  string
+	Description string
+}
+
+// FormatView renders a single view's elements as a table.
+func FormatView(m *model.BausteinsichtModel, viewKey string, f Format) (string, error) {
+	view, ok := m.Views[viewKey]
+	if !ok {
+		return "", fmt.Errorf("view %q not found", viewKey)
+	}
+
+	rows, err := resolveRows(m, &view)
+	if err != nil {
+		return "", err
+	}
+
+	var b strings.Builder
+	writeTitle(&b, view.Title, f)
+	writeTable(&b, rows, f)
+	return b.String(), nil
+}
+
+// FormatAllViews renders all views as tables in a single document.
+func FormatAllViews(m *model.BausteinsichtModel, f Format) (string, error) {
+	keys := sortedViewKeys(m)
+	var b strings.Builder
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		view := m.Views[key]
+		rows, err := resolveRows(m, &view)
+		if err != nil {
+			return "", err
+		}
+		writeTitle(&b, view.Title, f)
+		writeTable(&b, rows, f)
+	}
+	return b.String(), nil
+}
+
+// FormatCombined renders all elements across all views (deduplicated) as a single table.
+func FormatCombined(m *model.BausteinsichtModel, f Format) (string, error) {
+	seen := make(map[string]bool)
+	var rows []row
+
+	flat := model.FlattenElements(m)
+	keys := sortedViewKeys(m)
+
+	for _, key := range keys {
+		view := m.Views[key]
+		v := view
+		resolved, err := model.ResolveView(m, &v)
+		if err != nil {
+			continue
+		}
+		for _, id := range resolved {
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			elem := flat[id]
+			if elem == nil {
+				continue
+			}
+			rows = append(rows, row{
+				ID:          id,
+				Title:       elem.Title,
+				Kind:        elem.Kind,
+				Technology:  elem.Technology,
+				Description: elem.Description,
+			})
+		}
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+
+	var b strings.Builder
+	writeTitle(&b, "All Elements", f)
+	writeTable(&b, rows, f)
+	return b.String(), nil
+}
+
+func resolveRows(m *model.BausteinsichtModel, view *model.View) ([]row, error) {
+	resolved, err := model.ResolveView(m, view)
+	if err != nil {
+		return nil, err
+	}
+
+	flat := model.FlattenElements(m)
+	sort.Strings(resolved)
+
+	var rows []row
+	for _, id := range resolved {
+		elem := flat[id]
+		if elem == nil {
+			continue
+		}
+		rows = append(rows, row{
+			ID:          id,
+			Title:       elem.Title,
+			Kind:        elem.Kind,
+			Technology:  elem.Technology,
+			Description: elem.Description,
+		})
+	}
+	return rows, nil
+}
+
+func writeTitle(b *strings.Builder, title string, f Format) {
+	switch f {
+	case AsciiDoc:
+		fmt.Fprintf(b, "=== %s\n\n", title)
+	case Markdown:
+		fmt.Fprintf(b, "### %s\n\n", title)
+	}
+}
+
+func writeTable(b *strings.Builder, rows []row, f Format) {
+	switch f {
+	case AsciiDoc:
+		writeAsciiDocTable(b, rows)
+	case Markdown:
+		writeMarkdownTable(b, rows)
+	}
+}
+
+func writeAsciiDocTable(b *strings.Builder, rows []row) {
+	b.WriteString("[cols=\"2,1,1,3\"]\n|===\n")
+	b.WriteString("| Element | Kind | Technology | Description\n\n")
+	for _, r := range rows {
+		fmt.Fprintf(b, "| %s\n| %s\n| %s\n| %s\n\n", r.Title, r.Kind, r.Technology, r.Description)
+	}
+	b.WriteString("|===\n")
+}
+
+func writeMarkdownTable(b *strings.Builder, rows []row) {
+	b.WriteString("| Element | Kind | Technology | Description |\n")
+	b.WriteString("|---------|------|------------|-------------|\n")
+	for _, r := range rows {
+		fmt.Fprintf(b, "| %s | %s | %s | %s |\n", r.Title, r.Kind, r.Technology, r.Description)
+	}
+}
+
+func sortedViewKeys(m *model.BausteinsichtModel) []string {
+	keys := make([]string, 0, len(m.Views))
+	for k := range m.Views {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/table/table_test.go
+++ b/internal/table/table_test.go
@@ -1,0 +1,157 @@
+package table
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func testModel() *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system":    {Notation: "Software System", Container: true},
+				"container": {Notation: "Container", Container: true},
+				"component": {Notation: "Component"},
+				"actor":     {Notation: "Actor"},
+			},
+		},
+		Model: map[string]model.Element{
+			"user": {Kind: "actor", Title: "User", Description: "End user of the application"},
+			"shop": {Kind: "system", Title: "Online Shop", Description: "E-commerce platform", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API", Description: "REST API backend", Technology: "Go / Gin"},
+				"db":  {Kind: "container", Title: "Database", Description: "Persistent storage", Technology: "PostgreSQL"},
+			}},
+		},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"user", "shop"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "shop",
+				Include: []string{"user", "shop.*"},
+			},
+		},
+	}
+}
+
+func TestFormatAsciiDoc_SingleView(t *testing.T) {
+	m := testModel()
+
+	result, err := FormatView(m, "containers", AsciiDoc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain a table header
+	if !strings.Contains(result, "|===") {
+		t.Error("expected AsciiDoc table delimiter |===")
+	}
+	// Should contain column headers
+	if !strings.Contains(result, "Element") || !strings.Contains(result, "Technology") {
+		t.Error("expected column headers Element and Technology")
+	}
+	// Should contain the view title
+	if !strings.Contains(result, "Container View") {
+		t.Error("expected view title 'Container View'")
+	}
+	// Should contain element data
+	if !strings.Contains(result, "API") {
+		t.Error("expected element 'API' in output")
+	}
+	if !strings.Contains(result, "Go / Gin") {
+		t.Error("expected technology 'Go / Gin' in output")
+	}
+	if !strings.Contains(result, "Database") {
+		t.Error("expected element 'Database' in output")
+	}
+}
+
+func TestFormatMarkdown_SingleView(t *testing.T) {
+	m := testModel()
+
+	result, err := FormatView(m, "containers", Markdown)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Markdown tables use | and --- separators
+	if !strings.Contains(result, "| Element") {
+		t.Error("expected Markdown table header with '| Element'")
+	}
+	if !strings.Contains(result, "---") {
+		t.Error("expected Markdown separator row with ---")
+	}
+	if !strings.Contains(result, "API") {
+		t.Error("expected element 'API' in output")
+	}
+}
+
+func TestFormatAllViews(t *testing.T) {
+	m := testModel()
+
+	result, err := FormatAllViews(m, AsciiDoc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain both view titles
+	if !strings.Contains(result, "System Context") {
+		t.Error("expected view title 'System Context'")
+	}
+	if !strings.Contains(result, "Container View") {
+		t.Error("expected view title 'Container View'")
+	}
+}
+
+func TestFormatCombined(t *testing.T) {
+	m := testModel()
+
+	result, err := FormatCombined(m, AsciiDoc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should contain all elements, deduplicated
+	if !strings.Contains(result, "Online Shop") {
+		t.Error("expected 'Online Shop' in combined output")
+	}
+	if !strings.Contains(result, "API") {
+		t.Error("expected 'API' in combined output")
+	}
+	// Should not duplicate elements
+	if strings.Count(result, "| API") > 1 {
+		t.Error("expected 'API' to appear only once in combined output (deduplicated)")
+	}
+}
+
+func TestFormatView_InvalidView(t *testing.T) {
+	m := testModel()
+
+	_, err := FormatView(m, "nonexistent", AsciiDoc)
+	if err == nil {
+		t.Error("expected error for nonexistent view")
+	}
+}
+
+func TestFormatView_ElementsSorted(t *testing.T) {
+	m := testModel()
+
+	result, err := FormatView(m, "containers", AsciiDoc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// API should appear before Database (sorted by ID: shop.api < shop.db)
+	apiIdx := strings.Index(result, "API")
+	dbIdx := strings.Index(result, "Database")
+	if apiIdx < 0 || dbIdx < 0 {
+		t.Fatal("expected both API and Database in output")
+	}
+	if apiIdx > dbIdx {
+		t.Error("expected elements to be sorted (API before Database)")
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #222: new `export-table` command exports element attributes as structured tables
- New package `internal/table` with formatting logic for AsciiDoc and Markdown
- CLI command with `--view`, `--table-format`, `--output`, and `--combined` flags

## Usage

```bash
# Single view to stdout (AsciiDoc)
bausteinsicht export-table --model architecture.jsonc --view containers

# All views as Markdown
bausteinsicht export-table --model architecture.jsonc --table-format md

# Combined (deduplicated) to file
bausteinsicht export-table --model architecture.jsonc --combined --output docs/
```

## Changes

- `internal/table/table.go` — Core formatting: `FormatView`, `FormatAllViews`, `FormatCombined`
- `internal/table/table_test.go` — 6 unit tests for formatting logic
- `cmd/bausteinsicht/export_table.go` — CLI command implementation
- `cmd/bausteinsicht/export_table_test.go` — 7 integration tests
- `cmd/bausteinsicht/root.go` — Register new command

## Test plan

- [x] 6 unit tests for table formatting (AsciiDoc, Markdown, all views, combined, sorted, error)
- [x] 7 CLI integration tests (stdout, file output, invalid view/format)
- [x] All 8 packages pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)