### PR TITLE
fix: sanitize view keys in export filenames (SEC-015)

### DIFF
--- a/cmd/bausteinsicht/export_diagram.go
+++ b/cmd/bausteinsicht/export_diagram.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/docToolchain/Bausteinsicht/internal/diagram"
+	"github.com/docToolchain/Bausteinsicht/internal/export"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
@@ -112,7 +113,7 @@ func runExportDiagram(cmd *cobra.Command, _ []string) error {
 		if err := os.MkdirAll(outputDir, 0750); err != nil {
 			return exitWithCode(fmt.Errorf("creating output directory: %w", err), 2)
 		}
-		outPath := filepath.Join(outputDir, key+"."+ext)
+		outPath := filepath.Join(outputDir, export.SafeViewKey(key)+"."+ext)
 		if err := os.WriteFile(outPath, []byte(result), 0600); err != nil { //nolint:gosec // output files are non-sensitive documentation
 			return exitWithCode(fmt.Errorf("writing output: %w", err), 2)
 		}

--- a/cmd/bausteinsicht/export_table.go
+++ b/cmd/bausteinsicht/export_table.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/docToolchain/Bausteinsicht/internal/export"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/docToolchain/Bausteinsicht/internal/table"
 	"github.com/spf13/cobra"
@@ -72,7 +73,7 @@ func runExportTable(cmd *cobra.Command, _ []string) error {
 		filename = "elements." + tableFormat
 	case viewKey != "":
 		result, err = table.FormatView(m, viewKey, f)
-		filename = viewKey + "-elements." + tableFormat
+		filename = export.SafeViewKey(viewKey) + "-elements." + tableFormat
 	default:
 		result, err = table.FormatAllViews(m, f)
 		filename = "all-views-elements." + tableFormat

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 // ExportOptions configures a single page export operation.
@@ -55,9 +57,16 @@ func BuildExportArgs(opts ExportOptions) []string {
 	return args
 }
 
+// SafeViewKey strips directory components from a view key to prevent
+// path traversal when used in filenames (SEC-015).
+func SafeViewKey(key string) string {
+	key = filepath.Base(strings.ReplaceAll(key, "\\", "/"))
+	return key
+}
+
 // OutputFileName returns the canonical output file name for a view export.
 func OutputFileName(viewKey, format string) string {
-	return fmt.Sprintf("architecture-%s.%s", viewKey, format)
+	return fmt.Sprintf("architecture-%s.%s", SafeViewKey(viewKey), format)
 }
 
 // ExportPage runs the draw.io CLI to export a single page.

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -154,6 +154,45 @@ func TestOutputFileName(t *testing.T) {
 	}
 }
 
+func TestOutputFileName_StripsPathTraversal(t *testing.T) {
+	tests := []struct {
+		viewKey string
+		format  string
+		want    string
+	}{
+		{"../../../tmp/pwned", "png", "architecture-pwned.png"},
+		{"/etc/passwd", "svg", "architecture-passwd.svg"},
+		{"foo/../../bar", "png", "architecture-bar.png"},
+		{"normal-key", "png", "architecture-normal-key.png"},
+	}
+	for _, tt := range tests {
+		got := OutputFileName(tt.viewKey, tt.format)
+		if got != tt.want {
+			t.Errorf("OutputFileName(%q, %q) = %q, want %q", tt.viewKey, tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestSafeViewKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"context", "context"},
+		{"my-view", "my-view"},
+		{"../../../tmp/pwned", "pwned"},
+		{"/etc/passwd", "passwd"},
+		{"foo/bar", "bar"},
+		{"foo\\bar", "bar"},
+	}
+	for _, tt := range tests {
+		got := SafeViewKey(tt.key)
+		if got != tt.want {
+			t.Errorf("SafeViewKey(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
 // TestExportPage_ErrorWhenOutputMissing verifies that ExportPage returns an
 // error when the draw.io CLI exits successfully but the output file does not
 // exist (e.g., permission denied on output directory). (#195)

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -37,6 +37,9 @@
 
 | 2026-04-27 (govulncheck)
 | Fixed SEC-017: govulncheck v1.1.4 (Go 1.22.2) could not analyze `fsnotify` v1.9.0 internal packages. Updated to v1.3.0 (Go 1.25.9) — scan now passes with 0 vulnerabilities in called code.
+
+| 2026-04-27 (path traversal)
+| Fixed SEC-015: view keys used directly in export filenames without sanitization. Added `SafeViewKey()` using `filepath.Base` to strip directory components at all three export paths.
 |===
 
 === Scope
@@ -125,7 +128,7 @@ The primary risk scenario is a **malicious or crafted model/drawio file** shared
 | SEC-015
 | Medium
 | View key used directly in export filenames without path traversal sanitization
-| Open
+| Fixed (SafeViewKey)
 
 | SEC-016
 | Low
@@ -289,9 +292,9 @@ Confirmed by `govulncheck` — no vulnerable symbols called by project code.
 
 **Fix applied in #235:** `requirePage` test helpers and `strings.Cut` refactor. Nil checks added.
 
-==== SEC-015: View Key Path Traversal in Export Filenames (Medium) — NEW
+==== SEC-015: View Key Path Traversal in Export Filenames (Medium) — FIXED
 
-_Added 2026-03-30_
+_Added 2026-03-30, fixed 2026-04-27_
 
 **Affected files:**
 
@@ -300,7 +303,7 @@ _Added 2026-03-30_
 * `internal/export/export.go:53-54` — `OutputFileName(viewKey, format)`
 
 **Description:**
-View keys from the JSONC model are used directly in output filenames without sanitization.
+View keys from the JSONC model were used directly in output filenames without sanitization.
 A malicious model file could define a view key containing path separators or `..` sequences:
 
 [source,json]
@@ -314,12 +317,8 @@ A malicious model file could define a view key containing path separators or `..
 
 When exported with `--output ./docs`, this would write to `./docs/../../../tmp/pwned.puml`.
 
-**Risk:**
-For a local CLI tool this requires the user to run export on a malicious model file.
-In LLM agent or CI/CD pipelines processing untrusted models, this is exploitable for arbitrary file writes.
-
-**Recommendation:**
-Add view key validation in `validateViews()` restricting keys to `^[a-zA-Z0-9_-]+$`, or sanitize using `filepath.Base()` in `OutputFileName()`.
+**Fix:**
+Added `export.SafeViewKey()` which normalizes backslashes to forward slashes and applies `filepath.Base()` to strip directory components. Applied at all three export paths (`export.go`, `export_diagram.go`, `export_table.go`). The malicious key above now safely resolves to `pwned.puml` in the output directory.
 
 ==== SEC-016: No Output Directory Boundary Check (Low) — NEW
 
@@ -483,9 +482,6 @@ SEC-004, SEC-007, SEC-011 verified fixed 2026-03-30 (see individual findings abo
 | Document that `--model`/`--template` paths are fully trusted; add path validation if CLI is used in automation
 
 | Medium
-| SEC-015
-| Sanitize view keys in export filenames — restrict to `^[a-zA-Z0-9_-]+$` or use `filepath.Base()`
-
 | Medium
 | SEC-014
 | Add checksum verification for Dockerfile script downloads
@@ -516,7 +512,7 @@ SEC-004, SEC-007, SEC-011 verified fixed 2026-03-30 (see individual findings abo
 
 The next security review should:
 
-* Fix SEC-015 (view key path traversal) — highest priority open finding
+* Verify SEC-015 fix (view key sanitization) works in integration with real exports
 * Address SEC-014 (Dockerfile checksum verification)
 * Check for new CVEs in dependencies (govulncheck now functional — SEC-017 fixed)
 * Verify `gitleaks` runs in CI (currently only available in devcontainer)


### PR DESCRIPTION
## Summary

- **SEC-015**: View keys from the JSONC model were used directly in export filenames without sanitization. A malicious view key like `"../../../tmp/pwned"` could write files outside the intended output directory.
- Added `export.SafeViewKey()` — normalizes backslashes and applies `filepath.Base()` to strip directory components
- Applied at all three export paths: `export.go`, `export_diagram.go`, `export_table.go`
- Security report updated: SEC-015 marked as Fixed, removed from action items

## Test plan

- [x] `TestSafeViewKey` — verifies path traversal, absolute paths, backslash normalization
- [x] `TestOutputFileName_StripsPathTraversal` — verifies end-to-end filename safety
- [x] `go test -race ./...` — all 9 packages green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)