### PR TITLE
fix: pin draw.io version in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,9 +60,10 @@ RUN GITLEAKS_VERSION=$(curl -sL https://api.github.com/repos/gitleaks/gitleaks/r
 
 # ──────────────────────────────────────────────
 # draw.io Desktop (headless export via xvfb-run)
+# Pin draw.io version for reproducibility. Update and test before changing.
 # ──────────────────────────────────────────────
-RUN DRAWIO_VERSION=$(curl -sL https://api.github.com/repos/jgraph/drawio-desktop/releases/latest | jq -r '.tag_name' | sed 's/^v//') \
- && wget -q "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb" -O /tmp/drawio.deb \
+ARG DRAWIO_VERSION=29.5.2
+RUN wget -q "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VERSION}/drawio-amd64-${DRAWIO_VERSION}.deb" -O /tmp/drawio.deb \
  && apt-get update && apt-get install -y --no-install-recommends /tmp/drawio.deb \
  && rm -f /tmp/drawio.deb && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Replaces dynamic `latest` version lookup with pinned `ARG DRAWIO_VERSION=29.5.2`
- Prevents surprise breakage from upstream draw.io releases
- Version can be updated by changing the ARG and testing

Closes #247

## Test plan
- [ ] `devcontainer up` builds successfully with pinned version
- [ ] draw.io export works in devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)