### PR TITLE
Fix errors in diagram command

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -79,9 +79,10 @@ RUN wget -q "https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWI
 # Wrapper script so `drawio` runs headless via xvfb with dbus
 # -a: auto-pick a free display number (avoids conflicts with existing Xvfb)
 # --no-sandbox: required in container environments without user namespaces
+# --disable-gpu: required in containers without GPU/rendering backend
 # dbus: Electron requires a running system bus for IPC
-RUN printf '#!/bin/sh\n# Ensure dbus is running (required by Electron/draw.io)\nif [ ! -S /run/dbus/system_bus_socket ]; then\n  sudo mkdir -p /run/dbus\n  sudo dbus-daemon --system --fork 2>/dev/null || true\nfi\nxvfb-run -a drawio --no-sandbox "$@"\n' > /usr/local/bin/drawio-export \
- && chmod +x /usr/local/bin/drawio-export
+COPY drawio-export /usr/local/bin/drawio-export
+RUN chmod +x /usr/local/bin/drawio-export
 
 # ──────────────────────────────────────────────
 # Firewall script (restricts outbound to whitelisted domains)

--- a/.devcontainer/drawio-export
+++ b/.devcontainer/drawio-export
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Wrapper for draw.io CLI in headless container environments.
+#
+# draw.io is an Electron app (Chromium-based) that requires:
+#   - A virtual display (Xvfb) — no physical monitor available in containers
+#   - A running D-Bus system daemon — Electron uses it for internal IPC
+#   - --no-sandbox — containers typically lack user namespaces for Chromium sandbox
+#   - --disable-gpu — no GPU/rendering backend in containers
+#
+# Without this wrapper, draw.io exits with code 0 but produces no output file.
+set -euo pipefail
+
+# dbus-run-session starts a private D-Bus session bus for the child process,
+# which Electron requires for IPC. The system bus (dbus-daemon --system) is
+# not sufficient — Electron specifically needs a session bus.
+# ELECTRON_DISABLE_GPU bypasses GPU acceleration without passing --disable-gpu
+# as a CLI flag. drawio's arg parser only filters --no-sandbox from program.args,
+# so --disable-gpu would land as paths[0] and break input file detection.
+export ELECTRON_DISABLE_GPU=1
+exec dbus-run-session -- xvfb-run -a drawio --no-sandbox "$@"

--- a/cmd/bausteinsicht/export.go
+++ b/cmd/bausteinsicht/export.go
@@ -23,7 +23,7 @@ func newExportCmd() *cobra.Command {
 	cmd.Flags().String("view", "", "Export only this view (by key)")
 	cmd.Flags().String("output", ".", "Output directory")
 	cmd.Flags().Bool("embed-diagram", false, "Embed draw.io XML source in output")
-	cmd.Flags().Float64("scale", 2.0, "Export scale factor (e.g. 2.0 for retina, 3.0 for print)")
+	cmd.Flags().Float64("scale", 1.0, "Export scale factor (e.g. 2.0 for retina, 3.0 for print); scale > 1 requires hardware GPU")
 	return cmd
 }
 

--- a/cmd/bausteinsicht/export_cmd_test.go
+++ b/cmd/bausteinsicht/export_cmd_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+// TestExportCmd_DefaultScaleIsOne is a regression test for the headless GPU crash bug.
+//
+// The original default was 2.0 (retina quality). In headless container environments,
+// draw.io's GPU process is disabled via ELECTRON_DISABLE_GPU. When --scale 2 is
+// passed, draw.io attempts GPU-accelerated rendering, the GPU process crashes with
+// exit code 9, and the export silently fails (exit 0, no output file created).
+//
+// Scale=1.0 uses software rendering and works in all environments. Scale > 1 is
+// now an opt-in that requires hardware GPU.
+func TestExportCmd_DefaultScaleIsOne(t *testing.T) {
+	cmd := newExportCmd()
+	scale, err := cmd.Flags().GetFloat64("scale")
+	if err != nil {
+		t.Fatalf("getting scale flag: %v", err)
+	}
+	if scale != 1.0 {
+		t.Errorf("default scale = %v, want 1.0 (scale > 1 requires GPU and fails in headless containers)", scale)
+	}
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -42,7 +42,13 @@ func BuildExportArgs(opts ExportOptions) []string {
 	if opts.EmbedDiagram {
 		args = append(args, "--embed-diagram")
 	}
-	if opts.Scale > 0 {
+	// Only pass --scale for values > 1. Scale=1 is draw.io's native resolution
+	// and does not need an explicit flag. Scale > 1 (e.g. 2.0 for retina) uses
+	// the GPU rendering pipeline and requires hardware GPU acceleration.
+	// Passing --scale 2 in headless containers (where the GPU process is
+	// disabled via ELECTRON_DISABLE_GPU) causes the GPU process to crash with
+	// exit code 9, resulting in a silent export failure (exit 0, no output file).
+	if opts.Scale > 1 {
 		args = append(args, "--scale", fmt.Sprintf("%g", opts.Scale))
 	}
 	args = append(args, opts.InputFile)

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -79,6 +79,44 @@ func TestBuildExportArgs(t *testing.T) {
 	}
 }
 
+// TestBuildExportArgs_InputFileIsLastArg is a regression test for the bug where
+// unrecognized Electron flags (e.g. --disable-gpu) passed before the input file
+// would land as program.args[0] in draw.io's CLI parser, causing
+// "Error: input file/directory not found" with exit code 0.
+// The input file must always be the last argument so it is unambiguously paths[0].
+func TestBuildExportArgs_InputFileIsLastArg(t *testing.T) {
+	for _, scale := range []float64{0, 1.0, 2.0} {
+		args := BuildExportArgs(ExportOptions{
+			Format:     "png",
+			PageIndex:  1,
+			OutputPath: "/tmp/out.png",
+			InputFile:  "arch.drawio",
+			Scale:      scale,
+		})
+		if args[len(args)-1] != "arch.drawio" {
+			t.Errorf("scale=%v: input file must be the last argument, got %q (full args: %v)", scale, args[len(args)-1], args)
+		}
+	}
+}
+
+// TestBuildExportArgs_ScaleOneNotIncluded verifies that Scale=1.0 (the headless-safe
+// default) does not add a --scale flag, avoiding the GPU process crash that occurs
+// when draw.io tries to render at scale > 1 without hardware GPU acceleration.
+func TestBuildExportArgs_ScaleOneNotIncluded(t *testing.T) {
+	args := BuildExportArgs(ExportOptions{
+		Format:     "png",
+		PageIndex:  1,
+		OutputPath: "/tmp/out.png",
+		InputFile:  "arch.drawio",
+		Scale:      1.0,
+	})
+	for i, arg := range args {
+		if arg == "--scale" {
+			t.Errorf("--scale should not be present for Scale=1.0 (GPU not required), but found at index %d", i)
+		}
+	}
+}
+
 func TestBuildExportArgs_WithoutEmbed(t *testing.T) {
 	args := BuildExportArgs(ExportOptions{
 		Format:       "svg",


### PR DESCRIPTION
 
 Zusammenfassung der Fixes:
  1. .devcontainer/drawio-export — fehlendes Wrapper-Script erstellt:
    - dbus-run-session für den Electron Session Bus
    - xvfb-run -a für virtuelles Display
    - --no-sandbox für Root-in-Container
    - export ELECTRON_DISABLE_GPU=1 statt --disable-gpu (da unbekannte ---Flags in program.args landen und die Datei-Erkennung brechen)
  2. cmd/bausteinsicht/export.go — Default-Scale von 2.0 auf 1.0 geändert, da Scale > 1 den GPU-Prozess benötigt der in headless Containern nicht verfügbar ist.