### PR TITLE
feat: cross-platform support — CI matrix + draw.io binary detection (#317)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,10 @@ permissions: {}
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,51 @@
-.PHONY: build test test-race bench vet staticcheck gosec nilaway govulncheck gitleaks golangci-lint check clean install-tools install-hooks
+DIST := dist
+
+.PHONY: build build_all \
+        build_linux_amd64 build_linux_arm64 \
+        build_darwin_amd64 build_darwin_arm64 \
+        build_windows_amd64 build_windows_arm64 \
+        test test-race bench vet staticcheck gosec nilaway govulncheck \
+        gitleaks golangci-lint check clean install-tools install-hooks
 
 # Ensure GOPATH/bin is in PATH for installed tools
 export PATH := $(PATH):$(shell go env GOPATH)/bin
 
-# Build
+# Build for the current platform
 build:
 	go build -o bausteinsicht ./cmd/bausteinsicht/
+
+# Build for all supported platforms → dist/
+build_all: build_linux_amd64 build_linux_arm64 build_darwin_amd64 build_darwin_arm64 build_windows_amd64 build_windows_arm64
+
+build_linux_amd64:
+	@mkdir -p $(DIST)/bausteinsicht_linux_amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(DIST)/bausteinsicht_linux_amd64/bausteinsicht ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_linux_amd64/bausteinsicht"
+
+build_linux_arm64:
+	@mkdir -p $(DIST)/bausteinsicht_linux_arm64
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(DIST)/bausteinsicht_linux_arm64/bausteinsicht ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_linux_arm64/bausteinsicht"
+
+build_darwin_amd64:
+	@mkdir -p $(DIST)/bausteinsicht_darwin_amd64
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o $(DIST)/bausteinsicht_darwin_amd64/bausteinsicht ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_darwin_amd64/bausteinsicht"
+
+build_darwin_arm64:
+	@mkdir -p $(DIST)/bausteinsicht_darwin_arm64
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o $(DIST)/bausteinsicht_darwin_arm64/bausteinsicht ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_darwin_arm64/bausteinsicht"
+
+build_windows_amd64:
+	@mkdir -p $(DIST)/bausteinsicht_windows_amd64
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o $(DIST)/bausteinsicht_windows_amd64/bausteinsicht.exe ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_windows_amd64/bausteinsicht.exe"
+
+build_windows_arm64:
+	@mkdir -p $(DIST)/bausteinsicht_windows_arm64
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -o $(DIST)/bausteinsicht_windows_arm64/bausteinsicht.exe ./cmd/bausteinsicht/
+	@echo "→ $(DIST)/bausteinsicht_windows_arm64/bausteinsicht.exe"
 
 # Run all tests
 test:
@@ -67,3 +107,4 @@ install-hooks:
 
 clean:
 	rm -f bausteinsicht
+	rm -rf $(DIST)

--- a/README.adoc
+++ b/README.adoc
@@ -208,4 +208,8 @@ If you are evaluating alternatives or want to understand the landscape, these pr
 * https://isoflow.io/[Isoflow] — a visual-first architecture diagramming tool with an isometric rendering style. Focused on the visual editing experience rather than text-based modeling.
 * https://github.com/SlavaVedernikov/C4InterFlow[C4InterFlow] — extends the C4 model with interface and flow concepts for documenting system interactions at a more granular level.
 
-Bausteinsicht's unique contribution is **bidirectional synchronization** between a text model (JSONC) and draw.io diagrams — edits in either direction are merged. See link:src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc[ADR-001] for a d
+Bausteinsicht's unique contribution is **bidirectional synchronization** between a text model (JSONC) and draw.io diagrams — edits in either direction are merged. See link:src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc[ADR-001] for a detailed comparison of DSL formats.
+
+== License
+
+See link:LICENSE[LICENSE].

--- a/README.adoc
+++ b/README.adoc
@@ -92,6 +92,20 @@ cd Bausteinsicht
 make build
 ----
 
+Cross-compilation for any platform works out of the box — no extra tooling needed:
+
+[source,bash]
+----
+make build_linux_amd64      # → dist/bausteinsicht_linux_amd64/bausteinsicht
+make build_linux_arm64      # → dist/bausteinsicht_linux_arm64/bausteinsicht
+make build_darwin_amd64     # → dist/bausteinsicht_darwin_amd64/bausteinsicht
+make build_darwin_arm64     # → dist/bausteinsicht_darwin_arm64/bausteinsicht
+make build_windows_amd64    # → dist/bausteinsicht_windows_amd64/bausteinsicht.exe
+make build_windows_arm64    # → dist/bausteinsicht_windows_arm64/bausteinsicht.exe
+
+make build_all              # build all platforms at once
+----
+
 == Quick Start
 
 [source,bash]
@@ -130,6 +144,7 @@ See the link:src/docs/spec/06_tutorial.adoc[Getting Started Tutorial] for a step
 * **Relationship lifting** — connectors auto-lift to parent when endpoint is not on a view
 * **CLI-first** — all commands support `--format json` for LLM/AI agent workflows
 * **JSON Schema** — IDE autocompletion without plugins
+* **Cross-platform** — native binaries for Linux, macOS, and Windows (amd64 + arm64)
 
 == Development
 
@@ -193,8 +208,4 @@ If you are evaluating alternatives or want to understand the landscape, these pr
 * https://isoflow.io/[Isoflow] — a visual-first architecture diagramming tool with an isometric rendering style. Focused on the visual editing experience rather than text-based modeling.
 * https://github.com/SlavaVedernikov/C4InterFlow[C4InterFlow] — extends the C4 model with interface and flow concepts for documenting system interactions at a more granular level.
 
-Bausteinsicht's unique contribution is **bidirectional synchronization** between a text model (JSONC) and draw.io diagrams — edits in either direction are merged. See link:src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc[ADR-001] for a detailed comparison of DSL formats.
-
-== License
-
-See link:LICENSE[LICENSE].
+Bausteinsicht's unique contribution is **bidirectional synchronization** between a text model (JSONC) and draw.io diagrams — edits in either direction are merged. See link:src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc[ADR-001] for a d

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -21,13 +21,24 @@ type ExportOptions struct {
 	Scale        float64 // export scale factor (0 = default, e.g. 2.0 for retina)
 }
 
-// DetectDrawioBinary finds the draw.io CLI binary. It checks for
-// "drawio-export" first (devcontainer wrapper with xvfb), then "drawio".
+// platformPaths is a function variable so tests can override it.
+var platformPaths = platformDrawioPaths
+
+// DetectDrawioBinary finds the draw.io CLI binary.
+// Search order:
+//  1. "drawio-export" — devcontainer wrapper (Linux, adds xvfb + --no-sandbox)
+//  2. "drawio" — on PATH (Linux package install)
+//  3. Platform-native install paths (Windows, macOS) via platformPaths()
 func DetectDrawioBinary() (string, error) {
 	for _, name := range []string{"drawio-export", "drawio"} {
 		path, err := exec.LookPath(name)
 		if err == nil {
 			return path, nil
+		}
+	}
+	for _, candidate := range platformPaths() {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
 		}
 	}
 	return "", fmt.Errorf("draw.io CLI not found; install from https://www.drawio.com/")

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -4,18 +4,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
-func TestDetectDrawioBinary_FindsDrawioExport(t *testing.T) {
-	// Create a fake drawio-export in a temp dir.
-	dir := t.TempDir()
-	fakeBin := filepath.Join(dir, "drawio-export")
-	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0755); err != nil {
+// fakeBinary creates a minimal executable in dir with the given base name,
+// adding .exe on Windows so exec.LookPath can find it.
+func fakeBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
+	return path
+}
+
+func TestDetectDrawioBinary_FindsDrawioExport(t *testing.T) {
+	dir := t.TempDir()
+	fakeBin := fakeBinary(t, dir, "drawio-export")
 	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", dir+":"+origPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
 
 	bin, err := DetectDrawioBinary()
 	if err != nil {
@@ -28,10 +39,7 @@ func TestDetectDrawioBinary_FindsDrawioExport(t *testing.T) {
 
 func TestDetectDrawioBinary_FallsBackToDrawio(t *testing.T) {
 	dir := t.TempDir()
-	fakeBin := filepath.Join(dir, "drawio")
-	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	fakeBin := fakeBinary(t, dir, "drawio")
 	// Set PATH to only the temp dir so drawio-export is NOT found.
 	t.Setenv("PATH", dir)
 

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -46,6 +46,10 @@ func TestDetectDrawioBinary_FallsBackToDrawio(t *testing.T) {
 
 func TestDetectDrawioBinary_ErrorWhenNotFound(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
+	// Override platform paths so filesystem installs don't interfere.
+	old := platformPaths
+	platformPaths = func() []string { return nil }
+	t.Cleanup(func() { platformPaths = old })
 	_, err := DetectDrawioBinary()
 	if err == nil {
 		t.Error("expected error when no draw.io binary found")

--- a/internal/export/platform_darwin.go
+++ b/internal/export/platform_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package export
+
+import "os"
+
+// platformDrawioPaths returns platform-native draw.io install locations for macOS.
+func platformDrawioPaths() []string {
+	paths := []string{
+		"/Applications/draw.io.app/Contents/MacOS/draw.io",
+	}
+	// Also check user-level install.
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, home+"/Applications/draw.io.app/Contents/MacOS/draw.io")
+	}
+	return paths
+}

--- a/internal/export/platform_linux.go
+++ b/internal/export/platform_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package export
+
+// platformDrawioPaths returns platform-native draw.io install locations for Linux.
+// On Linux, draw.io is typically on PATH already; this is a last-resort fallback.
+func platformDrawioPaths() []string {
+	return []string{
+		"/opt/drawio/drawio",
+		"/usr/lib/drawio/drawio",
+	}
+}

--- a/internal/export/platform_windows.go
+++ b/internal/export/platform_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package export
+
+import "os"
+
+// platformDrawioPaths returns platform-native draw.io install locations for Windows.
+func platformDrawioPaths() []string {
+	var paths []string
+	// Per-user install (most common via the official installer).
+	if localApp := os.Getenv("LOCALAPPDATA"); localApp != "" {
+		paths = append(paths, localApp+`\Programs\draw.io\draw.io.exe`)
+	}
+	// System-wide install.
+	for _, prog := range []string{os.Getenv("PROGRAMFILES"), os.Getenv("PROGRAMFILES(X86)")} {
+		if prog != "" {
+			paths = append(paths, prog+`\draw.io\draw.io.exe`)
+		}
+	}
+	return paths
+}

--- a/src/docs/manual/user-manual.adoc
+++ b/src/docs/manual/user-manual.adoc
@@ -388,6 +388,23 @@ This is intentional. New elements are marked with a red dashed border (`strokeCo
 
 When both the model and draw.io change the same field between syncs, Bausteinsicht reports a conflict. Resolve by choosing one version and running sync again.
 
+==== Image export on Windows
+
+The `bausteinsicht export` command uses the draw.io Desktop CLI (Electron app) to render images.
+On Windows, install draw.io from https://www.drawio.com/ and Bausteinsicht detects it automatically.
+
+Bausteinsicht checks the following locations in order:
+
+1. `drawio-export` on PATH (not available on native Windows — devcontainer wrapper only)
+2. `drawio` on PATH (if added manually)
+3. `%LOCALAPPDATA%\Programs\draw.io\draw.io.exe` — standard per-user install via the official installer
+4. `%PROGRAMFILES%\draw.io\draw.io.exe` — system-wide install
+5. `%PROGRAMFILES(X86)%\draw.io\draw.io.exe` — 32-bit system-wide install
+
+No additional configuration is required on native Windows — xvfb, D-Bus, and `--no-sandbox` are Linux/container-only concerns.
+
+NOTE: If you run Bausteinsicht inside **WSL2**, treat it as a Linux environment: xvfb, D-Bus, and `--no-sandbox` apply as described below.
+
 ==== PNG/SVG export fails in headless or container environments
 
 The `bausteinsicht export` command uses the draw.io Desktop CLI (Electron app) to render images.


### PR DESCRIPTION
## Summary

- Extends Go CI to run build and tests on **Ubuntu, Windows, and macOS** (matrix)
- Adds platform-native draw.io install path detection for **Windows** (`%LOCALAPPDATA%\Programs\draw.io\draw.io.exe`) and **macOS** (`/Applications/draw.io.app/Contents/MacOS/draw.io`)
- Implements via build-tag platform files (`platform_linux/darwin/windows.go`) — no runtime overhead on other platforms
- Makes `platformPaths` overridable for unit tests (fixes `TestDetectDrawioBinary_ErrorWhenNotFound` on systems with draw.io installed at `/opt/drawio/drawio`)

Phase 4 (Homebrew/Winget distribution) tracked separately in #318.

## Test plan

- [ ] CI matrix passes on all three OS runners
- [ ] `go build ./...` compiles cleanly on Linux, macOS, Windows
- [ ] `TestDetectDrawioBinary_*` tests pass
- [ ] `DetectDrawioBinary()` finds draw.io on macOS native install path
- [ ] `DetectDrawioBinary()` finds draw.io on Windows native install path

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)