### PR TITLE
fix: remove published email, fix website footer and sitemap URLs

### DIFF
--- a/docToolchainConfig.groovy
+++ b/docToolchainConfig.groovy
@@ -88,6 +88,7 @@ microsite.with {
 
     // is your microsite deployed with a context path?
     contextPath = '/'
+    host = 'https://doctoolchain.org/Bausteinsicht'
     // the folder of a site definition (theme) relative to the docDir+inputPath
     //siteFolder = '../site'
 
@@ -104,19 +105,19 @@ microsite.with {
     //
     // contact eMail
     // example: mailto:bert@example.com
-    footerMail = '##footer-email##'
+    footerMail = '-'
     //
     // twitter account url
-    footerTwitter = '##twitter-url##'
+    footerTwitter = '-'
     //
     // Stackoverflow QA
-    footerSO = '##Stackoverflow-url##'
+    footerSO = '-'
     //
     // Github Repository
-    footerGithub = '##Github-url##'
+    footerGithub = 'https://github.com/docToolchain/Bausteinsicht'
     //
     // Slack Channel
-    footerSlack = '##Slack-url##'
+    footerSlack = '-'
     //
     // Footer Text
     // example: <small class="text-white">built with docToolchain and jBake <br /> theme: docsy</small>
@@ -127,12 +128,12 @@ microsite.with {
     //
     // the url to create an issue in github
     // Example: https://github.com/docToolchain/docToolchain/issues/new
-    issueUrl = '##issue-url##'
+    issueUrl = 'https://github.com/docToolchain/Bausteinsicht/issues/new'
     //
     // the base url for code files in github
     // Example: https://github.com/doctoolchain/doctoolchain/edit/master/src/docs
     branch = System.getenv("DTC_PROJECT_BRANCH")?:'-'
-    gitRepoUrl = '##git-repo-url##'
+    gitRepoUrl = 'https://github.com/docToolchain/Bausteinsicht/edit/main/src/docs'
 
     //
     // the location of the landing page

--- a/docToolchainConfig.groovy
+++ b/docToolchainConfig.groovy
@@ -105,19 +105,19 @@ microsite.with {
     //
     // contact eMail
     // example: mailto:bert@example.com
-    footerMail = '-'
+    footerMail = ''
     //
     // twitter account url
-    footerTwitter = '-'
+    footerTwitter = ''
     //
     // Stackoverflow QA
-    footerSO = '-'
+    footerSO = ''
     //
     // Github Repository
     footerGithub = 'https://github.com/docToolchain/Bausteinsicht'
     //
     // Slack Channel
-    footerSlack = '-'
+    footerSlack = ''
     //
     // Footer Text
     // example: <small class="text-white">built with docToolchain and jBake <br /> theme: docsy</small>

--- a/src/docs/arc42/architecture.jsonc
+++ b/src/docs/arc42/architecture.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/docToolchain/Bauteinsicht/main/schema/bausteinsicht.schema.json",
   "config": {
-    "author": "ralf.d.mueller@gmail.com with Claude.ai",
+    "author": "Bausteinsicht contributors",
     "repo": "github.com/docToolchain/Bauteinsicht"
   },
   "specification": {


### PR DESCRIPTION
## Summary
- **Remove personal email** from `architecture.jsonc` — was publicly accessible at `doctoolchain.org/Bausteinsicht/arc42/architecture.jsonc`
- **Replace unresolved template placeholders** (`##footer-email##`, `##Github-url##`, `##issue-url##`, etc.) in `docToolchainConfig.groovy` with actual GitHub URLs or `-` to disable unused links
- **Fix sitemap base URL** — all 45 entries pointed to `http://jbake.org/` instead of `https://doctoolchain.org/Bausteinsicht/` due to missing `host` property

## Test plan
- [ ] Verify `architecture.jsonc` no longer contains email after deploy
- [ ] Check website footer: GitHub icon links to repo, unused icons (Twitter, Slack, SO, email) are hidden
- [ ] Check sidebar: "Edit on GitHub" and "Create Issue" links work
- [ ] Verify `sitemap.xml` URLs start with `https://doctoolchain.org/Bausteinsicht/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)