### PR TITLE
feat: add integrity checksum to sync state file

### DIFF
--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -15,6 +15,7 @@ import (
 
 // SyncState stores the state after each successful sync.
 type SyncState struct {
+	Checksum         string                  `json:"checksum,omitempty"`
 	Timestamp        string                  `json:"timestamp"`
 	ModelHash        string                  `json:"model_hash"`
 	DrawioHash       string                  `json:"drawio_hash"`
@@ -66,6 +67,22 @@ func LoadState(path string) (*SyncState, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return nil, fmt.Errorf("LoadState %q: %w", path, err)
 	}
+
+	// Verify integrity checksum if present (backward compat: old files without checksum skip validation).
+	if state.Checksum != "" {
+		savedChecksum := state.Checksum
+		state.Checksum = ""
+		canonical, err := json.Marshal(&state)
+		if err != nil {
+			return nil, fmt.Errorf("LoadState %q: checksum verification marshal: %w", path, err)
+		}
+		sum := sha256.Sum256(canonical)
+		computed := fmt.Sprintf("sha256:%x", sum)
+		if computed != savedChecksum {
+			return nil, fmt.Errorf("LoadState %q: sync state corrupted (checksum mismatch); delete .bausteinsicht-sync and re-run sync", path)
+		}
+	}
+
 	if state.Elements == nil {
 		state.Elements = make(map[string]ElementState)
 	}
@@ -77,6 +94,15 @@ func LoadState(path string) (*SyncState, error) {
 
 // SaveState atomically writes state to path using a temp file + rename.
 func SaveState(path string, state *SyncState) error {
+	// Compute integrity checksum: marshal without checksum → hash → set checksum → marshal with checksum.
+	state.Checksum = ""
+	canonical, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("SaveState checksum marshal: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	state.Checksum = fmt.Sprintf("sha256:%x", sum)
+
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("SaveState marshal: %w", err)
@@ -127,7 +153,10 @@ func BuildState(m *model.BausteinsichtModel, doc *drawio.Document, modelPath, dr
 		return nil, fmt.Errorf("BuildState drawio hash: %w", err)
 	}
 
-	flat, _ := model.FlattenElements(m)
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return nil, fmt.Errorf("BuildState flatten: %w", err)
+	}
 	elements := make(map[string]ElementState, len(flat))
 	for id, elem := range flat {
 		elements[id] = ElementState{

--- a/internal/sync/state_test.go
+++ b/internal/sync/state_test.go
@@ -174,6 +174,83 @@ func TestComputeHash_MissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadState_ChecksumValid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bausteinsicht-sync")
+
+	state := &SyncState{
+		Timestamp:     "2024-01-01T00:00:00Z",
+		ModelHash:     "sha256:abc",
+		DrawioHash:    "sha256:def",
+		Elements:      map[string]ElementState{"x": {Title: "X", Kind: "k"}},
+		Relationships: []RelationshipState{},
+	}
+	if err := SaveState(path, state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	loaded, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if loaded.Elements["x"].Title != "X" {
+		t.Errorf("expected title X, got %q", loaded.Elements["x"].Title)
+	}
+}
+
+func TestLoadState_ChecksumCorrupted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bausteinsicht-sync")
+
+	state := &SyncState{
+		Timestamp:     "2024-01-01T00:00:00Z",
+		ModelHash:     "sha256:abc",
+		DrawioHash:    "sha256:def",
+		Elements:      map[string]ElementState{"x": {Title: "X", Kind: "k"}},
+		Relationships: []RelationshipState{},
+	}
+	if err := SaveState(path, state); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	// Corrupt the file by modifying content but keeping JSON valid.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	corrupted := strings.Replace(string(data), `"X"`, `"Y"`, 1)
+	if err := os.WriteFile(path, []byte(corrupted), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = LoadState(path)
+	if err == nil {
+		t.Fatal("expected checksum mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("expected 'checksum mismatch' in error, got: %v", err)
+	}
+}
+
+func TestLoadState_OldFileWithoutChecksum(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bausteinsicht-sync")
+
+	// Write a valid state file without checksum (old format).
+	oldFormat := `{"timestamp":"2024-01-01T00:00:00Z","model_hash":"sha256:abc","drawio_hash":"sha256:def","elements":{},"relationships":[]}`
+	if err := os.WriteFile(path, []byte(oldFormat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadState(path)
+	if err != nil {
+		t.Fatalf("expected old file without checksum to load OK, got: %v", err)
+	}
+	if loaded.Timestamp != "2024-01-01T00:00:00Z" {
+		t.Errorf("unexpected timestamp: %q", loaded.Timestamp)
+	}
+}
+
 func TestBuildState_CorrectSnapshot(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Computes SHA-256 checksum over sync state on save, verifies on load
- Corrupted `.bausteinsicht-sync` files produce a clear error with recovery instructions
- Old state files without checksum are accepted (backward compatible)

Depends on #258

Closes #246

## Test plan
- [x] `TestLoadState_ChecksumValid` — round-trip save/load succeeds
- [x] `TestLoadState_ChecksumCorrupted` — tampered file detected
- [x] `TestLoadState_OldFileWithoutChecksum` — backward compat verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)