### PR TITLE
feat: Architecture Constraints / Lint Command (#283)

### DIFF
--- a/cmd/bausteinsicht/lint.go
+++ b/cmd/bausteinsicht/lint.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docToolchain/Bausteinsicht/internal/constraints"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newLintCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:           "lint",
+		Short:         "Check architecture constraints",
+		Long:          "Evaluates all constraints defined in the model and reports violations.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runLint,
+	}
+}
+
+func runLint(cmd *cobra.Command, _ []string) error {
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(err, 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(err, 2)
+	}
+
+	if len(m.Constraints) == 0 {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), "No constraints defined."); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	result := constraints.Evaluate(m)
+
+	if format == "json" {
+		return lintOutputJSON(cmd, result)
+	}
+	return lintOutputText(cmd, result)
+}
+
+func lintOutputJSON(cmd *cobra.Command, r constraints.Result) error {
+	type jsonResult struct {
+		Passed     bool                 `json:"passed"`
+		Total      int                  `json:"total"`
+		Violations []constraints.Violation `json:"violations"`
+	}
+
+	out := jsonResult{
+		Passed:     r.Total == 0,
+		Total:      r.Total,
+		Violations: r.Violations,
+	}
+	if out.Violations == nil {
+		out.Violations = []constraints.Violation{}
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+		return err
+	}
+	if r.Total > 0 {
+		return exitWithCode(fmt.Errorf("lint: %d violation(s) found", r.Total), 1)
+	}
+	return nil
+}
+
+func lintOutputText(cmd *cobra.Command, r constraints.Result) error {
+	if r.Total == 0 {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "All constraints passed.")
+		return err
+	}
+
+	for _, v := range r.Violations {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "VIOLATION [%s]: %s\n", v.ConstraintID, v.Message); err != nil {
+			return err
+		}
+		for _, el := range v.Elements {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  - %s\n", el); err != nil {
+				return err
+			}
+		}
+	}
+
+	return exitWithCode(fmt.Errorf("lint: %d violation(s) found", r.Total), 1)
+}

--- a/cmd/bausteinsicht/lint_test.go
+++ b/cmd/bausteinsicht/lint_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func executeLintCmd(args ...string) (string, error) {
+	cmd := NewRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+const modelWithConstraints = `{
+	"specification": {
+		"elements": {
+			"system":    {"notation": "System"},
+			"container": {"notation": "Container"},
+			"person":    {"notation": "Person"}
+		}
+	},
+	"model": {
+		"frontend": {"kind": "system",    "title": "Frontend", "description": "desc"},
+		"backend":  {"kind": "system",    "title": "Backend",  "description": "desc"},
+		"db":       {"kind": "container", "title": "Database", "technology": "PostgreSQL"}
+	},
+	"relationships": [
+		{"from": "frontend", "to": "backend"}
+	],
+	"views": {"main": {"title": "Main"}},
+	"constraints": [
+		{
+			"id":          "C01",
+			"description": "Systems must have descriptions",
+			"rule":        "required-field",
+			"element-kind": "system",
+			"field":       "description"
+		}
+	]
+}`
+
+const modelNoConstraints = `{
+	"specification": {
+		"elements": {"system": {"notation": "System"}}
+	},
+	"model": {"a": {"kind": "system", "title": "A"}},
+	"relationships": [],
+	"views": {"main": {"title": "Main"}}
+}`
+
+const modelWithViolation = `{
+	"specification": {
+		"elements": {
+			"system":    {"notation": "System"},
+			"container": {"notation": "Container"}
+		}
+	},
+	"model": {
+		"a": {"kind": "system",    "title": "A"},
+		"b": {"kind": "container", "title": "B"}
+	},
+	"relationships": [{"from": "a", "to": "b"}],
+	"views": {"main": {"title": "Main"}},
+	"constraints": [
+		{
+			"id":          "C01",
+			"description": "Systems must not use containers",
+			"rule":        "required-field",
+			"element-kind": "system",
+			"field":       "description"
+		}
+	]
+}`
+
+func writeModel(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "model.jsonc")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestLint_NoViolations(t *testing.T) {
+	p := writeModel(t, modelWithConstraints)
+	out, err := executeLintCmd("lint", "--model", p)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+	if !strings.Contains(out, "All constraints passed.") {
+		t.Errorf("expected 'All constraints passed.', got %q", out)
+	}
+}
+
+func TestLint_NoConstraintsDefined(t *testing.T) {
+	p := writeModel(t, modelNoConstraints)
+	out, err := executeLintCmd("lint", "--model", p)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+	if !strings.Contains(out, "No constraints defined.") {
+		t.Errorf("expected 'No constraints defined.', got %q", out)
+	}
+}
+
+func TestLint_Violation_ExitCode1(t *testing.T) {
+	p := writeModel(t, modelWithViolation)
+	out, err := executeLintCmd("lint", "--model", p)
+	if err == nil {
+		t.Fatal("expected error (exit code 1), got nil")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+	if !strings.Contains(out, "VIOLATION") {
+		t.Errorf("expected VIOLATION in output, got %q", out)
+	}
+}
+
+func TestLint_NonExistentFile_ExitCode2(t *testing.T) {
+	_, err := executeLintCmd("lint", "--model", "/nonexistent/model.jsonc")
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 2 {
+		t.Errorf("expected exit code 2, got %d", ee.code)
+	}
+}
+
+func TestLint_JSONOutput_Passed(t *testing.T) {
+	p := writeModel(t, modelWithConstraints)
+	out, err := executeLintCmd("lint", "--model", p, "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+
+	var result struct {
+		Passed     bool        `json:"passed"`
+		Total      int         `json:"total"`
+		Violations interface{} `json:"violations"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\nOutput: %s", err, out)
+	}
+	if !result.Passed {
+		t.Error("expected passed=true")
+	}
+	if result.Total != 0 {
+		t.Errorf("expected total=0, got %d", result.Total)
+	}
+}
+
+func TestLint_JSONOutput_Violation(t *testing.T) {
+	p := writeModel(t, modelWithViolation)
+	out, err := executeLintCmd("lint", "--model", p, "--format", "json")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var result struct {
+		Passed     bool `json:"passed"`
+		Total      int  `json:"total"`
+		Violations []struct {
+			ConstraintID string   `json:"constraint_id"`
+			Message      string   `json:"message"`
+			Elements     []string `json:"elements"`
+		} `json:"violations"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\nOutput: %s", err, out)
+	}
+	if result.Passed {
+		t.Error("expected passed=false")
+	}
+	if result.Total == 0 {
+		t.Error("expected total > 0")
+	}
+	if len(result.Violations) == 0 {
+		t.Error("expected violations array to be non-empty")
+	}
+}
+
+func TestLint_ViolationLists_Elements(t *testing.T) {
+	p := writeModel(t, modelWithViolation)
+	out, err := executeLintCmd("lint", "--model", p)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(out, "  - ") {
+		t.Errorf("expected indented element list in output, got %q", out)
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -65,6 +65,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newExportSequenceCmd())
 	rootCmd.AddCommand(newFindCmd())
 	rootCmd.AddCommand(newShowCmd())
+	rootCmd.AddCommand(newLintCmd())
 
 	return rootCmd
 }

--- a/internal/constraints/engine.go
+++ b/internal/constraints/engine.go
@@ -1,0 +1,53 @@
+package constraints
+
+import (
+	"fmt"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// ErrUnknownRule is returned when a constraint specifies an unsupported rule type.
+type ErrUnknownRule struct {
+	Rule string
+}
+
+func (e ErrUnknownRule) Error() string {
+	return fmt.Sprintf("unknown constraint rule %q", e.Rule)
+}
+
+// Evaluate runs all constraints against the model and returns the aggregated result.
+// Unknown rule types are reported as violations so they don't silently pass.
+func Evaluate(m *model.BausteinsichtModel) Result {
+	var all []Violation
+	for _, c := range m.Constraints {
+		vs, err := evaluate(c, m)
+		if err != nil {
+			all = append(all, Violation{
+				ConstraintID: c.ID,
+				Message:      err.Error(),
+			})
+			continue
+		}
+		all = append(all, vs...)
+	}
+	return Result{Violations: all, Total: len(all)}
+}
+
+func evaluate(c model.Constraint, m *model.BausteinsichtModel) ([]Violation, error) {
+	switch c.Rule {
+	case "no-relationship":
+		return noRelationship(c, m), nil
+	case "allowed-relationship":
+		return allowedRelationship(c, m), nil
+	case "required-field":
+		return requiredField(c, m), nil
+	case "max-depth":
+		return maxDepth(c, m), nil
+	case "no-circular-dependency":
+		return noCircularDependency(c, m), nil
+	case "technology-allowed":
+		return technologyAllowed(c, m), nil
+	default:
+		return nil, ErrUnknownRule{Rule: c.Rule}
+	}
+}

--- a/internal/constraints/engine_test.go
+++ b/internal/constraints/engine_test.go
@@ -1,0 +1,328 @@
+package constraints_test
+
+import (
+	"testing"
+
+	"github.com/docToolchain/Bausteinsicht/internal/constraints"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// makeModel builds a minimal BausteinsichtModel with the given elements, relationships, and constraints.
+func makeModel(elements map[string]model.Element, rels []model.Relationship, cs []model.Constraint) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"system":    {Notation: "System"},
+				"container": {Notation: "Container"},
+				"component": {Notation: "Component"},
+				"person":    {Notation: "Person"},
+			},
+		},
+		Model:         elements,
+		Relationships: rels,
+		Constraints:   cs,
+	}
+}
+
+func countViolations(r constraints.Result) int {
+	return r.Total
+}
+
+// ─── no-relationship ─────────────────────────────────────────────────────────
+
+func TestNoRelationship_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "a", To: "b"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			FromKind: "container", ToKind: "system",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if countViolations(r) != 0 {
+		t.Errorf("expected 0 violations, got %d: %v", r.Total, r.Violations)
+	}
+}
+
+func TestNoRelationship_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "a", To: "b"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			FromKind: "system", ToKind: "container",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// ─── allowed-relationship ────────────────────────────────────────────────────
+
+func TestAllowedRelationship_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "a", To: "b"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "allowed-relationship",
+			FromKinds: []string{"system"}, ToKind: "container",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d", r.Total)
+	}
+}
+
+func TestAllowedRelationship_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"p": {Kind: "person"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "p", To: "b"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "allowed-relationship",
+			FromKinds: []string{"system"}, ToKind: "container",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// ─── required-field ──────────────────────────────────────────────────────────
+
+func TestRequiredField_MissingDescription(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system", Title: "A"},
+			"b": {Kind: "system", Title: "B", Description: "ok"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "required-field",
+			ElementKind: "system", Field: "description",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+	if len(r.Violations[0].Elements) != 1 {
+		t.Errorf("expected 1 offending element, got %d", len(r.Violations[0].Elements))
+	}
+}
+
+func TestRequiredField_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system", Title: "A", Description: "desc"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "required-field",
+			ElementKind: "system", Field: "description",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d", r.Total)
+	}
+}
+
+func TestRequiredField_Technology(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "required-field",
+			ElementKind: "container", Field: "technology",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// ─── max-depth ───────────────────────────────────────────────────────────────
+
+func TestMaxDepth_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system", Children: map[string]model.Element{
+				"b": {Kind: "container"},
+			}},
+		},
+		nil,
+		[]model.Constraint{{ID: "c1", Rule: "max-depth", Max: 2}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d", r.Total)
+	}
+}
+
+func TestMaxDepth_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system", Children: map[string]model.Element{
+				"b": {Kind: "container", Children: map[string]model.Element{
+					"c": {Kind: "component"},
+				}},
+			}},
+		},
+		nil,
+		[]model.Constraint{{ID: "c1", Rule: "max-depth", Max: 2}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// ─── no-circular-dependency ──────────────────────────────────────────────────
+
+func TestNoCircularDependency_NoCycle(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "system"},
+			"c": {Kind: "system"},
+		},
+		[]model.Relationship{
+			{From: "a", To: "b"},
+			{From: "b", To: "c"},
+		},
+		[]model.Constraint{{ID: "c1", Rule: "no-circular-dependency", Description: "no cycles"}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d: %v", r.Total, r.Violations)
+	}
+}
+
+func TestNoCircularDependency_Cycle(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "system"},
+		},
+		[]model.Relationship{
+			{From: "a", To: "b"},
+			{From: "b", To: "a"},
+		},
+		[]model.Constraint{{ID: "c1", Rule: "no-circular-dependency", Description: "no cycles"}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+	if len(r.Violations[0].Elements) == 0 {
+		t.Error("expected cycle elements to be listed")
+	}
+}
+
+// ─── technology-allowed ──────────────────────────────────────────────────────
+
+func TestTechnologyAllowed_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container", Technology: "Go"},
+			"b": {Kind: "container", Technology: "go"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "technology-allowed",
+			ElementKind: "container", Technologies: []string{"Go", "Java"},
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d", r.Total)
+	}
+}
+
+func TestTechnologyAllowed_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container", Technology: "PHP"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "technology-allowed",
+			ElementKind: "container", Technologies: []string{"Go", "Java"},
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+func TestTechnologyAllowed_EmptyTechnologySkipped(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container"},
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "technology-allowed",
+			ElementKind: "container", Technologies: []string{"Go"},
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations for unset technology, got %d", r.Total)
+	}
+}
+
+// ─── unknown rule ────────────────────────────────────────────────────────────
+
+func TestUnknownRule(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{"a": {Kind: "system"}},
+		nil,
+		[]model.Constraint{{ID: "c1", Rule: "does-not-exist"}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation for unknown rule, got %d", r.Total)
+	}
+}
+
+// ─── multiple constraints ────────────────────────────────────────────────────
+
+func TestMultipleConstraints(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "system"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "a", To: "b"}},
+		[]model.Constraint{
+			{ID: "c1", Rule: "required-field", ElementKind: "system", Field: "description"},
+			{ID: "c2", Rule: "required-field", ElementKind: "container", Field: "technology"},
+		},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 2 {
+		t.Errorf("expected 2 violations, got %d", r.Total)
+	}
+}

--- a/internal/constraints/rules.go
+++ b/internal/constraints/rules.go
@@ -1,0 +1,227 @@
+package constraints
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// noRelationship enforces that no relationship exists from any element of
+// fromKind to any element of toKind.
+func noRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
+	}
+	kindOf := buildKindMap(flat)
+
+	var bad []string
+	for _, rel := range m.Relationships {
+		if kindOf[rel.From] == c.FromKind && kindOf[rel.To] == c.ToKind {
+			bad = append(bad, fmt.Sprintf("%s → %s", rel.From, rel.To))
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      fmt.Sprintf("%s: %s kind must not relate to %s kind", c.Description, c.FromKind, c.ToKind),
+		Elements:     bad,
+	}}
+}
+
+// allowedRelationship enforces that only elements whose kind is in fromKinds
+// may have relationships pointing to elements of toKind.
+func allowedRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
+	}
+	kindOf := buildKindMap(flat)
+
+	allowed := make(map[string]bool, len(c.FromKinds))
+	for _, k := range c.FromKinds {
+		allowed[k] = true
+	}
+
+	var bad []string
+	for _, rel := range m.Relationships {
+		if kindOf[rel.To] == c.ToKind && !allowed[kindOf[rel.From]] {
+			bad = append(bad, fmt.Sprintf("%s (%s) → %s", rel.From, kindOf[rel.From], rel.To))
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      fmt.Sprintf("%s: only [%s] may relate to %s kind", c.Description, strings.Join(c.FromKinds, ", "), c.ToKind),
+		Elements:     bad,
+	}}
+}
+
+// requiredField enforces that all elements of elementKind have the given field
+// set to a non-empty value. Supported fields: "description", "technology", "title".
+func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
+	}
+
+	var bad []string
+	for id, el := range flat {
+		if el.Kind != c.ElementKind {
+			continue
+		}
+		var missing bool
+		switch c.Field {
+		case "description":
+			missing = el.Description == ""
+		case "technology":
+			missing = el.Technology == ""
+		case "title":
+			missing = el.Title == ""
+		}
+		if missing {
+			bad = append(bad, fmt.Sprintf("%s: missing %s", id, c.Field))
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      fmt.Sprintf("%s: all %s elements must have %q set", c.Description, c.ElementKind, c.Field),
+		Elements:     bad,
+	}}
+}
+
+// maxDepth enforces that no element is nested deeper than max levels.
+// Root-level elements have depth 1.
+func maxDepth(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	var bad []string
+	walkDepth(m.Model, 1, c.Max, &bad)
+	if len(bad) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      fmt.Sprintf("%s: maximum nesting depth is %d", c.Description, c.Max),
+		Elements:     bad,
+	}}
+}
+
+func walkDepth(elements map[string]model.Element, depth, max int, bad *[]string) {
+	for id, el := range elements {
+		if depth > max {
+			*bad = append(*bad, fmt.Sprintf("%s (depth %d)", id, depth))
+		}
+		if len(el.Children) > 0 {
+			walkDepth(el.Children, depth+1, max, bad)
+		}
+	}
+}
+
+// noCircularDependency detects cycles in the relationship graph using DFS.
+func noCircularDependency(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	// Build adjacency list.
+	adj := make(map[string][]string)
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
+	}
+	for id := range flat {
+		adj[id] = nil
+	}
+	for _, rel := range m.Relationships {
+		adj[rel.From] = append(adj[rel.From], rel.To)
+	}
+
+	visited := make(map[string]bool)
+	inStack := make(map[string]bool)
+	var cycles []string
+
+	var dfs func(node string, path []string)
+	dfs = func(node string, path []string) {
+		visited[node] = true
+		inStack[node] = true
+		path = append(path, node)
+
+		for _, neighbour := range adj[node] {
+			if !visited[neighbour] {
+				dfs(neighbour, path)
+			} else if inStack[neighbour] {
+				// Found a cycle — record the loop segment.
+				for i, n := range path {
+					if n == neighbour {
+						cycle := strings.Join(append(path[i:], neighbour), " → ")
+						cycles = append(cycles, cycle)
+						break
+					}
+				}
+			}
+		}
+		inStack[node] = false
+	}
+
+	for node := range adj {
+		if !visited[node] {
+			dfs(node, nil)
+		}
+	}
+
+	if len(cycles) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      c.Description + ": circular dependencies detected",
+		Elements:     cycles,
+	}}
+}
+
+// technologyAllowed enforces that elements of elementKind only use technologies
+// from the given allowed list.
+func technologyAllowed(c model.Constraint, m *model.BausteinsichtModel) []Violation {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
+	}
+	allowed := make(map[string]bool, len(c.Technologies))
+	for _, t := range c.Technologies {
+		allowed[strings.ToLower(t)] = true
+	}
+
+	var bad []string
+	for id, el := range flat {
+		if el.Kind != c.ElementKind {
+			continue
+		}
+		if el.Technology == "" {
+			continue // technology not set — use required-field rule to enforce that separately
+		}
+		if !allowed[strings.ToLower(el.Technology)] {
+			bad = append(bad, fmt.Sprintf("%s: technology %q not in allowed list [%s]",
+				id, el.Technology, strings.Join(c.Technologies, ", ")))
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return []Violation{{
+		ConstraintID: c.ID,
+		Message:      fmt.Sprintf("%s: %s elements must use one of [%s]", c.Description, c.ElementKind, strings.Join(c.Technologies, ", ")),
+		Elements:     bad,
+	}}
+}
+
+// buildKindMap returns a map from element ID to its kind for all flattened elements.
+func buildKindMap(flat map[string]*model.Element) map[string]string {
+	m := make(map[string]string, len(flat))
+	for id, el := range flat {
+		m[id] = el.Kind
+	}
+	return m
+}

--- a/internal/constraints/rules.go
+++ b/internal/constraints/rules.go
@@ -83,6 +83,12 @@ func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation 
 			missing = el.Technology == ""
 		case "title":
 			missing = el.Title == ""
+		default:
+			// Unsupported field name — return error violation immediately
+			return []Violation{{
+				ConstraintID: c.ID,
+				Message:      fmt.Sprintf("%s: unsupported field %q (valid: description, technology, title)", c.Description, c.Field),
+			}}
 		}
 		if missing {
 			bad = append(bad, fmt.Sprintf("%s: missing %s", id, c.Field))

--- a/internal/constraints/types.go
+++ b/internal/constraints/types.go
@@ -1,0 +1,16 @@
+// Package constraints evaluates architectural rules defined in the model's
+// constraints section and reports violations.
+package constraints
+
+// Violation describes a single rule failure.
+type Violation struct {
+	ConstraintID string   `json:"constraint_id"`
+	Message      string   `json:"message"`
+	Elements     []string `json:"elements,omitempty"`
+}
+
+// Result holds all violations found during a lint run.
+type Result struct {
+	Violations []Violation `json:"violations"`
+	Total      int         `json:"total"`
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -17,6 +17,7 @@ type BausteinsichtModel struct {
 	Relationships []Relationship     `json:"relationships"`
 	Views         map[string]View    `json:"views"`
 	DynamicViews  []DynamicView      `json:"dynamicViews,omitempty"`
+	Constraints   []Constraint       `json:"constraints,omitempty"`
 
 	// ElementOrder stores the definition order of element kinds from
 	// specification.elements. Used by the layout engine for layer assignment.
@@ -47,6 +48,28 @@ type DynamicView struct {
 	Title       string         `json:"title"`
 	Description string         `json:"description,omitempty"`
 	Steps       []SequenceStep `json:"steps"`
+}
+
+// Constraint defines an architectural rule that can be enforced via `bausteinsicht lint`.
+type Constraint struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Rule        string `json:"rule"`
+
+	// no-relationship / allowed-relationship
+	FromKind  string   `json:"from-kind,omitempty"`
+	ToKind    string   `json:"to-kind,omitempty"`
+	FromKinds []string `json:"from-kinds,omitempty"`
+
+	// required-field
+	ElementKind string `json:"element-kind,omitempty"`
+	Field       string `json:"field,omitempty"`
+
+	// max-depth
+	Max int `json:"max,omitempty"`
+
+	// technology-allowed
+	Technologies []string `json:"technologies,omitempty"`
 }
 
 type Specification struct {

--- a/templates/sample-model.jsonc
+++ b/templates/sample-model.jsonc
@@ -282,6 +282,29 @@
     }
   ],
 
+  // Constraints: architectural rules enforced by `bausteinsicht lint`
+  "constraints": [
+    {
+      "id":          "C01",
+      "description": "External actors must not access internal containers directly",
+      "rule":        "no-relationship",
+      "from-kind":   "person",
+      "to-kind":     "container"
+    },
+    {
+      "id":           "C02",
+      "description":  "All containers must declare their technology",
+      "rule":         "required-field",
+      "element-kind": "container",
+      "field":        "technology"
+    },
+    {
+      "id":          "C03",
+      "description": "No circular dependencies allowed",
+      "rule":        "no-circular-dependency"
+    }
+  ],
+
   // Views: each view becomes a page in the draw.io diagram
   "views": {
     "context": {


### PR DESCRIPTION
## Summary

- Adds `constraints` section to the model DSL with 6 rule types: `no-relationship`, `allowed-relationship`, `required-field`, `max-depth`, `no-circular-dependency`, `technology-allowed`
- New `bausteinsicht lint` command evaluates all constraints and outputs violations in text or JSON format
- Exit codes: `0` = clean, `1` = violations found, `2` = model load error — enabling CI/CD enforcement
- Sample model extended with three example constraints

## Changes

| Package | File | Change |
|---------|------|--------|
| `internal/model` | `types.go` | `Constraint` struct + `Constraints []Constraint` in `BausteinsichtModel` |
| `internal/constraints` | `types.go`, `engine.go`, `rules.go` | New package: `Evaluate()`, 6 rule functions, `Violation`/`Result` types |
| `internal/constraints` | `engine_test.go` | 16 unit tests covering all rules and edge cases |
| `cmd/bausteinsicht` | `lint.go` | New `lint` command with `--format text\|json` |
| `cmd/bausteinsicht` | `lint_test.go` | 7 CLI-level tests (exit codes, JSON/text output) |
| `templates` | `sample-model.jsonc` | Example constraints section |

## Test plan

- [x] `go test ./internal/constraints/` — 16 tests, all rules + edge cases
- [x] `go test ./cmd/bausteinsicht/ -run TestLint` — 7 tests, exit codes 0/1/2, JSON/text format
- [x] `go build ./...` — clean build

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)