### PR TITLE
ci: stop GitHub Pages build on PRs, cancel stale builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,15 +3,13 @@ name: GitHub Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch: {}
 
 permissions: {}
 
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from GitHub Pages workflow — PRs don't need site builds, Go CI is sufficient
- Set `cancel-in-progress: true` — rapid merges no longer queue up parallel docToolchain builds

Reduces unnecessary Actions usage and prevents the long queue of pending/in-progress builds we saw today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)