### PR TITLE
feat: add template versioning for compatibility checks

### DIFF
--- a/internal/drawio/template.go
+++ b/internal/drawio/template.go
@@ -9,6 +9,9 @@ import (
 	"github.com/beevik/etree"
 )
 
+// CurrentTemplateVersion is the latest template format version supported.
+const CurrentTemplateVersion = 1
+
 // SubCellStyle holds style and geometry for a text sub-cell within an element.
 type SubCellStyle struct {
 	Style         string  // mxCell style string
@@ -31,6 +34,7 @@ type TemplateStyle struct {
 
 // TemplateSet holds all styles parsed from a draw.io template file.
 type TemplateSet struct {
+	Version    int                      // template format version (0 means unset/v1)
 	elements   map[string]TemplateStyle // keyed by kind (actor, system, container, component)
 	boundaries map[string]TemplateStyle // keyed by kind (system_boundary, container_boundary)
 	connector  string                   // default connector style
@@ -58,7 +62,21 @@ func LoadTemplateFromBytes(data []byte) (*TemplateSet, error) {
 		return nil, fmt.Errorf("LoadTemplateFromBytes: not a valid draw.io template (missing <mxfile> root element)")
 	}
 
+	// Read template version from <mxfile> root. Missing → version 1 (backward compat).
+	version := 1
+	if vStr := root.SelectAttrValue("bausteinsicht_template_version", ""); vStr != "" {
+		v, err := strconv.Atoi(vStr)
+		if err != nil {
+			return nil, fmt.Errorf("LoadTemplateFromBytes: invalid template version %q: %w", vStr, err)
+		}
+		version = v
+	}
+	if version > CurrentTemplateVersion {
+		return nil, fmt.Errorf("LoadTemplateFromBytes: template version %d not supported (max: %d)", version, CurrentTemplateVersion)
+	}
+
 	ts := &TemplateSet{
+		Version:    version,
 		elements:   make(map[string]TemplateStyle),
 		boundaries: make(map[string]TemplateStyle),
 	}

--- a/internal/drawio/template_test.go
+++ b/internal/drawio/template_test.go
@@ -2,6 +2,7 @@ package drawio_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/docToolchain/Bauteinsicht/internal/drawio"
@@ -157,6 +158,39 @@ func TestGetStyle_SubCellStyles(t *testing.T) {
 	}
 	if actorStyle.DescStyle == nil {
 		t.Error("actor: expected non-nil DescStyle")
+	}
+}
+
+func TestLoadTemplateFromBytes_NoVersionAttr(t *testing.T) {
+	data := []byte(`<mxfile><diagram id="t" name="T"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`)
+	ts, err := drawio.LoadTemplateFromBytes(data)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ts.Version != 1 {
+		t.Errorf("expected version 1 for missing attr, got %d", ts.Version)
+	}
+}
+
+func TestLoadTemplateFromBytes_Version1(t *testing.T) {
+	data := []byte(`<mxfile bausteinsicht_template_version="1"><diagram id="t" name="T"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`)
+	ts, err := drawio.LoadTemplateFromBytes(data)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if ts.Version != 1 {
+		t.Errorf("expected version 1, got %d", ts.Version)
+	}
+}
+
+func TestLoadTemplateFromBytes_UnsupportedVersion(t *testing.T) {
+	data := []byte(`<mxfile bausteinsicht_template_version="99"><diagram id="t" name="T"><mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/></root></mxGraphModel></diagram></mxfile>`)
+	_, err := drawio.LoadTemplateFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error for unsupported version, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected 'not supported' in error, got: %v", err)
 	}
 }
 

--- a/templates/default.drawio
+++ b/templates/default.drawio
@@ -1,4 +1,4 @@
-<mxfile host="Electron" compressed="false" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/29.5.2 Chrome/142.0.7444.265 Electron/39.6.1 Safari/537.36" version="29.5.2">
+<mxfile host="Electron" compressed="false" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/29.5.2 Chrome/142.0.7444.265 Electron/39.6.1 Safari/537.36" version="29.5.2" bausteinsicht_template_version="1">
   <diagram id="template" name="Bausteinsicht Template">
     <mxGraphModel dx="480" dy="358" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#ffffff" math="0" shadow="0">
       <root>


### PR DESCRIPTION
## Summary
- Adds `bausteinsicht_template_version` attribute to `<mxfile>` root in `default.drawio`
- `LoadTemplates` now reads and exposes the template version
- Enables future compatibility checks when template format evolves

Closes #248

## Test plan
- [ ] `make test` passes — new template version test included
- [ ] Existing templates without version attribute still load (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)