### PR TITLE
feat: add export-diagram command for PlantUML C4 and Mermaid C4 (#224, #225)

### DIFF
--- a/cmd/bausteinsicht/export_diagram.go
+++ b/cmd/bausteinsicht/export_diagram.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docToolchain/Bauteinsicht/internal/diagram"
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newExportDiagramCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export-diagram",
+		Short: "Export views as PlantUML C4 or Mermaid C4 diagrams",
+		Long:  "Exports architecture views as text-based C4 diagrams (PlantUML or Mermaid).",
+		RunE:  runExportDiagram,
+	}
+
+	cmd.Flags().String("view", "", "Export only this view (by key)")
+	cmd.Flags().String("diagram-format", "plantuml", "Diagram format: plantuml or mermaid")
+	cmd.Flags().String("output", "", "Output directory (default: stdout)")
+
+	return cmd
+}
+
+func runExportDiagram(cmd *cobra.Command, _ []string) error {
+	modelPath, _ := cmd.Flags().GetString("model")
+	viewKey, _ := cmd.Flags().GetString("view")
+	diagramFormat, _ := cmd.Flags().GetString("diagram-format")
+	outputDir, _ := cmd.Flags().GetString("output")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	var f diagram.Format
+	var ext string
+	switch diagramFormat {
+	case "plantuml":
+		f = diagram.PlantUML
+		ext = "puml"
+	case "mermaid":
+		f = diagram.Mermaid
+		ext = "mmd"
+	default:
+		return exitWithCode(fmt.Errorf("unknown diagram format %q: valid values are \"plantuml\" and \"mermaid\"", diagramFormat), 2)
+	}
+
+	// Determine which views to export.
+	views := make(map[string]model.View)
+	if viewKey != "" {
+		v, ok := m.Views[viewKey]
+		if !ok {
+			return exitWithCode(fmt.Errorf("view %q not found", viewKey), 1)
+		}
+		views[viewKey] = v
+	} else {
+		views = m.Views
+	}
+
+	for key := range views {
+		result, fmtErr := diagram.FormatView(m, key, f)
+		if fmtErr != nil {
+			return exitWithCode(fmtErr, 1)
+		}
+
+		if outputDir == "" {
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), result)
+			continue
+		}
+
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return exitWithCode(fmt.Errorf("creating output directory: %w", err), 2)
+		}
+		outPath := filepath.Join(outputDir, key+"."+ext)
+		if err := os.WriteFile(outPath, []byte(result), 0644); err != nil {
+			return exitWithCode(fmt.Errorf("writing output: %w", err), 2)
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Exported: %s\n", outPath)
+	}
+
+	return nil
+}

--- a/cmd/bausteinsicht/export_diagram_test.go
+++ b/cmd/bausteinsicht/export_diagram_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const exportDiagramTestModel = `{
+  "specification": {
+    "elements": {
+      "system": {"notation": "System", "container": true},
+      "container": {"notation": "Container"},
+      "actor": {"notation": "Actor"},
+      "external_system": {"notation": "External System"}
+    }
+  },
+  "model": {
+    "user": {"kind": "actor", "title": "User", "description": "End user"},
+    "shop": {"kind": "system", "title": "Shop", "description": "E-commerce", "children": {
+      "api": {"kind": "container", "title": "API", "description": "REST", "technology": "Go"}
+    }},
+    "ext": {"kind": "external_system", "title": "External", "description": "Third party"}
+  },
+  "relationships": [
+    {"from": "user", "to": "shop", "label": "uses", "kind": "uses"}
+  ],
+  "views": {
+    "context": {
+      "title": "System Context",
+      "include": ["user", "shop", "ext"]
+    },
+    "containers": {
+      "title": "Container View",
+      "scope": "shop",
+      "include": ["user", "shop.*"]
+    }
+  }
+}`
+
+func writeExportDiagramModel(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(p, []byte(exportDiagramTestModel), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestExportDiagram_PlantUMLToStdout(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	out, err := executeRootCmd("export-diagram", "--model", modelPath, "--view", "context", "--diagram-format", "plantuml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "@startuml") {
+		t.Error("expected @startuml in output")
+	}
+	if !strings.Contains(out, "Person(") {
+		t.Error("expected Person() macro")
+	}
+}
+
+func TestExportDiagram_MermaidToStdout(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	out, err := executeRootCmd("export-diagram", "--model", modelPath, "--view", "context", "--diagram-format", "mermaid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "C4Context") {
+		t.Error("expected C4Context in output")
+	}
+}
+
+func TestExportDiagram_WriteToFile(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	outDir := t.TempDir()
+	_, err := executeRootCmd("export-diagram", "--model", modelPath, "--view", "context", "--diagram-format", "plantuml", "--output", outDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outPath := filepath.Join(outDir, "context.puml")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("expected output file: %v", err)
+	}
+	if !strings.Contains(string(data), "@startuml") {
+		t.Error("expected @startuml in file")
+	}
+}
+
+func TestExportDiagram_MermaidFile(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	outDir := t.TempDir()
+	_, err := executeRootCmd("export-diagram", "--model", modelPath, "--view", "context", "--diagram-format", "mermaid", "--output", outDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	outPath := filepath.Join(outDir, "context.mmd")
+	if _, err := os.ReadFile(outPath); err != nil {
+		t.Fatalf("expected .mmd output file: %v", err)
+	}
+}
+
+func TestExportDiagram_InvalidFormat(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	_, err := executeRootCmd("export-diagram", "--model", modelPath, "--diagram-format", "dot")
+	if err == nil {
+		t.Error("expected error for invalid format")
+	}
+}
+
+func TestExportDiagram_InvalidView(t *testing.T) {
+	modelPath := writeExportDiagramModel(t)
+	_, err := executeRootCmd("export-diagram", "--model", modelPath, "--view", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent view")
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -46,6 +46,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newWatchCmd())
 	rootCmd.AddCommand(newExportCmd())
 	rootCmd.AddCommand(newExportTableCmd())
+	rootCmd.AddCommand(newExportDiagramCmd())
 
 	return rootCmd
 }

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -1,0 +1,272 @@
+package diagram
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+// Format represents the output diagram format.
+type Format int
+
+const (
+	PlantUML Format = iota
+	Mermaid
+)
+
+const c4PlantUMLBase = "https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master"
+
+// FormatView renders a view as a C4 diagram in the given format.
+func FormatView(m *model.BausteinsichtModel, viewKey string, f Format) (string, error) {
+	view, ok := m.Views[viewKey]
+	if !ok {
+		return "", fmt.Errorf("view %q not found", viewKey)
+	}
+
+	resolved, err := model.ResolveView(m, &view)
+	if err != nil {
+		return "", err
+	}
+
+	flat := model.FlattenElements(m)
+	sort.Strings(resolved)
+
+	// Determine C4 level from view content.
+	level := detectLevel(resolved, flat, view.Scope)
+
+	// Separate scope-internal elements from external ones.
+	scopeElems, externalElems := partitionElements(resolved, flat, view.Scope)
+
+	// Filter relationships to those visible in this view.
+	elemSet := make(map[string]bool, len(resolved))
+	for _, id := range resolved {
+		elemSet[id] = true
+	}
+	if view.Scope != "" {
+		elemSet[view.Scope] = true
+	}
+	rels := filterRelationships(m.Relationships, elemSet)
+
+	var b strings.Builder
+	switch f {
+	case PlantUML:
+		writePlantUML(&b, view, level, scopeElems, externalElems, rels, flat)
+	case Mermaid:
+		writeMermaid(&b, view, level, scopeElems, externalElems, rels, flat)
+	}
+	return b.String(), nil
+}
+
+type elemEntry struct {
+	ID   string
+	Elem *model.Element
+}
+
+func detectLevel(resolved []string, flat map[string]*model.Element, scope string) string {
+	for _, id := range resolved {
+		elem := flat[id]
+		if elem == nil {
+			continue
+		}
+		if elem.Kind == "component" {
+			return "Component"
+		}
+		if elem.Kind == "container" {
+			return "Container"
+		}
+	}
+	if scope != "" {
+		return "Container"
+	}
+	return "Context"
+}
+
+func partitionElements(resolved []string, flat map[string]*model.Element, scope string) (inside, outside []elemEntry) {
+	for _, id := range resolved {
+		elem := flat[id]
+		if elem == nil {
+			continue
+		}
+		if scope != "" && strings.HasPrefix(id, scope+".") {
+			inside = append(inside, elemEntry{id, elem})
+		} else {
+			outside = append(outside, elemEntry{id, elem})
+		}
+	}
+	return
+}
+
+type relEntry struct {
+	From, To, Label string
+}
+
+func filterRelationships(rels []model.Relationship, elemSet map[string]bool) []relEntry {
+	var result []relEntry
+	seen := make(map[string]bool)
+	for _, r := range rels {
+		from := liftToVisible(r.From, elemSet)
+		to := liftToVisible(r.To, elemSet)
+		if from == "" || to == "" || from == to {
+			continue
+		}
+		key := from + ":" + to
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, relEntry{from, to, r.Label})
+	}
+	return result
+}
+
+func liftToVisible(id string, elemSet map[string]bool) string {
+	if elemSet[id] {
+		return id
+	}
+	for {
+		dot := strings.LastIndex(id, ".")
+		if dot < 0 {
+			return ""
+		}
+		id = id[:dot]
+		if elemSet[id] {
+			return id
+		}
+	}
+}
+
+func c4Macro(kind string) string {
+	switch kind {
+	case "actor":
+		return "Person"
+	case "system":
+		return "System"
+	case "external_system":
+		return "System_Ext"
+	case "container":
+		return "Container"
+	case "component":
+		return "Component"
+	default:
+		return "System"
+	}
+}
+
+func sanitizeID(id string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(id, ".", "_"), "-", "_")
+}
+
+func escapeQuotes(s string) string {
+	return strings.ReplaceAll(s, "\"", "'")
+}
+
+// --- PlantUML ---
+
+func writePlantUML(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
+	b.WriteString("@startuml\n")
+	fmt.Fprintf(b, "!include %s/C4_%s.puml\n\n", c4PlantUMLBase, level)
+
+	// External elements (outside scope boundary).
+	for _, e := range outside {
+		writePlantUMLElement(b, e, "")
+	}
+
+	// Scope boundary with internal elements.
+	if view.Scope != "" {
+		scopeElem := flat[view.Scope]
+		scopeTitle := view.Scope
+		if scopeElem != nil {
+			scopeTitle = scopeElem.Title
+		}
+		boundaryMacro := "System_Boundary"
+		if scopeElem != nil && scopeElem.Kind == "container" {
+			boundaryMacro = "Container_Boundary"
+		}
+		fmt.Fprintf(b, "%s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
+		for _, e := range inside {
+			writePlantUMLElement(b, e, "  ")
+		}
+		b.WriteString("}\n")
+	} else {
+		for _, e := range inside {
+			writePlantUMLElement(b, e, "")
+		}
+	}
+
+	// Relationships.
+	if len(rels) > 0 {
+		b.WriteString("\n")
+	}
+	for _, r := range rels {
+		fmt.Fprintf(b, "Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
+	}
+
+	b.WriteString("@enduml\n")
+}
+
+func writePlantUMLElement(b *strings.Builder, e elemEntry, indent string) {
+	macro := c4Macro(e.Elem.Kind)
+	if e.Elem.Technology != "" {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Technology), escapeQuotes(e.Elem.Description))
+	} else {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Description))
+	}
+}
+
+// --- Mermaid ---
+
+func writeMermaid(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
+	fmt.Fprintf(b, "C4%s\n", level)
+	fmt.Fprintf(b, "    title %s\n\n", view.Title)
+
+	for _, e := range outside {
+		writeMermaidElement(b, e, "    ")
+	}
+
+	if view.Scope != "" {
+		scopeElem := flat[view.Scope]
+		scopeTitle := view.Scope
+		if scopeElem != nil {
+			scopeTitle = scopeElem.Title
+		}
+		boundaryMacro := "System_Boundary"
+		if scopeElem != nil && scopeElem.Kind == "container" {
+			boundaryMacro = "Container_Boundary"
+		}
+		fmt.Fprintf(b, "    %s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
+		for _, e := range inside {
+			writeMermaidElement(b, e, "        ")
+		}
+		b.WriteString("    }\n")
+	} else {
+		for _, e := range inside {
+			writeMermaidElement(b, e, "    ")
+		}
+	}
+
+	if len(rels) > 0 {
+		b.WriteString("\n")
+	}
+	for _, r := range rels {
+		fmt.Fprintf(b, "    Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
+	}
+}
+
+func writeMermaidElement(b *strings.Builder, e elemEntry, indent string) {
+	macro := c4Macro(e.Elem.Kind)
+	if e.Elem.Technology != "" {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Technology), escapeQuotes(e.Elem.Description))
+	} else {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Description))
+	}
+}

--- a/internal/diagram/diagram_test.go
+++ b/internal/diagram/diagram_test.go
@@ -1,0 +1,176 @@
+package diagram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bauteinsicht/internal/model"
+)
+
+func testModel() *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system":          {Notation: "Software System", Container: true},
+				"container":       {Notation: "Container", Container: true},
+				"component":       {Notation: "Component"},
+				"actor":           {Notation: "Actor"},
+				"external_system": {Notation: "External System"},
+			},
+		},
+		Model: map[string]model.Element{
+			"user": {Kind: "actor", Title: "User", Description: "End user"},
+			"shop": {Kind: "system", Title: "Online Shop", Description: "E-commerce platform", Children: map[string]model.Element{
+				"api": {Kind: "container", Title: "API", Description: "REST backend", Technology: "Go"},
+				"db":  {Kind: "container", Title: "Database", Description: "Storage", Technology: "PostgreSQL"},
+			}},
+			"payment": {Kind: "external_system", Title: "Payment Gateway", Description: "External payment provider"},
+		},
+		Relationships: []model.Relationship{
+			{From: "user", To: "shop", Label: "uses", Kind: "uses"},
+			{From: "user", To: "payment", Label: "pays via", Kind: "uses"},
+			{From: "shop.api", To: "shop.db", Label: "reads/writes", Kind: "uses"},
+			{From: "shop.api", To: "payment", Label: "processes payment", Kind: "uses"},
+		},
+		Views: map[string]model.View{
+			"context": {
+				Title:   "System Context",
+				Include: []string{"user", "shop", "payment"},
+			},
+			"containers": {
+				Title:   "Container View",
+				Scope:   "shop",
+				Include: []string{"user", "shop.*", "payment"},
+			},
+		},
+	}
+}
+
+// --- PlantUML Tests ---
+
+func TestPlantUML_ContextView(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "context", PlantUML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "@startuml") {
+		t.Error("expected @startuml")
+	}
+	if !strings.Contains(result, "@enduml") {
+		t.Error("expected @enduml")
+	}
+	if !strings.Contains(result, "C4_Context.puml") {
+		t.Error("expected C4_Context.puml include")
+	}
+	if !strings.Contains(result, "Person(") {
+		t.Error("expected Person() macro for actor")
+	}
+	if !strings.Contains(result, "System(") {
+		t.Error("expected System() macro")
+	}
+	if !strings.Contains(result, "System_Ext(") {
+		t.Error("expected System_Ext() macro for external system")
+	}
+	if !strings.Contains(result, "Rel(") {
+		t.Error("expected Rel() for relationships")
+	}
+}
+
+func TestPlantUML_ContainerView(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "containers", PlantUML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "C4_Container.puml") {
+		t.Error("expected C4_Container.puml include for container view")
+	}
+	if !strings.Contains(result, "System_Boundary(") {
+		t.Error("expected System_Boundary for scope element")
+	}
+	if !strings.Contains(result, "Container(") {
+		t.Error("expected Container() macro")
+	}
+}
+
+func TestPlantUML_Relationships(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "context", PlantUML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "uses") {
+		t.Error("expected relationship label 'uses'")
+	}
+	if !strings.Contains(result, "pays via") {
+		t.Error("expected relationship label 'pays via'")
+	}
+}
+
+func TestPlantUML_InvalidView(t *testing.T) {
+	m := testModel()
+	_, err := FormatView(m, "nonexistent", PlantUML)
+	if err == nil {
+		t.Error("expected error for nonexistent view")
+	}
+}
+
+// --- Mermaid Tests ---
+
+func TestMermaid_ContextView(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "context", Mermaid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "C4Context") {
+		t.Error("expected C4Context diagram type")
+	}
+	if !strings.Contains(result, "Person(") {
+		t.Error("expected Person() for actor")
+	}
+	if !strings.Contains(result, "System(") {
+		t.Error("expected System()")
+	}
+	if !strings.Contains(result, "System_Ext(") {
+		t.Error("expected System_Ext()")
+	}
+	if !strings.Contains(result, "Rel(") {
+		t.Error("expected Rel()")
+	}
+}
+
+func TestMermaid_ContainerView(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "containers", Mermaid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "C4Container") {
+		t.Error("expected C4Container diagram type")
+	}
+	if !strings.Contains(result, "System_Boundary(") {
+		t.Error("expected System_Boundary for scope")
+	}
+	if !strings.Contains(result, "Container(") {
+		t.Error("expected Container()")
+	}
+}
+
+func TestMermaid_Relationships(t *testing.T) {
+	m := testModel()
+	result, err := FormatView(m, "context", Mermaid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "uses") {
+		t.Error("expected relationship label 'uses'")
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #224: PlantUML C4 diagram export using C4-PlantUML stdlib
- Closes #225: Mermaid C4 diagram export
- New `export-diagram` command with `--diagram-format plantuml|mermaid`
- New `internal/diagram` package with shared formatting logic

## Usage

```bash
# PlantUML C4 to stdout
bausteinsicht export-diagram --model architecture.jsonc --view context

# Mermaid C4 to file
bausteinsicht export-diagram --model architecture.jsonc --diagram-format mermaid --output docs/

# All views as PlantUML files
bausteinsicht export-diagram --model architecture.jsonc --output diagrams/
```

## Element Kind Mapping

| Bausteinsicht Kind | C4 Macro |
|--------------------|----------|
| actor | `Person()` |
| system | `System()` |
| external_system | `System_Ext()` |
| container | `Container()` |
| component | `Component()` |

## Changes

- `internal/diagram/diagram.go` — Core formatting for PlantUML and Mermaid C4
- `internal/diagram/diagram_test.go` — 7 unit tests (PlantUML + Mermaid)
- `cmd/bausteinsicht/export_diagram.go` — CLI command
- `cmd/bausteinsicht/export_diagram_test.go` — 6 integration tests
- `cmd/bausteinsicht/root.go` — Register new command

## Test plan

- [x] 7 unit tests for diagram formatting
- [x] 6 CLI integration tests (stdout, file, formats, errors)
- [x] All 9 packages pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)