### PR TITLE
docs: reverse-engineer full documentation set from source

### DIFF
--- a/src/docs/OPEN_QUESTIONS.adoc
+++ b/src/docs/OPEN_QUESTIONS.adoc
@@ -1,0 +1,374 @@
+= Open Questions
+:toc: left
+:toclevels: 2
+:sectnums:
+:icons: font
+
+This list captures every assumption made while writing PRD-001, the specification (`spec/01..05`) and the arc42 chapters that could **not** be proven from the code alone.
+Each entry follows the prescribed structure.
+
+== Business Context
+
+[[OQ-001]]
+=== OQ-001: Who is the formal product owner / sponsor?
+
+Category:: Business Context
+Confidence:: Low
+Your Best Guess:: docToolchain maintainers — the repository lives under `github.com/docToolchain` and CONTRIBUTING.md mentions arc42 ADRs as a first-class artefact.
+Why You Can't Be Sure:: The repo has no `OWNERS`, `MAINTAINERS`, governance file, or "About" prose beyond the README. No `CODEOWNERS` either.
+What Would Help:: A short governance/maintainership note in CONTRIBUTING.md or README.
+
+[[OQ-002]]
+=== OQ-002: Is Bausteinsicht an experiment, an incubation, or a long-term product?
+
+Category:: Business Context
+Confidence:: Low
+Your Best Guess:: Long-term — the project ships releases, has CI on three OSes, and embeds a Claude Code skill suggesting third-party integrations are anticipated.
+Why You Can't Be Sure:: No roadmap document, no version history beyond `version="dev"` in `main.go`.
+What Would Help:: A `ROADMAP.adoc` or release notes referenced from README.
+
+[[OQ-003]]
+=== OQ-003: What success metrics matter for v1?
+
+Category:: Business Context
+Confidence:: Low
+Your Best Guess:: Adoption (release downloads), round-trip fidelity (no JSONC comment loss in production usage), low CI failure rate on `make check`.
+Why You Can't Be Sure:: No analytics / telemetry / KPIs are defined anywhere in the repo.
+What Would Help:: A "success criteria" paragraph in PRD-001 (this PRD lists this question instead).
+
+== Stakeholder Context
+
+[[OQ-010]]
+=== OQ-010: Are there expected enterprise integrations beyond docToolchain?
+
+Category:: Stakeholder Context
+Confidence:: Low
+Your Best Guess:: Generic — the JSON-everywhere CLI suggests downstream integration with arbitrary CI/CD or doc generators rather than a specific vendor.
+Why You Can't Be Sure:: Only docToolchain and Claude Code are explicitly mentioned. No examples integrating with Backstage, Confluence, etc.
+What Would Help:: A concrete "integrations" matrix in README.
+
+[[OQ-011]]
+=== OQ-011: Who runs Bausteinsicht — humans, CI, or AI agents in production?
+
+Category:: Stakeholder Context
+Confidence:: Medium
+Your Best Guess:: All three. The CLI is designed for local interactive use (watch mode) but every command has `--format json` for non-interactive use and there is a Claude Code skill.
+Why You Can't Be Sure:: No telemetry to confirm.
+What Would Help:: User-research notes or a section in the README summarising primary usage modes.
+
+== Design Rationale
+
+[[OQ-020]]
+=== OQ-020: Why JSONC instead of YAML or a custom DSL? What was rejected and why?
+
+Category:: Design Rationale
+Confidence:: Medium
+Your Best Guess:: ADR-001 captures my reconstruction (familiarity, comment support, schema-driven IDE tooling).
+Why You Can't Be Sure:: There is no original ADR file in the repo at the path README links (`src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc`); the link is "future work" until generated.
+What Would Help:: The author's original notes or PR discussion.
+
+[[OQ-021]]
+=== OQ-021: Why "model wins" by default for conflicts?
+
+Category:: Design Rationale
+Confidence:: Medium
+Your Best Guess:: It aligns with "JSONC is source of truth"; it is deterministic and CI-friendly. ADR-004 captures this rationale.
+Why You Can't Be Sure:: The interface (`ConflictResolver`) is in place but only one implementation exists. No design doc explains whether other resolvers are planned for v1.x or v2.
+What Would Help:: A maintained roadmap entry on conflict-policy expansion.
+
+[[OQ-022]]
+=== OQ-022: Why is the layout engine bespoke instead of using Graphviz / dagre / d3-hierarchy?
+
+Category:: Design Rationale
+Confidence:: Low
+Your Best Guess:: Independence from external runtimes (preserves the static-binary property), and the limited set of layouts (layered/grid/none) is enough for C4-style architecture pictures.
+Why You Can't Be Sure:: No comments in `internal/sync/layout.go` discuss alternatives.
+What Would Help:: A short note in `08_crosscutting_concepts.adoc` justifying the layout choice.
+
+[[OQ-023]]
+=== OQ-023: Why a self-checksum on the state file rather than relying on file hashes alone?
+
+Category:: Design Rationale
+Confidence:: Medium
+Your Best Guess:: To detect manual edits / corruption of `.bausteinsicht-sync` and to give a clean error/recovery path.
+Why You Can't Be Sure:: No comment cites a specific incident or threat.
+What Would Help:: A `# rationale:` comment near `state.go::SaveState`.
+
+[[OQ-024]]
+=== OQ-024: What is the format-version policy for `.bausteinsicht-sync`?
+
+Category:: Design Rationale
+Confidence:: Low
+Your Best Guess:: There is no version field on `SyncState` today; corruption / mismatch is the only handled case. A future format change would require a migrator or a "delete and re-sync" message.
+Why You Can't Be Sure:: No version field, no migration code.
+What Would Help:: An explicit `Schema int` on `SyncState` and a documented migration plan.
+
+[[OQ-025]]
+=== OQ-025: Why is `architecture.drawio` the hard-coded sibling of the model file?
+
+Category:: Design Rationale
+Confidence:: Low
+Your Best Guess:: Convention-over-configuration; matches what `init` produces. Allowing arbitrary names would require a flag and would clash with auto-detection of the model.
+Why You Can't Be Sure:: No flag and no override is exposed.
+What Would Help:: An explicit `bausteinsicht.toml` or a top-level `drawio` field in the JSONC model.
+
+[[OQ-026]]
+=== OQ-026: Why are `Element.Tags` and `Element.Metadata` declared but not consumed?
+
+Category:: Design Rationale
+Confidence:: Low
+Your Best Guess:: Reserved for future filtering or rendering; declared early to avoid a future schema break.
+Why You Can't Be Sure:: No consumer found and no comment explains the intent.
+What Would Help:: Either remove the fields or add a `// TODO: ...` with the planned consumer.
+
+[[OQ-027]]
+=== OQ-027: Is `bausteinsicht_template_version = 1` meant to be incremented soon?
+
+Category:: Design Rationale
+Confidence:: Low
+Your Best Guess:: It is forward-looking — present so that future template format changes can be detected without breaking installed users.
+Why You Can't Be Sure:: No migration code or v0/v1 difference is currently encoded.
+What Would Help:: An ADR documenting the template-versioning policy.
+
+== Domain Knowledge
+
+[[OQ-030]]
+=== OQ-030: What is the canonical list of layout values? Code accepts `""`, `"layered"`, `"grid"`, `"none"` — is `""` documented as "use the default" or as a separate value?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: `""` means "use default" (treated as `"layered"`).
+Why You Can't Be Sure:: The validator accepts both empty and `"layered"` without distinguishing them.
+What Would Help:: An explicit default value in the JSON Schema and a unit-test naming this behaviour.
+
+[[OQ-031]]
+=== OQ-031: Are pattern globs `*` and `**` strictly mutually exclusive at a given path component?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Yes — `MatchPattern` does not support combinations like `prefix.x*y`.
+Why You Can't Be Sure:: The implementation handles the four documented forms and the literal-equality case but I did not see explicit rejection of malformed patterns.
+What Would Help:: A unit test that pins down behaviour for `prefix.x*y` (accept literally? reject?).
+
+[[OQ-032]]
+=== OQ-032: Is the C4 level always one of {Context, Container, Component} or could a future model introduce a "Code" level?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Limited to the three; `internal/diagram/diagram.go::detectLevel` only emits these three.
+Why You Can't Be Sure:: PlantUML's C4-PlantUML library supports a Code level; the project may add it later.
+What Would Help:: Comment in `detectLevel` stating "only Context/Container/Component for now" or a plan for Code.
+
+[[OQ-033]]
+=== OQ-033: How are "external" elements detected for top/bottom layout placement?
+
+Category:: Domain Knowledge
+Confidence:: Low
+Your Best Guess:: Heuristic — actors at the top, scope-children inside, others at the bottom. The exact rule (kind name? presence of `external_system`?) was not unambiguously visible.
+Why You Can't Be Sure:: I traced the layered layout but the kind-classification heuristic deserves direct inspection that I could not complete in the time available.
+What Would Help:: A comment in `internal/sync/layout.go` naming the rule, or a "first kind = top, last kind = bottom" pinning.
+
+[[OQ-034]]
+=== OQ-034: Are duplicate relationships with same `from`/`to` but different `kind` always rendered as separate edges, or could they be merged into one labelled edge?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Always separate edges, identified by `rel-<from>-<to>-<index>`.
+Why You Can't Be Sure:: `TestRun_MultipleRelsSamePair` confirms the model supports them — it does not specify visual rendering details.
+What Would Help:: An explicit visual test fixture.
+
+[[OQ-035]]
+=== OQ-035: Element ID grammar — does `_` need to be supported, or only `-`?
+
+Category:: Domain Knowledge
+Confidence:: High
+Your Best Guess:: Both are supported per the regex `^[a-zA-Z][a-zA-Z0-9_-]*$`.
+Why You Can't Be Sure:: I confirmed in `add_element.go` and `TestAddElementValidIDs`.
+What Would Help:: This is essentially closed; included for completeness.
+
+== Future Direction
+
+[[OQ-040]]
+=== OQ-040: Is a `--dry-run` / `plan` flag planned?
+
+Category:: Future Direction
+Confidence:: Low
+Your Best Guess:: It is implied (the diff engine could emit a plan without writing files) but no flag exists today.
+Why You Can't Be Sure:: No flag and no comment hints at it.
+What Would Help:: An issue / ADR draft.
+
+[[OQ-041]]
+=== OQ-041: Will the project ship a JSON Schema (`bausteinsicht.schema.json`)?
+
+Category:: Future Direction
+Confidence:: High
+Your Best Guess:: Yes — the embedded sample references it via a stable URL (`https://raw.githubusercontent.com/.../schema/bausteinsicht.schema.json`). The repo currently does not contain `schema/` so the URL 404s.
+Why You Can't Be Sure:: The file is referenced but missing; either the schema is generated at release time (we did not find a script for that) or it is genuinely TODO.
+What Would Help:: Either commit the schema or remove the `$schema` reference until it exists.
+
+[[OQ-042]]
+=== OQ-042: Is collaborative editing (multi-user) a target?
+
+Category:: Future Direction
+Confidence:: Low
+Your Best Guess:: Not in v1 — the design assumes a single workstation; concurrent edits would require richer conflict policy than "model wins".
+Why You Can't Be Sure:: No CRDT, OT, or merge code.
+What Would Help:: Explicit non-goal in PRD.
+
+[[OQ-043]]
+=== OQ-043: Will the export pipeline ever stop depending on the draw.io binary?
+
+Category:: Future Direction
+Confidence:: Low
+Your Best Guess:: Maybe — the project already emits PlantUML and Mermaid; an "SVG without draw.io" path is technically feasible.
+Why You Can't Be Sure:: No comment in `internal/export` discusses this.
+What Would Help:: An ADR draft on rendering strategy.
+
+[[OQ-044]]
+=== OQ-044: Will additional output formats (DOT, structurizr DSL) be added?
+
+Category:: Future Direction
+Confidence:: Low
+Your Best Guess:: Possibly — the `Format` enum (`internal/diagram/diagram.go`) is shaped for extension.
+Why You Can't Be Sure:: No issue / TODO found.
+
+== Quality Goals
+
+[[OQ-050]]
+=== OQ-050: What is the formal performance budget?
+
+Category:: Quality Goals
+Confidence:: Low
+Your Best Guess:: Sync should complete in well under a second for n≤500 elements (informed by the bench timings in the explore agent's report).
+Why You Can't Be Sure:: Benchmarks exist but no thresholds; no performance test asserts anything.
+What Would Help:: A `bench_threshold_test.go` that fails on regression.
+
+[[OQ-051]]
+=== OQ-051: What is the supported maximum architecture size?
+
+Category:: Quality Goals
+Confidence:: Medium
+Your Best Guess:: Several thousand elements would be feasible (10 MiB JSONC ≫ 500 elements). Hard limits are file size and depth (50).
+Why You Can't Be Sure:: No documented "supported scale" statement.
+What Would Help:: A scale section in PRD.
+
+[[OQ-052]]
+=== OQ-052: Are there accessibility requirements for the rendered diagrams?
+
+Category:: Quality Goals
+Confidence:: Low
+Your Best Guess:: Not in v1 — colours are hard-coded gray (`#CCCCCC`, `#BBBBBB`); no high-contrast / dyslexia-friendly mode found.
+What Would Help:: Either a stated non-goal or a backlog item.
+
+[[OQ-053]]
+=== OQ-053: What is the threat model?
+
+Category:: Quality Goals
+Confidence:: Medium
+Your Best Guess:: Local CLI; trust the user's own model; defensive against tampered state files; SEC-001/008/013/015/016 codify the boundaries.
+Why You Can't Be Sure:: README references `src/docs/spec/07_trust_model.adoc` and `src/docs/security/2026-03-01-security-review.adoc` which are not present. The trust model is implied, not stated.
+What Would Help:: Author the linked trust-model document.
+
+== Process / Documentation
+
+[[OQ-060]]
+=== OQ-060: Where is the actual `bausteinsicht.schema.json`?
+
+Category:: Domain Knowledge
+Confidence:: High
+Your Best Guess:: Not in the repository on the working branch. The README and sample model link to a path under `schema/` but the directory does not exist.
+What Would Help:: Add `schema/bausteinsicht.schema.json` and a CI step that regenerates it from the Go structs (e.g., via `invopop/jsonschema`).
+
+[[OQ-061]]
+=== OQ-061: Where is the User Manual?
+
+Category:: Documentation
+Confidence:: High
+Your Best Guess:: README links `src/docs/manual/user-manual.adoc` (multi-view, llm-workflows anchors); the file is not present in the repo today.
+What Would Help:: Author the user manual; this PRD/spec/arc42 set covers spec-level content but not step-by-step user guidance.
+
+[[OQ-062]]
+=== OQ-062: Where is the Tutorial linked from README ("Getting Started Tutorial" — `src/docs/spec/06_tutorial.adoc`)?
+
+Category:: Documentation
+Confidence:: High
+Your Best Guess:: Not in the repo on this branch; it is a planned artefact.
+What Would Help:: Author the tutorial, or remove the broken link.
+
+[[OQ-063]]
+=== OQ-063: Where is the Trust Model document referenced from README ("Security" → `src/docs/spec/07_trust_model.adoc`)?
+
+Category:: Documentation
+Confidence:: High
+Your Best Guess:: Not in the repo on this branch; the SEC-NNN codes scattered in the source code are the *only* trace of the threat model.
+What Would Help:: Consolidate the SEC mitigations into a dedicated trust-model document.
+
+[[OQ-064]]
+=== OQ-064: Where is the Security Review referenced from README (`src/docs/security/2026-03-01-security-review.adoc`)?
+
+Category:: Documentation
+Confidence:: High
+Your Best Guess:: Not in the repo on this branch.
+What Would Help:: Either create the file as part of the next security pass or update the README to remove the link.
+
+== Specific small uncertainties
+
+[[OQ-070]]
+=== OQ-070: Does `--scale` >1 cause a runtime warning or fail when no GPU is available?
+
+Category:: Domain Knowledge
+Confidence:: Low
+Your Best Guess:: Behaviour depends entirely on the underlying `drawio` CLI; Bausteinsicht just passes the value through.
+What Would Help:: A note in CLI Spec naming "behaviour delegated to draw.io".
+
+[[OQ-071]]
+=== OQ-071: When `--combined` and `--view` are both set on `export-table`, which wins?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Implementation likely treats `--combined` as overriding `--view`, since it produces a single merged table.
+What Would Help:: Either a CLI test for the combination or an explicit rejection when both are passed.
+
+[[OQ-072]]
+=== OQ-072: Is `bausteinsicht_id` required or optional on a draw.io `<object>`?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Optional. Cells without it are user content; cells with it are managed.
+What Would Help:: A test fixture mixing managed and unmanaged cells.
+
+[[OQ-073]]
+=== OQ-073: Does the metadata box render when `config.metadata` is `false` and was previously `true`?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: The box is removed (since the next sync sees no demand for it). I did not trace deletion of pre-existing metadata cells.
+What Would Help:: A test fixture toggling `config.metadata` between syncs.
+
+[[OQ-074]]
+=== OQ-074: Are JSONC nested block comments handled?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: Not handled — typical JSONC parsers do not support nesting and `StripJSONC`'s state machine looks single-level.
+What Would Help:: Either a fixture asserting the un-supported behaviour or a comment in `StripJSONC` stating the limitation.
+
+[[OQ-075]]
+=== OQ-075: How is element creation under a deeply nested parent flattened by `InsertObjectEntry`?
+
+Category:: Domain Knowledge
+Confidence:: Medium
+Your Best Guess:: It walks the path and adds the entry at the bottom of the corresponding object literal; the helper computes indent from existing whitespace.
+What Would Help:: A property test (rapid) over arbitrary nesting depths to pin behaviour.
+
+[[OQ-076]]
+=== OQ-076: Is the stable JSON schema for command outputs versioned?
+
+Category:: Quality Goals
+Confidence:: Low
+Your Best Guess:: Implicitly v1; no `--api-version` flag exists.
+What Would Help:: A `bausteinsicht --json-version` flag or a documented stability policy.
+
+== Closing note
+
+This list is the canonical inventory of "things I assumed but could not verify". If you read PRD-001 and noticed a definitive-sounding statement, the corresponding uncertainty is here.

--- a/src/docs/PRD/PRD-001.adoc
+++ b/src/docs/PRD/PRD-001.adoc
@@ -1,0 +1,276 @@
+= PRD-001: Bausteinsicht — Architecture-as-Code with Bidirectional draw.io Sync
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+
+[NOTE]
+====
+This Product Requirements Document was reverse-engineered from the source code, CLI surface, embedded templates, error messages, and tests.
+Statements that could not be traced to code are tracked in `src/docs/OPEN_QUESTIONS.adoc`.
+====
+
+== Vision
+
+Bausteinsicht is a local CLI that lets a team **define a software-architecture model in a single JSONC file and keep it visually in sync with draw.io diagrams in both directions**.
+The text file is the version-controllable source of truth for diff/review/CI; the draw.io file is the rich visual surface for human editing.
+Both surfaces remain authoritative for a defined set of edits, and changes flow either way without losing comments, formatting, or visual layout.
+
+The product is C4-inspired but not limited to four fixed levels — element kinds and relationship kinds are user-defined in the model's `specification` block (templates/sample-model.jsonc, README.adoc).
+
+== Problem Statement
+
+Architecture-as-code tooling today forces a tradeoff:
+
+* **Diagram-first tools** (raw draw.io, Lucidchart) make beautiful pictures but the model is locked inside an XML or proprietary file. Code review and refactoring of the architecture are awkward.
+* **Text-first tools** (Structurizr DSL, LikeC4, PlantUML) are versionable and reviewable but require contributors to learn a DSL, and visual editing requires re-rendering. Drag-and-drop layout edits do not propagate back to the source (README.adoc — "Related Projects").
+
+Bausteinsicht resolves the tradeoff: a JSONC source of truth, comment-preserving patches, and a sync engine that merges draw.io edits back into the JSONC. The user picks the surface they prefer for any given edit.
+
+== Target Audience
+
+Derived from CLI affordances, embedded skill (`.kiro/skills/bausteinsicht/SKILL.md`), example model (`examples/online-shop/architecture.jsonc`), and README workflows:
+
+* **Software architects and tech leads** maintaining living architecture documentation across multiple C4 levels.
+* **Platform / DevOps engineers** who want architecture diagrams in CI alongside code (single CLI binary, no Java/Node runtime — go.mod, Makefile).
+* **arc42 / docToolchain users** — the project lives under `github.com/docToolchain` and the README and CONTRIBUTING.md reference arc42 ADRs as a documentation target.
+* **AI/LLM-driven workflows** — every command has a documented JSON output mode (`--format json`, root.go:50) and there is an explicit `bausteinsicht` Claude Code skill (`.kiro/skills/bausteinsicht/SKILL.md`) that exposes the CLI to agents.
+
+== Functional Requirements
+
+=== Model and Source of Truth
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-001
+| The system MUST accept a single JSONC file (JSON with `//` line comments, `/* */` block comments, and trailing commas) as the architecture model. _Source: internal/model/loader.go `StripJSONC`._
+
+| FR-002
+| The model MUST have four sections: `specification` (element kinds and relationship kinds), `model` (element hierarchy), `relationships` (array of edges), `views` (named visualisations). An optional `config` block sets metadata-box content. _Source: internal/model/types.go `BausteinsichtModel`._
+
+| FR-003
+| Element kinds and relationship kinds MUST be user-defined inside `specification.elements` and `specification.relationships`. The element-kind definition order MUST be preserved and used as the layout tier order. _Source: internal/model/loader.go `extractElementOrder`, internal/sync/layout.go._
+
+| FR-004
+| Elements MUST nest hierarchically through a `children` map; nesting depth MUST be limited to 50 to bound recursion. _Source: internal/model/types.go `Element.Children`, internal/model/resolve.go `MaxElementDepth = 50`._
+
+| FR-005
+| Element IDs in CLI input MUST match `^[a-zA-Z][a-zA-Z0-9_-]*$`; dot is reserved as the hierarchy separator in path references such as `onlineshop.api.catalog`. _Source: cmd/bausteinsicht/add_element.go (regex), internal/model/resolve.go `Resolve`._
+
+| FR-006
+| Model file size MUST be limited to 10 MiB. _Source: internal/model/loader.go `MaxModelFileSize = 10 * 1024 * 1024`._
+|===
+
+=== CLI Commands
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-010
+| `bausteinsicht init` MUST scaffold a new project (`architecture.jsonc`, `template.drawio`, `architecture.drawio`, `.bausteinsicht-sync`) and refuse to overwrite any existing file. _Source: cmd/bausteinsicht/init.go._
+
+| FR-011
+| `bausteinsicht sync` MUST run a bidirectional three-way sync: model → draw.io and draw.io → model. _Source: cmd/bausteinsicht/sync.go, internal/sync/engine.go._
+
+| FR-012
+| `bausteinsicht validate` MUST validate the model and report errors and warnings without modifying any file. _Source: cmd/bausteinsicht/validate.go._
+
+| FR-013
+| `bausteinsicht add element` MUST add a new element with comment-preserving JSONC patching. _Source: cmd/bausteinsicht/add_element.go, internal/model/patch.go `InsertObjectEntry`._
+
+| FR-014
+| `bausteinsicht add relationship` MUST append a new relationship with comment-preserving JSONC patching and reject exact duplicates. _Source: cmd/bausteinsicht/add_relationship.go, internal/model/patch.go `AppendArrayEntry`._
+
+| FR-015
+| `bausteinsicht watch` MUST run continuously, debounce file-system events (default 300 ms), and re-sync on changes to either the model or the draw.io file. _Source: cmd/bausteinsicht/watch.go, internal/watcher/watcher.go `DefaultDebounce`._
+
+| FR-016
+| `bausteinsicht export` MUST shell out to a detected draw.io CLI to render PNG/SVG images per view. _Source: cmd/bausteinsicht/export.go, internal/export/._
+
+| FR-017
+| `bausteinsicht export-table` MUST emit per-view or combined element tables as AsciiDoc or Markdown (and JSON when `--format json` is set). _Source: cmd/bausteinsicht/export_table.go, internal/table/._
+
+| FR-018
+| `bausteinsicht export-diagram` MUST emit per-view diagrams as PlantUML C4 or Mermaid. _Source: cmd/bausteinsicht/export_diagram.go, internal/diagram/._
+
+| FR-019
+| Every command MUST support `--format text|json` for machine-readable output. _Source: cmd/bausteinsicht/root.go:50._
+
+| FR-020
+| Every command MUST auto-detect the model file (single `*.jsonc` in the current directory) when `--model` is not supplied. _Source: internal/model/loader.go `AutoDetect`._
+|===
+
+=== Synchronization
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-030
+| Forward sync (model → draw.io) MUST create, update, and delete elements and connectors so that each defined view becomes a draw.io page identified by `view-<viewID>`. _Source: internal/sync/forward.go, cmd/bausteinsicht/sync.go._
+
+| FR-031
+| Newly created elements MUST be visually marked with a red dashed border (`strokeColor=#FF0000;dashed=1;`) so the user can recognise unplaced elements. _Source: internal/sync/forward.go `newElementMarker`._
+
+| FR-032
+| Reverse sync (draw.io → model) MUST propagate changes to element title, description, and technology fields, plus relationship label changes, back into the JSONC model. _Source: internal/sync/reverse.go, internal/sync/diff.go._
+
+| FR-033
+| When a user reverses a connector in draw.io (Deleted A→B + Added B→A) the system MUST detect the swap and update the existing relationship in place to preserve `kind`, `label`, and `description`. _Source: internal/sync/reverse.go `applyRelSwap`._
+
+| FR-034
+| Conflicts (same field changed in both surfaces since the last sync) MUST be resolved with **model wins** by default; the losing draw.io change MUST be reported as a warning. _Source: internal/sync/conflict.go `ModelWinsResolver`._
+
+| FR-035
+| The sync engine MUST persist a sync state file (`.bausteinsicht-sync`) that records last-synced field values and SHA-256 hashes of both files, with a SHA-256 integrity checksum on the state file itself. _Source: internal/sync/state.go._
+
+| FR-036
+| If the draw.io file is missing or contains no `<diagram>` elements, sync MUST recreate it from the template and discard the stale sync state. _Source: cmd/bausteinsicht/sync.go._
+
+| FR-037
+| The sync engine MUST preserve JSONC comments and formatting when only field-level updates need to be saved (comment-preserving patch path); structural changes MUST fall back to a full marshal that preserves the file's pre-`{` preamble. _Source: internal/sync/patchops.go `ReversePatchOps`, internal/model/loader.go `Save`._
+
+| FR-038
+| Forward sync MUST relayout pages on `--relayout`, otherwise it MUST preserve manual positions of existing elements. _Source: cmd/bausteinsicht/sync.go (`--relayout` flag), internal/sync/forward.go._
+
+| FR-039
+| The sync engine MUST suppress false-positive deletions for elements that appear only on newly created view pages. _Source: internal/sync/diff.go `computeNewPageOnlyElements`._
+
+| FR-040
+| Empty title updates from draw.io MUST be rejected and reported as a warning. _Source: internal/sync/reverse.go (#150)._
+|===
+
+=== Views and Layout
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-050
+| A view MUST select elements with `include` patterns (literal IDs or globs `*` and `**`), refine with `exclude`, and optionally draw a boundary around a `scope` element. _Source: internal/model/resolve.go `MatchPattern`, `ResolveView`._
+
+| FR-051
+| Pattern semantics MUST be: `**` = all elements; `*` = top-level only; `prefix.*` = direct children; `prefix.**` = all descendants; otherwise exact match. _Source: internal/model/resolve.go `MatchPattern`._
+
+| FR-052
+| A view MUST support layout modes `layered` (default), `grid`, and `none`. _Source: internal/sync/layout.go `computeLayout`._
+
+| FR-053
+| In `layered` layout, element kinds MUST be ordered into tiers using the order in which they were defined in `specification.elements`. _Source: internal/sync/layout.go, internal/model/loader.go `extractElementOrder`._
+
+| FR-054
+| When a relationship endpoint is not visible on a view but an ancestor is, the connector MUST be lifted to the visible ancestor instead of being silently dropped. _Source: internal/sync/diff.go `computeVisibleRelationships` ("relationship lifting" — README.adoc Features)._
+
+| FR-055
+| Each view page SHOULD include a metadata box (view title, description, repo URL, model path, sync timestamp, author) and a legend of element-kind notations and colours, controlled by `config.metadata` and `config.legend`. _Source: internal/sync/metadata.go, internal/model/types.go `Config`._
+|===
+
+=== Validation
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-060
+| The validator MUST reject empty/whitespace element IDs, missing required fields (`kind`, `title`), unknown kinds, and unknown relationship kinds. _Source: internal/model/validate.go._
+
+| FR-061
+| The validator MUST reject `children` on a kind that does not declare `container: true`. _Source: internal/model/validate.go._
+
+| FR-062
+| The validator MUST reject relationships whose `from` or `to` does not resolve and MUST flag exact duplicates (same from/to/kind/label). _Source: internal/model/validate.go._
+
+| FR-063
+| The validator MUST reject views with invalid `layout` values, unresolved `scope`, or literal include/exclude IDs that do not exist; pattern entries (containing `*`) MUST NOT be flagged as missing. _Source: internal/model/validate.go._
+
+| FR-064
+| The validator MUST emit warnings (not errors) when the specification has no element kinds or the model is empty. _Source: internal/model/validate.go._
+|===
+
+=== Output, Errors, and Exit Codes
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| FR-070
+| Exit code MUST be `0` on success, `1` on validation/business-rule failure or unresolved conflicts, `2` on I/O / file-not-found / pre-flight error. _Source: cmd/bausteinsicht/*.go (`exitWithCode`)._
+
+| FR-071
+| When `--format json` is set, errors MUST be emitted to stderr as `{"error": <msg>, "code": <int>}`. _Source: cmd/bausteinsicht/root.go `ExecuteRoot`._
+
+| FR-072
+| Verbose mode (`--verbose`) MUST log a per-command progress trace to stderr. _Source: cmd/bausteinsicht/sync.go, watch.go._
+|===
+
+== Non-Functional Requirements
+
+[cols="1,4", options="header"]
+|===
+| ID | Requirement
+
+| NFR-001 _(Portability)_
+| The CLI MUST build as a single static binary for linux/darwin/windows × amd64/arm64 with `CGO_ENABLED=0`. _Source: Makefile, .goreleaser.yml._
+
+| NFR-002 _(Reproducibility)_
+| The build MUST require Go 1.25+ and only the dependencies pinned in `go.mod` (cobra, etree, fsnotify, rapid). No network access at run time. _Source: go.mod, README.adoc "Security"._
+
+| NFR-003 _(Atomicity / Durability)_
+| Every file write (model save, drawio save, sync-state save) MUST use a write-to-temp-then-rename pattern. _Source: internal/model/loader.go `Save`, internal/drawio/document.go `SaveDocument`, internal/sync/state.go `SaveState`._
+
+| NFR-004 _(Integrity)_
+| The sync state file MUST carry a `sha256:<hex>` self-checksum and detect tampering or corruption. _Source: internal/sync/state.go._
+
+| NFR-005 _(Security — path containment)_
+| `--model`, `--template`, and the export `--output` directory MUST be rejected if they contain `..` traversal components. _Source: cmd/bausteinsicht/root.go `validatePathContainment` (SEC-001, SEC-016), cmd/bausteinsicht/export.go (SEC-015)._
+
+| NFR-006 _(Security — HTML escaping)_
+| Element titles, technology and description rendered in draw.io HTML labels and metadata boxes MUST be HTML-escaped. _Source: internal/drawio/label.go `escapeHTML` (SEC-008), internal/sync/metadata.go._
+
+| NFR-007 _(Robustness — input bounds)_
+| The loader MUST cap model files at 10 MiB and traversal/recursion at depth 50. _Source: internal/model/loader.go `MaxModelFileSize`, internal/model/resolve.go `MaxElementDepth`._
+
+| NFR-008 _(Performance)_
+| Sync, flatten, and load operations MUST have benchmark coverage at n=10 / 100 / 500 elements. _Source: internal/model/bench_test.go, internal/sync/bench_test.go._
+
+| NFR-009 _(Quality gates)_
+| `make check` MUST run `go vet`, `staticcheck`, `gosec`, `nilaway`, `govulncheck`, plus race-detected tests; pre-commit hook MUST also run `gofmt`, `golangci-lint`, and `gitleaks`. _Source: Makefile, scripts/pre-commit._
+
+| NFR-010 _(IDE ergonomics)_
+| The model MUST advertise a `$schema` URL so editors can offer autocompletion without plugins. _Source: templates/sample-model.jsonc, README.adoc Features._
+
+| NFR-011 _(LLM ergonomics)_
+| Every command's machine output MUST be stable JSON. _Source: each command file's JSON branch._
+
+| NFR-012 _(Cross-platform export)_
+| draw.io CLI detection MUST consider `drawio-export` (devcontainer), `drawio` on PATH, and platform-specific paths on linux/darwin/windows. _Source: internal/export/platform_*.go._
+
+| NFR-013 _(Observability)_
+| Warnings, conflicts, and errors MUST go to stderr; structured "results" go to stdout. _Source: cmd/bausteinsicht/sync.go etc._
+|===
+
+== Success Metrics
+
+Not directly observable in code. See OQ entries.
+
+* **Adoption:** GitHub stars / release downloads (.goreleaser.yml).
+* **Round-trip fidelity:** zero loss of JSONC comments after a draw.io edit (CONTRIBUTING.md mandates a comment-preservation E2E test for every new field).
+* **Sync latency:** watch-mode debounce of 300 ms is the implicit upper bound on perceived editor latency (`internal/watcher/watcher.go`).
+
+== Future Considerations
+
+The following capabilities are *implied* by code structure or comments but not yet implemented:
+
+* **Pluggable conflict resolvers** — `ConflictResolver` is an interface with only `ModelWinsResolver` (internal/sync/conflict.go); a "draw.io wins" or interactive resolver could be added.
+* **Template versioning** — `bausteinsicht_template_version` already declared (`drawio/template.go`, `CurrentTemplateVersion = 1`); migration paths for v2 are not yet present.
+* **Additional export formats** — current diagram exports are PlantUML and Mermaid; a `Format` enum (internal/diagram/diagram.go) suggests the list is meant to grow.
+* **Tags on elements** (`Element.Tags []string`, types.go) — not yet used in layout, validation, or any view filter that we could trace.
+* **Element metadata map** (`Element.Metadata map[string]string`, types.go) — declared but no consuming code path was found.
+* **Watch mode for non-default file names** — watch.go expects `architecture.drawio` next to the model.
+
+== Open Questions
+
+See `src/docs/OPEN_QUESTIONS.adoc`. All assumptions made in this PRD that could not be proven from code are listed there.

--- a/src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc
+++ b/src/docs/arc42/ADRs/ADR-001-DSL-Format.adoc
@@ -1,0 +1,53 @@
+= ADR-001: JSONC as the model DSL
+
+== Status
+
+Accepted (reflects current implementation in `internal/model/loader.go`).
+
+== Context
+
+Bausteinsicht needs a textual format for the architecture model that is:
+
+* Editable by hand by architects, with comments to explain intent.
+* Reviewable in pull requests (line-based diffs).
+* Parseable in Go without writing a custom parser.
+* Friendly to AI agents (schema-driven, well-known syntax).
+* Compatible with IDE autocompletion through a JSON Schema.
+
+The README's "Related Projects" section explicitly contrasts Bausteinsicht against DSL-first tools (Structurizr, LikeC4) — the project chose to lean on a familiar data format rather than invent yet another DSL.
+
+== Decision
+
+Use **JSONC** — JSON with `// line comments`, `/* block comments */`, and trailing commas. Implementation: `loader.StripJSONC` strips JSONC artefacts before delegating to Go's `encoding/json`. Comments are preserved during writes by routing field updates through `internal/model/patch.go` (byte-range patching that respects strings + comments) and falling back to a full save with the file's preamble re-prepended.
+
+== Alternatives considered
+
+. **YAML** — comment-friendly, indentation-based, broad ecosystem. But: ambiguous types, indentation pitfalls in multi-line strings, no obvious patch tooling that preserves comments at byte level.
+. **Custom DSL (à la Structurizr)** — most expressive; but high adoption cost (custom parser, custom error reporting, no IDE for free).
+. **Pure JSON (no comments)** — simplest; but excludes inline rationale for architectural decisions.
+
+== Pugh Matrix
+
+Quality goals from `chapters/01_introduction_and_goals.adoc`. Scale: -1 (worse), 0 (neutral), +1 (better than baseline). Baseline = pure JSON.
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)              | JSONC | YAML | Custom DSL | Pure JSON (baseline)
+| Comment / rationale support (×3)    | +1    | +1   | +1         | 0
+| Round-trip / patch fidelity (×3)    | +1    | -1   | 0          | 0
+| Familiarity / onboarding (×2)       | +1    |  0   | -1         | 0
+| Tooling: IDE autocomplete via $schema (×2) | +1 | 0 | -1         | 0
+| Parsing simplicity (×1)             |  0    |  0   | -1         | 0
+| Output stability for diff/CI (×2)   | +1    | -1   |  0         | 0
+| **Weighted total**                  | **+12** | **-2** | **-3**   | **0**
+|===
+
+JSONC dominates on every axis except parsing simplicity (where it ties pure JSON because StripJSONC is a small preprocessor).
+
+== Consequences
+
+* **Positive:** comments survive edits; the model is reviewable like code; IDEs already understand JSONC.
+* **Negative:** a small parser surface (`StripJSONC`) is bespoke and must be kept aligned with byte-range patch logic. Edge cases — escaped quotes, nested comments, BOM — are covered by tests but represent ongoing maintenance.
+* **Forced subsequent decisions:**
+  * ADR-006 (embedded resources) ships a sample model so users see comments in action immediately.
+  * The schema URL is referenced from `templates/sample-model.jsonc` to enable editor autocomplete (NFR-010).

--- a/src/docs/arc42/ADRs/ADR-002-CLI-Framework.adoc
+++ b/src/docs/arc42/ADRs/ADR-002-CLI-Framework.adoc
@@ -1,0 +1,46 @@
+= ADR-002: Cobra as the CLI framework
+
+== Status
+
+Accepted (the project depends on `github.com/spf13/cobra` and uses its idiomatic command tree in `cmd/bausteinsicht/`).
+
+== Context
+
+Bausteinsicht ships eight commands (`init`, `sync`, `validate`, `add element`, `add relationship`, `watch`, `export`, `export-table`, `export-diagram`) plus persistent flags (`--format`, `--model`, `--template`, `--verbose`). The CLI must:
+
+* Validate flags consistently across every subcommand (e.g. format value, path traversal).
+* Emit machine-readable JSON or human-readable text on demand.
+* Provide help and version output by default.
+* Support sub-subcommands (`add element`, `add relationship`).
+
+== Decision
+
+Use **Cobra** with **pflag**. Persistent prerun hooks (`PersistentPreRunE`, `cmd/bausteinsicht/root.go:18-47`) enforce global validation: format normalisation, path containment, template extension. Errors flow back through `ExecuteRoot` which silences cobra's default error printing and emits either text or `{"error":..., "code":...}` on stderr.
+
+== Alternatives considered
+
+. **`flag` (stdlib)** — minimal; baseline.
+. **`urfave/cli`** — also popular; comparable feature set; different idioms.
+. **Hand-rolled argument parser** — more control; major maintenance cost.
+
+== Pugh Matrix
+
+Baseline = `flag`.
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)                  | Cobra | urfave/cli | Hand-rolled | flag (baseline)
+| Subcommand ergonomics (×3)              | +1    | +1         | -1          | 0
+| Help / version out of the box (×2)      | +1    | +1         | -1          | 0
+| Persistent flag validation hook (×3)    | +1    | +1         | -1          | 0
+| Bundle size / external surface (×1)     |  -1   |  -1        | +1          | 0
+| Long-term maintenance (×2)              | +1    |  0         | -1          | 0
+| Existing Go community familiarity (×1)  | +1    |  0         | -1          | 0
+| **Weighted total**                      | **+9**| **+7**     | **-9**      | **0**
+|===
+
+== Consequences
+
+* **Positive:** subcommand grouping (e.g., `add element`/`add relationship`) is natural; persistent flags compose cleanly; help output is consistent and testable.
+* **Negative:** small additional dependency (`cobra` + `pflag` + `mousetrap` indirect — see `go.sum`). Tests must instantiate `NewRootCmd()` rather than hit a global.
+* The `ExecuteRoot` wrapper (`cmd/bausteinsicht/root.go:93-115`) is needed to make Cobra fit the JSON error envelope contract.

--- a/src/docs/arc42/ADRs/ADR-003-Sync-Strategy.adoc
+++ b/src/docs/arc42/ADRs/ADR-003-Sync-Strategy.adoc
@@ -1,0 +1,48 @@
+= ADR-003: Three-way diff with explicit state file
+
+== Status
+
+Accepted (`internal/sync/state.go`, `internal/sync/diff.go`).
+
+== Context
+
+Forward sync (model → drawio) is straightforward — render the model. Reverse sync (drawio → model) needs to know **which side changed since the last sync** to avoid clobbering edits. Two structural choices apply:
+
+* **Stateless** — diff model and draw.io directly. If they differ, pick one as the source of truth.
+* **Stateful** — record what was synced and run a three-way diff between model, draw.io, and that recorded state.
+
+The stateless approach cannot distinguish "I updated the title in draw.io" from "I deleted the model element". A three-way diff can.
+
+== Decision
+
+Persist a **`.bausteinsicht-sync` state file** containing the last-synced field values for every element/relationship plus SHA-256 hashes of the model and drawio files plus a SHA-256 self-checksum on the state object.
+
+Use `internal/sync/diff.go::DetectChanges` to compute four buckets per field — `M==S?`, `D==S?` — and classify each (field, element) pair as: unchanged / model-side / drawio-side / conflict.
+
+== Alternatives considered
+
+. **Stateless reconciliation** — rely on draw.io as authoritative on visual edits, JSONC on structural edits. Reduces moving parts, but cannot detect deletions in JSONC vs. a stale draw.io file.
+. **Inline state in the draw.io file** (custom attributes) — keeps state portable; risks corruption when the user edits the file by hand.
+. **Inline state in the JSONC file** — survives `init`/clean checkouts; pollutes the source of truth.
+
+== Pugh Matrix
+
+Baseline = stateless reconciliation.
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)                       | State file | State in drawio | State in JSONC | Stateless (baseline)
+| Three-way diff possible (×3)                 | +1         | +1              | +1             | 0
+| Source-of-truth files stay clean (×3)        | +1         | -1              | -1             | 0
+| Survives `git clean -fd` / fresh checkout (×1) | -1       | +1              | +1             | 0
+| Tamper detection (×2)                        | +1         | 0               | 0              | 0
+| User can recover (delete + re-sync) (×2)     | +1         | -1              | -1             | 0
+| Implementation simplicity (×1)               | 0          | -1              | 0              | 0
+| **Weighted total**                            | **+10**    | **-1**          | **-2**         | **0**
+|===
+
+== Consequences
+
+* **Positive:** the three-way diff produces precise classification of changes; conflicts are recognisable; the user can recover by deleting one file.
+* **Negative:** the state file *must* be checked into `.gitignore` for collaborative use (a fresh clone has no state — the first sync becomes a "diff against empty" run that may misclassify). The user is told to delete `.bausteinsicht-sync` if its checksum is corrupted.
+* **Followup decision:** ADR-004 picks the resolver strategy used when both sides changed.

--- a/src/docs/arc42/ADRs/ADR-004-Conflict-Policy.adoc
+++ b/src/docs/arc42/ADRs/ADR-004-Conflict-Policy.adoc
@@ -1,0 +1,51 @@
+= ADR-004: Default conflict policy — model wins
+
+== Status
+
+Accepted (`internal/sync/conflict.go::ModelWinsResolver`).
+
+== Context
+
+When the same field changes on both surfaces between two syncs, exactly one value can survive. Architects need a default that is **predictable**, **explainable**, and aligned with the principle that JSONC is the source of truth (ADR-001). The choice of default has a downstream effect on the meaning of `--format json` summaries and exit codes.
+
+== Decision
+
+Default conflict policy is **model wins**. The `ConflictResolver` interface (`internal/sync/conflict.go:22-24`) is the extension seam:
+
+[source,go]
+----
+type ConflictResolver interface {
+    Resolve([]Conflict) []ResolvedConflict
+}
+----
+
+`ModelWinsResolver` is the only implementation in v1. It always picks the model value and emits a warning naming the field, both values, and the last-synced value. Whenever at least one conflict was resolved, `bausteinsicht sync` exits with code **1** (success-with-warnings).
+
+== Alternatives considered
+
+. **draw.io wins** — preserves visual-side edits.
+. **Last-writer wins** (file mtime) — automatic but fragile.
+. **Interactive resolver** — prompts the user.
+. **Three-way merge** (similar to git) — composes both changes when they don't actually conflict on the same byte; mismatch keeps both values somehow.
+
+== Pugh Matrix
+
+Baseline = "draw.io wins".
+
+[cols="3,1,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)                          | Model wins | Last-writer | Interactive | 3-way merge | drawio wins (baseline)
+| Predictability (×3)                             | +1         | -1          | 0           | -1          | 0
+| Aligns with "JSONC is SoT" (×3)                 | +1         |  0          | 0           | 0           | 0
+| Reviewability of resolution (×2)                | +1         | -1          | 0           | -1          | 0
+| Suitable for non-interactive CI (×2)            | +1         | +1          | -1          | 0           | 0
+| LLM-friendliness (×2)                           | +1         |  0          | -1          | 0           | 0
+| Lossless (preserves both edits when possible) (×1) | -1     | -1          | +1          | +1          | 0
+| **Weighted total**                              | **+11**    | **-3**      | **-3**      | **-3**      | **0**
+|===
+
+== Consequences
+
+* **Positive:** the policy matches the broader "JSONC is the source of truth" stance; behaviour is identical between interactive and non-interactive callers; warnings make the loss of a draw.io edit auditable.
+* **Negative:** an architect who edits exclusively in draw.io and then runs sync on a stale model will lose those edits, with only a stderr warning. We accept this because the warning is loud and the user is encouraged to update the model first.
+* **Future:** alternative resolvers can be plugged in via `ConflictResolver`; a user-facing flag (e.g. `--on-conflict=drawio|model|interactive`) is a documented future enhancement.

--- a/src/docs/arc42/ADRs/ADR-005-XML-Library.adoc
+++ b/src/docs/arc42/ADRs/ADR-005-XML-Library.adoc
@@ -1,0 +1,47 @@
+= ADR-005: `etree` as the XML library
+
+== Status
+
+Accepted (`go.mod` requires `github.com/beevik/etree v1.6.0`; usage in `internal/drawio/`).
+
+== Context
+
+The draw.io file format is XML with a non-trivial structure: `<mxfile>` → `<diagram>` → `<mxGraphModel>` → `<root>` → mixed `<mxCell>` and `<object>` children. Bausteinsicht must:
+
+* Parse and re-serialize without losing user-added attributes / cells.
+* Mutate specific elements (find a cell by id, change its style, add a child).
+* Pretty-print with stable indentation so that draw.io and the user diff cleanly on `git diff`.
+
+Go's `encoding/xml` requires struct mappings, which would force every draw.io feature (a moving target) to be modeled in Go. A DOM-style API is a better fit.
+
+== Decision
+
+Use `etree`, an in-memory DOM library that exposes `*etree.Element`, `SelectElement`, `SetAttr`, `CreateElement`, etc. The draw.io document is wrapped in `internal/drawio/document.go::Document`.
+
+== Alternatives considered
+
+. **`encoding/xml`** (stdlib).
+. **`go-xmldom`** or other niche DOM libs.
+. **String / regex manipulation**.
+
+== Pugh Matrix
+
+Baseline = `encoding/xml`.
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)                       | etree | other DOM | string/regex | encoding/xml (baseline)
+| Stable round-trip of unknown attributes (×3) | +1    | +1        | +1           | -1
+| Easy element lookup / mutation (×3)          | +1    | +1        | -1           | -1
+| Indent control on save (×2)                  | +1    |  0        |  0           | 0
+| External surface / maintenance (×1)          | -1    | -1        | +1           | 0
+| Performance (×1)                             |  0    |  0        | +1           | 0
+| Test coverage in this codebase (×1)          | +1    |  0        | -1           | 0
+| **Weighted total**                            | **+8**| **+5**    | **+1**       | **-9**
+|===
+
+== Consequences
+
+* **Positive:** every draw.io extension that the project does not model is round-tripped untouched (e.g., user mxCells without a `bausteinsicht_id`). Code in `internal/drawio/` is small and direct.
+* **Negative:** etree pretty-prints with spaces; small drift in serializer style would cause noisy git diffs. Fixed by configuring indent to `"  "` (two spaces) explicitly in `SaveDocument`.
+* **Risk:** etree is a single-author library; mitigated by the fact that the API used is small (find/select/attr/save) and could be replaced if needed.

--- a/src/docs/arc42/ADRs/ADR-006-Embedded-Templates.adoc
+++ b/src/docs/arc42/ADRs/ADR-006-Embedded-Templates.adoc
@@ -1,0 +1,44 @@
+= ADR-006: Embedded sample model and default template
+
+== Status
+
+Accepted (`templates/embed.go` uses `//go:embed`; `cmd/bausteinsicht/init.go` reads `templates.SampleModel` and `templates.DefaultTemplate`).
+
+== Context
+
+`bausteinsicht init` must produce a working project — a JSONC model, a draw.io template, and an initial diagram — in a directory that is otherwise empty. Two payloads (the sample model and the default template) need to ship with the binary:
+
+* It would be unergonomic to require the user to download or `curl` these files.
+* A single-binary distribution is a stated quality goal (NFR-001).
+
+== Decision
+
+Use Go's `embed` package: `templates/embed.go` declares `var SampleModel []byte` and `var DefaultTemplate []byte` backed by `templates/sample-model.jsonc` and `templates/default.drawio`. Init writes them verbatim into the working directory; sync uses `DefaultTemplate` as fallback when `--template` is not provided.
+
+== Alternatives considered
+
+. **Go string literals** — embed as huge `const` strings; harder to maintain (no syntax highlighting, no test fixtures shared with code).
+. **External download on first run** — small binary, but breaks the "no network" property (NFR-002, README "Security").
+. **External path required** — push the burden to the user; bad first-run experience.
+
+== Pugh Matrix
+
+Baseline = "Go string literals".
+
+[cols="3,1,1,1,1", options="header"]
+|===
+| Quality goal (weight)               | go:embed | External download | External required | string literals (baseline)
+| First-run UX (×3)                    | +1       | -1                | -1                | 0
+| No network at runtime (×3)           | +1       | -1                |  0                | 0
+| Files are first-class assets         |          |                   |                   |
+| (editable, lintable, testable) (×2)  | +1       |  0                | +1                | 0
+| Single-binary distribution (×2)      | +1       | -1                | -1                | 0
+| Maintenance overhead (×1)            | -1       | -1                |  0                | 0
+| **Weighted total**                   | **+9**   | **-9**            | **-3**            | **0**
+|===
+
+== Consequences
+
+* **Positive:** the binary is fully self-contained; `bausteinsicht init` works on an air-gapped machine; the embedded files are the same ones used as test fixtures (`templates/embed_test.go`).
+* **Negative:** any change to the sample model is a re-build of the binary. Users who want a custom default must pass `--template`.
+* **Followup:** the default template carries `bausteinsicht_template_version`; future versions of this template will require migration code (see Risks chapter).

--- a/src/docs/arc42/arc42.adoc
+++ b/src/docs/arc42/arc42.adoc
@@ -1,0 +1,21 @@
+= Bausteinsicht — Architecture Documentation (arc42)
+:toc: left
+:toclevels: 2
+:sectnums:
+:icons: font
+
+This is the master file for the arc42 architecture documentation.
+The 12 chapters live in `chapters/` and architecture decisions in `ADRs/`.
+
+include::chapters/01_introduction_and_goals.adoc[leveloffset=+1]
+include::chapters/02_architecture_constraints.adoc[leveloffset=+1]
+include::chapters/03_system_scope_and_context.adoc[leveloffset=+1]
+include::chapters/04_solution_strategy.adoc[leveloffset=+1]
+include::chapters/05_building_block_view.adoc[leveloffset=+1]
+include::chapters/06_runtime_view.adoc[leveloffset=+1]
+include::chapters/07_deployment_view.adoc[leveloffset=+1]
+include::chapters/08_crosscutting_concepts.adoc[leveloffset=+1]
+include::chapters/09_architecture_decisions.adoc[leveloffset=+1]
+include::chapters/10_quality_requirements.adoc[leveloffset=+1]
+include::chapters/11_risks_and_technical_debt.adoc[leveloffset=+1]
+include::chapters/12_glossary.adoc[leveloffset=+1]

--- a/src/docs/arc42/chapters/01_introduction_and_goals.adoc
+++ b/src/docs/arc42/chapters/01_introduction_and_goals.adoc
@@ -1,0 +1,36 @@
+= Introduction and Goals
+
+== Requirements overview
+
+Bausteinsicht is an architecture-as-code CLI: a single Go binary that lets a team define an architecture model in JSONC and keeps a draw.io diagram bidirectionally in sync with that model. The functional and non-functional requirements are listed in `src/docs/PRD/PRD-001.adoc` (FR-NNN, NFR-NNN). The full set of CLI capabilities is documented in `src/docs/spec/02_cli_specification.adoc`.
+
+In one sentence: _the JSONC file is the source of truth for review and CI; draw.io is the source of truth for visual layout; the sync engine reconciles both surfaces_.
+
+== Quality goals
+
+The quality goals were inferred from explicit code constants, the test/benchmark setup, and the security mitigations carrying SEC-NNN comments. They are listed here in priority order — top-most goals trump lower ones when they conflict.
+
+[cols="1,2,4", options="header"]
+|===
+| Priority | Goal | Why we believe this is a top goal
+
+| 1 | **Round-trip fidelity & comment preservation** | The codebase has dedicated patch infrastructure (`internal/model/patch.go`, `internal/sync/patchops.go`) and CONTRIBUTING.md mandates a comment-preservation E2E test for every new field.
+| 2 | **Reliability of file I/O** | Every save (model, draw.io, sync state) uses temp-file-then-rename; the sync state has a SHA-256 self-checksum.
+| 3 | **Security of local file handling** | Path-containment check on every user-provided path (SEC-001/015/016); HTML escaping in labels (SEC-008).
+| 4 | **Cross-platform portability** | `CGO_ENABLED=0` static binaries for 6 OS/arch combinations (Makefile, .goreleaser.yml).
+| 5 | **LLM/automation friendliness** | Stable JSON output on every command (`--format json`), explicit Claude Code skill (`.kiro/skills/bausteinsicht/SKILL.md`).
+| 6 | **Performance at architecture scale** | Benchmarks at n=10/100/500 elements (`bench_test.go`); maximum-depth and file-size limits (50, 10 MiB).
+|===
+
+== Stakeholders
+
+[cols="2,2,4", options="header"]
+|===
+| Role | Expectation | Source
+
+| Architect / tech lead | Edit either surface and trust the round-trip. | README "Jobs to be Done".
+| Developer | One CLI in CI; no Java/Node runtime; deterministic output. | go.mod, Makefile, `.goreleaser.yml`.
+| docToolchain integrator | arc42 ADRs as first-class citizens. | CONTRIBUTING.md "ADRs go in `src/docs/arc42/ADRs/`".
+| AI agent / automation | Machine-readable output for every command. | every `--format json` branch, Claude Code skill.
+| draw.io | Bausteinsicht keeps the file shape valid (`<mxfile>`/`<diagram>`/`<mxGraphModel>`/`<root>`/`<object>`/`<mxCell>`). | `internal/drawio/document.go::LoadDocument` validation.
+|===

--- a/src/docs/arc42/chapters/02_architecture_constraints.adoc
+++ b/src/docs/arc42/chapters/02_architecture_constraints.adoc
@@ -1,0 +1,22 @@
+= Architecture Constraints
+
+[cols="1,3,3", options="header"]
+|===
+| Type | Constraint | Source
+
+| Technical | Go 1.25.8 is the minimum and only supported toolchain. | `go.mod`.
+| Technical | Static binaries only — `CGO_ENABLED=0` for every cross-build target. | `Makefile`, `.goreleaser.yml`.
+| Technical | Six platform/arch combinations are first-class: linux/darwin/windows × amd64/arm64. | `Makefile`, `.goreleaser.yml`.
+| Technical | Only four runtime dependencies are pinned: `cobra`, `etree`, `fsnotify`, `rapid`. | `go.mod`.
+| Technical | `etree` is the XML library; the project does not depend on the Go standard XML serializer for draw.io files. | `go.mod`, `internal/drawio/document.go`.
+| Technical | The CLI MUST work without network access; image export shells out to a locally installed draw.io CLI. | README "Security", `internal/export/`.
+| Organizational | Documentation language is English. | CONTRIBUTING.md.
+| Organizational | Documentation format is AsciiDoc. | CONTRIBUTING.md.
+| Organizational | ADRs live in `src/docs/arc42/ADRs/` named `ADR-NNN-Title.adoc`. | CONTRIBUTING.md.
+| Organizational | All PRs go through `make check` (vet, staticcheck, gosec, nilaway, govulncheck, race-tests). | Makefile, `.github/workflows/go.yml`.
+| Organizational | Pre-commit hook runs gofmt, vet, golangci-lint, gitleaks. | `scripts/pre-commit`, `make install-hooks`.
+| Organizational | Releases are produced by goreleaser on tag push. | `.goreleaser.yml`, `.github/workflows/release.yml`.
+| Conventions | Tests live next to the code (`*_test.go`). | CONTRIBUTING.md.
+| Conventions | Property-based testing uses `pgregory.net/rapid` where applicable. | go.mod, CONTRIBUTING.md.
+| Conventions | When a new field is added to `Element`, six things MUST be updated (struct, schema, `elementFieldPath`, `applyElementChange`, comment-preservation E2E, roundtrip E2E). | CONTRIBUTING.md "Adding a New Model Field".
+|===

--- a/src/docs/arc42/chapters/03_system_scope_and_context.adoc
+++ b/src/docs/arc42/chapters/03_system_scope_and_context.adoc
@@ -1,0 +1,53 @@
+= System Scope and Context
+
+== Business context
+
+Bausteinsicht is a local CLI invoked by humans, by editors via watch mode, by CI pipelines, and by AI agents. It interacts with the file system and with one external binary (the draw.io CLI) for image export.
+
+[plantuml, c4-context, svg]
+....
+@startuml
+!include <C4/C4_Context>
+
+LAYOUT_WITH_LEGEND()
+
+title System Context — Bausteinsicht
+
+Person(architect,  "Architect / Developer", "Edits the JSONC model and the draw.io diagram.")
+Person(agent,      "AI Agent / LLM",        "Calls bausteinsicht with --format json.")
+System_Boundary(local, "Workstation / CI runner") {
+  System(bausteinsicht, "Bausteinsicht CLI", "Architecture-as-code with bidirectional sync.")
+  ContainerDb(model_file, "architecture.jsonc", "JSONC", "Model: source of truth.")
+  ContainerDb(drawio_file, "architecture.drawio", "XML",  "Diagram surface.")
+  ContainerDb(state_file,  ".bausteinsicht-sync", "JSON", "Sync state with sha256 checksum.")
+}
+System_Ext(drawio_cli, "draw.io CLI",        "Optional. Used by `export` to render PNG/SVG.")
+System_Ext(editor,     "draw.io desktop / web", "Where the architect edits the diagram visually.")
+
+Rel(architect,    bausteinsicht, "runs commands")
+Rel(agent,        bausteinsicht, "runs commands (--format json)")
+Rel(architect,    editor,        "edits architecture.drawio")
+Rel(bausteinsicht, model_file,   "read / write (JSONC patch + full save)")
+Rel(bausteinsicht, drawio_file,  "read / write (atomic)")
+Rel(bausteinsicht, state_file,   "read / write (atomic, sha256)")
+Rel(bausteinsicht, drawio_cli,   "exec (export only)")
+Rel(editor,        drawio_file,  "read / write")
+@enduml
+....
+
+== Technical context
+
+The CLI's only external boundary at runtime is the local file system plus the optional `drawio` / `drawio-export` binary discovered via `internal/export/platform_*.go`.
+
+[cols="2,2,4", options="header"]
+|===
+| Channel | Direction | Notes
+
+| File system (read / write) | both | All access is mediated by the `model`, `drawio`, and `sync.state` packages. Writes are atomic (temp + rename).
+| `os/exec` to draw.io CLI | outbound | Only by the `export` command. The binary is discovered, never bundled.
+| `fsnotify` events | inbound | Only used by `watch`.
+| Stdin | none | Bausteinsicht does not read from stdin.
+| Stdout | outbound | Structured results — text or JSON.
+| Stderr | outbound | Errors, warnings, verbose progress.
+| Network | none | The CLI does not make network calls. The `$schema` URL in the JSONC model is consumed only by IDEs/editors.
+|===

--- a/src/docs/arc42/chapters/04_solution_strategy.adoc
+++ b/src/docs/arc42/chapters/04_solution_strategy.adoc
@@ -1,0 +1,59 @@
+= Solution Strategy
+
+The architecture follows five strategic decisions.
+
+. **JSONC as the source of truth.** Comments and trailing commas are first-class; this lets architects keep prose in the model file and review changes in code review (see ADR-001).
+. **Three-way diff with explicit state file.** A dedicated `.bausteinsicht-sync` file holds last-synced field values and SHA-256 hashes so we can distinguish "user changed it in surface A" from "user changed it in surface B" from "neither side changed it". (see ADR-003).
+. **Comment-preserving JSONC patches.** Field updates emitted by reverse sync are applied as byte-range patches, not as a full re-serialization — so comments survive (`internal/model/patch.go`, `internal/sync/patchops.go`). Structural changes (add/delete) fall back to a full save that preserves the file's preamble before the first `{`.
+. **One Cobra subcommand per use case, with `--format json` everywhere.** The CLI doubles as a stable LLM/automation API (see ADR-002 for the choice of Cobra).
+. **Static binaries with no runtime dependencies.** Go + `CGO_ENABLED=0` + a tiny dependency set delivers a single binary per (OS, arch). Image export shells out to draw.io but is otherwise optional.
+
+[plantuml, c4-container, svg]
+....
+@startuml
+!include <C4/C4_Container>
+
+LAYOUT_WITH_LEGEND()
+
+title Container View — Bausteinsicht CLI
+
+Person(user, "Architect / AI Agent")
+
+System_Boundary(b, "bausteinsicht binary") {
+  Container(cli, "cmd/bausteinsicht", "Go (Cobra)", "Argument parsing, validation, JSON envelope, exit codes.")
+  Container(model, "internal/model",  "Go", "JSONC load, validate, resolve, comment-preserving patch.")
+  Container(sync, "internal/sync",    "Go", "Three-way diff, conflict resolution, forward/reverse sync.")
+  Container(drawio, "internal/drawio","Go", "draw.io XML manipulation (etree). HTML labels, connectors.")
+  Container(layout, "internal/sync/layout", "Go", "Layered/grid/none layout for view pages.")
+  Container(diagram, "internal/diagram", "Go", "PlantUML/Mermaid emitters.")
+  Container(table, "internal/table",  "Go", "AsciiDoc/Markdown emitters.")
+  Container(export, "internal/export","Go", "draw.io binary discovery + exec.")
+  Container(watcher, "internal/watcher","Go", "fsnotify wrapper with debounce + re-watch.")
+  Container(templates, "templates",   "Go embed", "Embedded sample model + default template.")
+}
+
+ContainerDb(jsonc, "architecture.jsonc", "JSONC")
+ContainerDb(drawio_file, "architecture.drawio", "XML")
+ContainerDb(state, ".bausteinsicht-sync", "JSON")
+System_Ext(drawio_cli, "drawio CLI", "Optional")
+
+Rel(user, cli, "runs commands")
+Rel(cli, model, "load / validate / save")
+Rel(cli, sync, "Run()")
+Rel(sync, model, "flatten, resolve")
+Rel(sync, drawio, "read / mutate XML")
+Rel(sync, layout, "compute positions")
+Rel(cli, diagram, "FormatView()")
+Rel(cli, table, "FormatView()")
+Rel(cli, export, "DetectDrawioBinary + Export")
+Rel(cli, watcher, "Start (watch only)")
+Rel(cli, templates, "embedded init payload")
+
+Rel(model, jsonc, "read / write (atomic)")
+Rel(drawio, drawio_file, "read / write (atomic)")
+Rel(sync, state, "read / write (atomic, sha256)")
+Rel(export, drawio_cli, "exec")
+@enduml
+....
+
+The `cmd` package is intentionally thin — every meaningful behaviour is in an `internal/` package and is unit-tested in isolation. The forward and reverse sync passes share the diff and state code through `internal/sync/engine.go::Run`, the single orchestration entry point.

--- a/src/docs/arc42/chapters/05_building_block_view.adoc
+++ b/src/docs/arc42/chapters/05_building_block_view.adoc
@@ -1,0 +1,137 @@
+= Building Block View
+
+== Level 1 — Whitebox of `bausteinsicht`
+
+[plantuml, bb-l1, svg]
+....
+@startuml
+!include <C4/C4_Component>
+
+LAYOUT_WITH_LEGEND()
+
+title Component View — internal packages
+
+Container_Boundary(b, "bausteinsicht binary") {
+  Component(cli,      "cmd/bausteinsicht",  "Cobra commands", "init, sync, validate, add, watch, export, export-table, export-diagram")
+  Component(model,    "internal/model",     "Domain model",   "types, loader (JSONC), validate, resolve, patch")
+  Component(sync,     "internal/sync",      "Sync engine",    "engine, diff, conflict, forward, reverse, state, metadata, layout, patchops")
+  Component(drawio,   "internal/drawio",    "draw.io XML",    "document, element, connector, label, template")
+  Component(diagram,  "internal/diagram",   "Diagram emitter","PlantUML / Mermaid")
+  Component(table,    "internal/table",     "Table emitter",  "AsciiDoc / Markdown")
+  Component(export,   "internal/export",    "draw.io exec",   "binary detection + render")
+  Component(watcher,  "internal/watcher",   "fsnotify",       "debounce + re-watch")
+  Component(templates,"templates",          "go:embed",       "default.drawio + sample-model.jsonc")
+}
+
+Rel(cli, model, "load/validate/save")
+Rel(cli, sync, "Run")
+Rel(cli, drawio, "load/save document")
+Rel(cli, diagram, "FormatView")
+Rel(cli, table, "FormatView/AllViews/Combined")
+Rel(cli, export, "DetectDrawioBinary, ExportPage")
+Rel(cli, watcher, "New, Start")
+Rel(cli, templates, "init scaffold")
+Rel(sync, model, "flatten, resolve, patch")
+Rel(sync, drawio, "find/create elements + connectors")
+Rel(sync, templates, "default template fallback")
+Rel(diagram, model, "ResolveView")
+Rel(table, model, "ResolveView")
+@enduml
+....
+
+== Level 2 — internal/model
+
+[plantuml, bb-model, svg]
+....
+@startuml
+!include <C4/C4_Component>
+
+Component(types,    "types.go",    "Go structs", "BausteinsichtModel, Element, Relationship, View, Spec")
+Component(loader,   "loader.go",   "JSONC I/O",  "Load, Save (atomic, preamble), AutoDetect, StripJSONC, MaxModelFileSize 10MiB")
+Component(validate, "validate.go", "Rules",       "ValidateWithWarnings, ValidationError/Warning")
+Component(resolve,  "resolve.go",  "Traversal",   "Resolve, FlattenElements, MatchPattern, ResolveView, MaxElementDepth 50")
+Component(patch,    "patch.go",    "Comment-safe","PatchValue, InsertObjectEntry, AppendArrayEntry, findValueRange")
+
+Rel(loader, types, "")
+Rel(validate, types, "")
+Rel(validate, resolve, "")
+Rel(resolve, types, "")
+Rel(patch, loader, "via files")
+@enduml
+....
+
+[cols="1,3", options="header"]
+|===
+| Block | Responsibility / interfaces
+| `types.go` | Pure struct definitions for the JSONC model. No logic.
+| `loader.go` | Serialization with JSONC awareness. `Load`, `Save`, `AutoDetect`, `StripJSONC`. Hard limits: 10 MiB file size; rejects empty/null roots.
+| `validate.go` | Static validation. `Validate(m) []ValidationError`, `ValidateWithWarnings(m) ValidationResult`. Rules described in `spec/03_data_models.adoc`.
+| `resolve.go` | Pure functions for navigating the model. `Resolve(id)`, `FlattenElements(m) -> map[string]*Element`, `MatchPattern(flat, pattern)`, `ResolveView(m, view) -> []string`. Recursion depth is bounded at 50 (`MaxElementDepth`).
+| `patch.go` | Byte-range patch operations on raw JSONC. `PatchSave`, `PatchInsert`, `InsertObjectEntry`, `AppendArrayEntry`. Preserves comments and indentation.
+|===
+
+== Level 2 — internal/sync
+
+[plantuml, bb-sync, svg]
+....
+@startuml
+!include <C4/C4_Component>
+
+Component(engine,   "engine.go",   "Go", "Run() — orchestrates the pipeline.")
+Component(diff,     "diff.go",     "Go", "DetectChanges(); visibility + lifting; new-page tracking.")
+Component(conflict, "conflict.go", "Go", "ConflictResolver iface; ModelWinsResolver default.")
+Component(forward,  "forward.go",  "Go", "ApplyForward — model → drawio.")
+Component(reverse,  "reverse.go",  "Go", "ApplyReverse — drawio → model. Direction-swap detection.")
+Component(state,    "state.go",    "Go", "SyncState w/ self sha256, BuildState, LoadState, SaveState.")
+Component(metadata, "metadata.go", "Go", "Metadata + legend boxes per view page.")
+Component(layout,   "layout.go",   "Go", "computeLayout — layered / grid / none.")
+Component(patchops, "patchops.go", "Go", "ReversePatchOps — convert change set to PatchOp list.")
+
+Rel(engine, diff, "")
+Rel(engine, conflict, "")
+Rel(engine, forward, "")
+Rel(engine, reverse, "")
+Rel(engine, state, "")
+Rel(forward, layout, "")
+Rel(forward, metadata, "")
+Rel(reverse, patchops, "")
+@enduml
+....
+
+[cols="1,3", options="header"]
+|===
+| Block | Responsibility / interfaces
+| `engine.go` | `Run(model, doc, state, tmpl, newPageIDs, opts) -> SyncResult`. Single entry point; called by both `sync` and `watch`.
+| `diff.go` | Three-way diff. Computes visible elements, visible relationships (with lifting), and new-page-only elements.
+| `conflict.go` | `Conflict`, `ResolvedConflict`, and the `ConflictResolver` interface. Default policy: model wins.
+| `forward.go` | Element / connector creation, update, deletion on view pages. Adds the red-dashed marker for new elements.
+| `reverse.go` | Applies draw.io edits back to the model. Detects direction swaps. Rejects empty titles.
+| `state.go` | `SyncState`, `BuildState`, `LoadState`, `SaveState`. Self-checksums with SHA-256.
+| `metadata.go` | `metadata-<viewID>` and `legend-<viewID>` cells.
+| `layout.go` | `computeLayout` — `layered`, `grid`, `none`. Tier order from `specification.elements`.
+| `patchops.go` | Decides whether a change set is patchable; emits `PatchOp` list for comment-preserving saves.
+|===
+
+== Level 2 — internal/drawio
+
+[cols="1,3", options="header"]
+|===
+| Block | Responsibility / interfaces
+| `document.go` | `LoadDocument`, `SaveDocument` (atomic), `NewDocument`, `Pages`, `GetPage`, `AddPage`, `RemovePage`. Validates `<mxfile>` shape on load.
+| `element.go`  | `CreateElement`, `FindElement`, `FindAllElements`. Adds `bausteinsicht_id` and `bausteinsicht_kind` attributes.
+| `connector.go`| `CreateConnector`, `FindConnector`, `FindAllConnectors`, `UpdateConnectorLabel`, `DeleteConnector`, `DeleteConnectorsFor`. Connector id `rel-<from>-<to>-<index>`.
+| `label.go`    | `GenerateLabel`, `ParseLabel`, `escapeHTML` (SEC-008).
+| `template.go` | `LoadTemplateFromBytes`, `TemplateSet`, `CurrentTemplateVersion = 1`.
+|===
+
+== Level 2 — Other internals
+
+[cols="1,3", options="header"]
+|===
+| Block | Responsibility
+| `internal/diagram/` | PlantUML C4 (`!include <C4/...>`) + Mermaid emitters. Auto-detects C4 level (Component/Container/Context).
+| `internal/table/`   | AsciiDoc + Markdown table emitters. Per-view, all-views, and combined deduplicated forms.
+| `internal/export/`  | draw.io binary discovery (per-platform) and `ExportPage` shell-out.
+| `internal/watcher/` | `fsnotify`-based watcher with `DefaultDebounce = 300ms`, re-watch on rename, syncing-flag mutex.
+| `templates/`        | `embed.go` exposes `SampleModel` and `DefaultTemplate` as `[]byte` constants.
+|===

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -1,0 +1,138 @@
+= Runtime View
+
+The runtime view illustrates the most relevant scenarios.
+
+== Scenario 1 — `bausteinsicht init`
+
+[plantuml, rt-init, svg]
+....
+@startuml
+actor User
+participant "cmd init" as cmd
+participant "templates (embed)" as tpl
+participant "model.Save" as ms
+participant "drawio.Save" as ds
+participant "sync.Run" as run
+participant "state.SaveState" as st
+
+User -> cmd: bausteinsicht init
+cmd -> cmd: check 4 target files do not exist
+cmd -> tpl: read SampleModel + DefaultTemplate
+cmd -> ms: write architecture.jsonc (atomic)
+cmd -> ds: write template.drawio (atomic)
+cmd -> cmd: load model + template, NewDocument()
+cmd -> run: initial forward sync (creates pages + metadata + legend)
+cmd -> ds: write architecture.drawio (atomic)
+cmd -> st: write .bausteinsicht-sync (atomic, sha256)
+cmd -> User: list of created files (text|json)
+@enduml
+....
+
+== Scenario 2 — `bausteinsicht sync` (typical)
+
+[plantuml, rt-sync, svg]
+....
+@startuml
+actor User
+participant "cmd sync" as cmd
+participant "model.Load + Validate" as mv
+participant "drawio.Load" as dl
+participant "state.Load" as sl
+participant "sync.Run" as run
+participant "diff" as diff
+participant "ConflictResolver" as cr
+participant "ApplyForward" as af
+participant "ApplyReverse" as ar
+participant "patchops + model.Patch" as pp
+participant "drawio.Save + state.Save" as save
+
+User -> cmd: bausteinsicht sync
+cmd -> mv: load + validate model
+mv --> cmd: ok (or exit 1)
+cmd -> dl: load architecture.drawio
+dl --> cmd: ok (or recreate from template)
+cmd -> sl: load .bausteinsicht-sync
+sl --> cmd: state (or empty)
+cmd -> run: Run(model, doc, state, tmpl, newPageIDs, opts)
+run -> diff: DetectChanges
+run -> cr: Resolve(conflicts) → model wins
+run -> af: ApplyForward
+run -> ar: ApplyReverse (in parallel, conceptually)
+run --> cmd: SyncResult
+cmd -> pp: try patch save (comment-preserving)
+note right: falls back to full Save\nfor structural changes
+cmd -> save: drawio + state (atomic)
+cmd -> User: summary (text|json)
+alt conflicts > 0
+  cmd -> User: exit 1 with warnings on stderr
+else
+  cmd -> User: exit 0
+end
+@enduml
+....
+
+== Scenario 3 — `bausteinsicht watch`
+
+[plantuml, rt-watch, svg]
+....
+@startuml
+participant "fsnotify" as fs
+participant "watcher.loop" as loop
+participant "doSync" as sync
+participant "syncMu / syncing flag" as mu
+
+fs -> loop: write event (architecture.jsonc)
+loop -> loop: debounce 300ms
+loop -> mu: TryLock
+alt syncing == true
+  loop -> loop: drop event (next event will retrigger)
+else
+  loop -> mu: set syncing=true
+  loop -> sync: doSync()
+  sync --> loop: result
+  loop -> mu: set syncing=false
+end
+fs -> loop: rename (atomic save in editor)
+loop -> loop: re-watch with exponential backoff (≤ 2s)
+@enduml
+....
+
+== Scenario 4 — Reverse sync of a label change with comment preservation
+
+[plantuml, rt-reverse, svg]
+....
+@startuml
+participant "ApplyReverse" as ar
+participant "ChangeSet" as cs
+participant "patchops.ReversePatchOps" as ro
+participant "model.PatchValue" as pv
+participant "fs.atomic write" as fw
+
+ar -> cs: build ElementChange{ID=onlineshop.api, Field=title, NewValue="REST API v2"}
+ar -> ro: ReversePatchOps(cs)
+ro --> ar: ([ {Path:[model,onlineshop,children,api,title], Value:"\"REST API v2\""} ], patchable=true)
+ar -> pv: apply PatchOp on raw bytes
+pv -> pv: findValueRange respecting strings + comments
+pv --> ar: patched bytes (comments untouched)
+ar -> fw: write temp + rename
+@enduml
+....
+
+== Scenario 5 — Conflict (model wins)
+
+[plantuml, rt-conflict, svg]
+....
+@startuml
+participant diff
+participant ModelWinsResolver as r
+participant ApplyForward as af
+participant Stderr
+
+diff -> r: [Conflict{el=api, field=title, model="REST API", drawio="API v3", state="REST API v1"}]
+r --> diff: [Resolved{Winner=model, Warning="...→ Keeping model value..."}]
+diff -> diff: drop drawio change for (api,title)
+diff -> af: include forward update for (api,title)
+af -> af: write "REST API" into drawio label (HTML-escaped)
+diff -> Stderr: emit warning lines
+@enduml
+....

--- a/src/docs/arc42/chapters/07_deployment_view.adoc
+++ b/src/docs/arc42/chapters/07_deployment_view.adoc
@@ -1,0 +1,51 @@
+= Deployment View
+
+Bausteinsicht is a single statically-linked binary. There is no server, no daemon, and no installer.
+
+[plantuml, deploy, svg]
+....
+@startuml
+node "Workstation / CI runner" as box {
+  artifact "bausteinsicht (static binary)" as bin
+  artifact "architecture.jsonc"            as model
+  artifact "architecture.drawio"           as drawio
+  artifact ".bausteinsicht-sync"           as state
+  artifact "template.drawio"               as tpl
+  artifact "drawio CLI (optional)"         as drawio_cli
+}
+
+bin .right.> model    : read/write
+bin .right.> drawio   : read/write
+bin .right.> state    : read/write (sha256)
+bin .right.> tpl      : read
+bin ..> drawio_cli    : exec (export only)
+@enduml
+....
+
+== Distribution
+
+Configured by `.goreleaser.yml`:
+
+* Builds 6 platform/arch combinations: linux/darwin/windows × amd64/arm64.
+* `CGO_ENABLED=0`.
+* `ldflags: -s -w -X main.version={{.Version}}` (the binary embeds its release tag).
+* Tar/zip archives named `bausteinsicht_{Version}_{OS}_{Arch}.{tar.gz,zip}`.
+* Checksums file `checksums.txt`.
+* Release changelog grouped by conventional-commit prefix.
+
+Triggered by `.github/workflows/release.yml` on a `v*` git tag.
+
+== Continuous Integration
+
+`.github/workflows/go.yml`:
+
+* Matrix: ubuntu-latest, windows-latest, macos-latest.
+* Steps per OS: `go build ./...` + `go test ./...`.
+* Separate `lint` job: `golangci-lint` on ubuntu-latest.
+* Permissions are scoped to `contents: read` per job.
+
+The full local quality gate is `make check` (`vet`, `staticcheck`, `gosec`, `nilaway`, `govulncheck`, race-tests). The pre-commit hook (`scripts/pre-commit`) additionally enforces `gofmt`, `golangci-lint`, and `gitleaks` on staged content.
+
+== Development environment
+
+`.devcontainer/devcontainer.json` provides a reproducible container with Go, all the analysis tools, and the headless draw.io CLI for image-export tests. Contributors who do not use the devcontainer can install the toolchain manually with `make install-tools`.

--- a/src/docs/arc42/chapters/08_crosscutting_concepts.adoc
+++ b/src/docs/arc42/chapters/08_crosscutting_concepts.adoc
@@ -1,0 +1,95 @@
+= Crosscutting Concepts
+
+== Atomic file I/O
+
+Every write goes through a temp-file-then-rename pattern. The temp file lives in the same directory as the destination so the rename is on a single filesystem.
+
+* `internal/model/loader.go::Save`
+* `internal/drawio/document.go::SaveDocument`
+* `internal/sync/state.go::SaveState`
+
+This protects against corruption caused by a crash mid-write or by disk-full scenarios.
+
+== JSONC handling and comment preservation
+
+JSONC support is implemented in two layers:
+
+. **Parsing.** `loader.StripJSONC` converts JSONC to JSON before passing to `encoding/json`. It preserves UTF-8 BOM removal, string-literal awareness, line + block comments, and trailing commas.
+. **Writing.** When only field values change, `internal/sync/patchops.go::ReversePatchOps` produces a list of `(jsonPath, newValue)` patches and `internal/model/patch.go` applies them to the raw byte stream — `findValueRange` walks the JSONC text respecting strings and comments to locate the target value. This means **comments and indentation around the patched value survive untouched**.
+. When structural changes (add/delete) are required, the saver falls back to a full marshal that re-prepends the file's preamble (everything before the first `{`).
+
+CONTRIBUTING.md formalizes this: any new `Element` field MUST come with a comment-preservation E2E test.
+
+== Validation
+
+A single pass (`internal/model/validate.go::ValidateWithWarnings`) covers element ids, kinds, container/child invariants, relationships, and views. The validator distinguishes errors (block sync) from warnings (do not block).
+
+CLI commands run validation **before** any write that could leave the model in an inconsistent state — most notably `sync` runs `Validate` to refuse to write a draw.io file based on an invalid model.
+
+== Conflict policy
+
+Implemented in `internal/sync/conflict.go` as the `ConflictResolver` interface. Only `ModelWinsResolver` is shipped today, but the interface seam is the documented extension point (see ADR-004).
+
+== Layout
+
+`internal/sync/layout.go` provides three modes:
+
+* `layered` (default) — element kinds become tiers in the order they were defined in `specification.elements`. Scoped views render externals top + bottom and the scope-children inside the boundary.
+* `grid` — regular grid placement.
+* `none` — every element at origin (0,0); useful when the user controls all placement manually.
+
+The element-kind order comes from `loader.extractElementOrder`, which uses a streaming JSON decoder so that Go's randomized map iteration does not destroy semantically meaningful order.
+
+== Security
+
+[cols="1,3", options="header"]
+|===
+| SEC code | What it enforces
+| SEC-001  | Path containment for `--model`. Rejects `..` components.
+| SEC-008  | HTML escaping for element labels rendered into draw.io HTML labels and metadata boxes.
+| SEC-013  | Element IDs must match `^[a-zA-Z][a-zA-Z0-9_-]*$`; in particular, no `.` so that dot-paths are unambiguous.
+| SEC-015  | Path containment for `export --output`.
+| SEC-016  | Path containment for `--template`.
+|===
+
+Other defensive properties:
+
+* SHA-256 self-checksum on the sync state (`internal/sync/state.go`).
+* Integrity check rejects tampered or corrupted state with a clear remediation message.
+* Hard limits: 10 MiB model file size; 50 levels of element nesting.
+* No network access at runtime.
+* `make check` includes `gosec` (security linter), `govulncheck` (CVE scanner), `gitleaks` (secret detection).
+
+== Observability
+
+* Structured stdout (text or JSON) is reserved for the **result** of a command.
+* Errors and warnings always go to **stderr**.
+* `--verbose` adds a per-command progress trace on stderr (e.g. `Syncing model: ... 123 elements, 45 relationships, 8 views`).
+* The watcher prints `[HH:MM:SS] Sync triggered by <file>` at each event.
+
+== Embedded resources
+
+`templates/embed.go` uses `//go:embed` to bundle:
+
+* `sample-model.jsonc` — copied verbatim by `init` into `architecture.jsonc`.
+* `default.drawio` — used as the template when none is supplied.
+
+This is what makes `bausteinsicht init` self-sufficient — no asset directory is needed at runtime.
+
+== Test discipline
+
+The repository ships ~400 `Test*` functions across all packages. Notable categories:
+
+* CLI integration tests (`cmd/bausteinsicht/*_test.go`) use temp dirs and exercise full command paths.
+* Sync engine tests (`internal/sync/*_test.go`) cover view-based sync, conflict resolution, lifting, scope boundaries, drill-down navigation.
+* Comment-preservation E2E tests are mandated by CONTRIBUTING.md for every model field.
+* Property-based tests use `pgregory.net/rapid`.
+* Benchmarks at n=10/100/500 elements (`internal/model/bench_test.go`, `internal/sync/bench_test.go`).
+* `make test-race` runs the entire suite with `-race`.
+
+== Cross-platform concerns
+
+* All builds set `CGO_ENABLED=0`.
+* `internal/export/platform_*.go` files give per-OS draw.io binary search paths.
+* Tests run on ubuntu-latest, macos-latest, windows-latest in CI.
+* Atomic rename works on every supported OS because the temp file is created in the destination directory.

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -1,0 +1,10 @@
+= Architecture Decisions
+
+The accepted ADRs are kept in `src/docs/arc42/ADRs/`. Each follows the Nygard format and includes a Pugh matrix evaluating the alternatives against quality goals (-1, 0, +1).
+
+* link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001 — JSONC as the model DSL]
+* link:../ADRs/ADR-002-CLI-Framework.adoc[ADR-002 — Cobra as the CLI framework]
+* link:../ADRs/ADR-003-Sync-Strategy.adoc[ADR-003 — Three-way diff with explicit state file]
+* link:../ADRs/ADR-004-Conflict-Policy.adoc[ADR-004 — Default conflict policy: model wins]
+* link:../ADRs/ADR-005-XML-Library.adoc[ADR-005 — `etree` as the XML library]
+* link:../ADRs/ADR-006-Embedded-Templates.adoc[ADR-006 — Embedded sample model and template]

--- a/src/docs/arc42/chapters/10_quality_requirements.adoc
+++ b/src/docs/arc42/chapters/10_quality_requirements.adoc
@@ -1,0 +1,21 @@
+= Quality Requirements
+
+The quality scenarios below are observable in code. They map back to the PRD NFRs (`NFR-001..013`) and to the corresponding tests / constants.
+
+[cols="2,2,4,2", options="header"]
+|===
+| Quality | Scenario | Mechanism | Evidence
+
+| **Round-trip fidelity** | Edit a label in draw.io → reverse-sync → edit the model JSONC → forward-sync. The original comments and indentation in the JSONC remain. | Comment-preserving patch path (`internal/model/patch.go`, `internal/sync/patchops.go`) | `TestSyncPreservesJSONCComments`, CONTRIBUTING.md mandate.
+| **Reliability of writes** | Process is `kill -9`'d while saving the model. The file on disk is either the old version or the new one — never half-written. | Atomic temp+rename in every save. | `loader.Save`, `drawio.SaveDocument`, `state.SaveState`.
+| **State integrity** | An adversary edits `.bausteinsicht-sync` by hand. Next sync run refuses to use it and tells the user how to recover. | SHA-256 self-checksum. | `state.LoadState` checksum branch.
+| **Path containment** | User passes `--model ../../../etc/passwd`. The CLI rejects the path before any read. | `validatePathContainment`. | `TestRootCmd_RejectsModelPathTraversal`, `TestValidatePathContainment`, SEC-001/015/016.
+| **HTML safety** | Element title contains `</b><script>`. The draw.io label and metadata box render the literal text, not the script. | `escapeHTML`. | `internal/drawio/label.go` (SEC-008).
+| **Bounded resource use** | Maliciously deep model with 100 levels of `children`. Loader rejects before consuming the stack. | `MaxElementDepth = 50`, `MaxModelFileSize = 10 MiB`. | `internal/model/resolve.go`, `internal/model/loader.go`.
+| **Cross-platform portability** | Build on linux/darwin/windows × amd64/arm64 yields a runnable static binary in each. | `CGO_ENABLED=0`, no platform-specific code outside `internal/export/`. | `Makefile` targets, `.goreleaser.yml`.
+| **Determinism of output** | `bausteinsicht sync --format json` run twice on the same state yields byte-identical output. | Sorted iteration over maps before emitting; stable JSON keys. | covered indirectly by `TestSyncJSONOutput`, `TestSyncAfterInit`.
+| **LLM ergonomics** | Every command output is parseable JSON when `--format json` is set. | `--format` is a persistent flag; each command has a JSON branch. | every `cmd/bausteinsicht/*.go`.
+| **Performance** | Sync of n=500 elements completes within bench budget. | Engine + diff are linear in element count. | `BenchmarkSyncRun`, `BenchmarkLoadModel`, `BenchmarkFlattenElements`.
+| **Idempotence** | `init` followed by `sync` reports `Already in sync. No changes.`. | Initial forward sync inserts metadata + legend before saving state. | `TestSyncAfterInit`.
+| **Test coverage** | Every public command and engine path has unit + integration coverage; race detector is part of `make check`. | ~400 `Test*` functions; `make test-race`. | `Makefile`.
+|===

--- a/src/docs/arc42/chapters/11_risks_and_technical_debt.adoc
+++ b/src/docs/arc42/chapters/11_risks_and_technical_debt.adoc
@@ -1,0 +1,39 @@
+= Risks and Technical Debt
+
+== Risks
+
+[cols="2,3,3", options="header"]
+|===
+| Risk | Description | Mitigation / Status
+
+| **Single-strategy conflict resolution** | `ModelWinsResolver` is the only resolver. Architects who prefer to capture diagram-side edits silently lose them on a conflicting save. | Interface seam already in place (`ConflictResolver`). Future ADR could add a draw.io-wins or interactive resolver. See ADR-004 and OQ.
+| **Reverse sync of structural changes is conservative** | Adding a brand-new element in draw.io that has no `bausteinsicht_id` is *not* synced into the model. Only the schema-aware tools that know to set the attribute can drive structural model changes through draw.io. | Documented behaviour. Open Question on whether a heuristic add-by-shape ever needs to be supported.
+| **draw.io CLI dependency for image export** | Only `export` requires the binary. If the binary is absent the command fails. | Detected with a clear error message and a download URL.
+| **Layout heuristic only — no manual layout in the model** | The architect cannot pin a position in JSONC; positions live in the draw.io file. If the diagram is regenerated from the template, manual positions are lost. | Mitigated by recording layout in the draw.io file and only reusing it on subsequent syncs. `--relayout` is opt-in.
+| **No formal JSON Schema in the repository** | `templates/sample-model.jsonc` references `$schema: ...bausteinsicht.schema.json` but the schema file is not in the repo. IDE users following the link see a 404. | Open Question (OQ).
+| **`Element.Tags` and `Element.Metadata` are dead fields** | Declared in `types.go` but no consumer found — risk of users relying on something that does nothing. | Either remove or wire up to a filter / rendering hook.
+| **`Tags` may surprise on round-trip** | Nothing prevents a draw.io export from clearing the field on save (since it is not part of the diff). | Open Question.
+| **No diff/preview command** | The user must run `sync` to see what would change. There is no `bausteinsicht plan` or `--dry-run`. | Future enhancement.
+| **`TestRun_*` tests rely on map-iteration ordering being normalized** | Any future change in the diff that introduces non-determinism would only show up as flake. | Mitigated by sorting before emit.
+| **Integrity of `.bausteinsicht-sync`** | The checksum protects against corruption / accidental edits, *not* against adversarial commits. | Documented; the file is local-only and not security-critical.
+|===
+
+== Technical debt
+
+[cols="2,4", options="header"]
+|===
+| Item | Notes
+
+| `Element.Metadata map[string]string` | Declared, never read by any production code path we could trace.
+| `Element.Tags []string` | Same as above.
+| `template_version` set but no migration | `CurrentTemplateVersion = 1` and the loader reads the attribute but no migration code exists for v0 → v1 (the comment says "backward compatible with v0").
+| Watch mode hard-codes `architecture.drawio` | The model can be auto-detected, but the matching draw.io file name is fixed.
+| Tests live next to code (`*_test.go`) — good — but cross-package E2E coverage is mostly in `cmd/bausteinsicht/sync_test.go`. | An explicit `e2e/` package may make the contract clearer over time.
+| `--model` and `--template` validation lives in the persistent prerun, not in a typed flag wrapper. | A small typed-flag helper would be safer.
+|===
+
+== Out-of-scope topics that may become risks if not addressed
+
+* Concurrent edits by multiple architects (the current design assumes a single workstation; collaborative editing isn't modelled).
+* Encrypted/secret content in models (no scrubbing performed).
+* Schema evolution of the model itself (rename a field, retire a field) — patch-save would silently lose data.

--- a/src/docs/arc42/chapters/12_glossary.adoc
+++ b/src/docs/arc42/chapters/12_glossary.adoc
@@ -1,0 +1,31 @@
+= Glossary
+
+[cols="1,4", options="header"]
+|===
+| Term | Definition
+
+| **Element** | A node in the architecture model (`internal/model/types.go::Element`). Has a kind, title, optional description/technology, and may have children if its kind is a container.
+| **Element kind** | A user-defined element category declared in `specification.elements`. Examples: `actor`, `system`, `container`, `component`, `datastore`.
+| **Container kind** | An element kind whose definition has `container: true` — it may host children.
+| **Relationship** | A directed edge between two elements identified by dot-paths (`internal/model/types.go::Relationship`).
+| **Relationship kind** | A user-defined edge category declared in `specification.relationships`. May render as dashed.
+| **Dot path** | The fully qualified id of an element, formed by joining the JSONC keys with `.`. Example: `onlineshop.api.catalog`.
+| **View** | A named selection of elements that becomes one draw.io page (`view-<viewID>`).
+| **Scope** | The element of a view drawn as a boundary swimlane.
+| **Include / Exclude pattern** | A literal id or one of `*`, `**`, `prefix.*`, `prefix.**` used to select / subtract elements in a view.
+| **Forward sync** | Propagation of changes from the JSONC model to the draw.io diagram.
+| **Reverse sync** | Propagation of changes from the draw.io diagram back into the JSONC model.
+| **Three-way diff** | The diff strategy used by the sync engine: it compares model, draw.io, and the last-synced state to classify each change as model-side, drawio-side, or conflict.
+| **Conflict** | A change to the same element field on both surfaces since the last sync.
+| **Resolver** | An implementation of `internal/sync/conflict.go::ConflictResolver` that picks a winner per conflict. Default: `ModelWinsResolver`.
+| **Sync state** | The file `.bausteinsicht-sync` carrying last-synced field values + file hashes + a SHA-256 self-checksum.
+| **JSONC** | JSON with C-style comments (`//` line, `/* */` block) and trailing commas.
+| **PatchOp** | A `(jsonPath, value)` instruction for byte-range patching of JSONC. Comment-preserving.
+| **Lifting** | The diff's behaviour of attaching a connector to the closest visible ancestor when an endpoint is not visible on a view.
+| **Marker style** | The `strokeColor=#FF0000;dashed=1;` style added to newly created elements so the architect can find and place them.
+| **Metadata box** | A draw.io cell `metadata-<viewID>` that shows view title, description, repo URL, model path, sync timestamp, and author.
+| **Legend box** | A draw.io cell `legend-<viewID>` showing the notation and colour for every kind used on the view.
+| **arc42** | The architecture documentation template used in this `arc42/` subtree.
+| **C4** | The four-level architecture model (Context, Container, Component, Code) inspiration for Bausteinsicht's element kinds.
+| **draw.io / diagrams.net** | The visual diagram editor whose XML format Bausteinsicht reads, writes, and renders.
+|===

--- a/src/docs/spec/01_use_cases.adoc
+++ b/src/docs/spec/01_use_cases.adoc
@@ -1,0 +1,491 @@
+= Use Cases
+:toc: left
+:toclevels: 2
+:sectnums:
+:icons: font
+
+This document captures the use cases of Bausteinsicht in Cockburn format.
+All use cases were derived from the CLI surface (`cmd/bausteinsicht/`), error messages, and tests.
+
+== Actors
+
+* **Architect** — primary user; edits the JSONC model and the draw.io diagram.
+* **Developer** — runs the CLI in a project, occasionally adds elements through `add element`/`add relationship`.
+* **CI Pipeline** — non-interactive caller that runs `validate`, `sync`, `export*` with `--format json`.
+* **AI Agent / LLM** — uses the documented JSON output to read and modify the model (`.kiro/skills/bausteinsicht/SKILL.md`).
+* **draw.io CLI** — supporting actor invoked by `bausteinsicht export` to render images.
+
+== Business Rules
+
+[cols="1,4", options="header"]
+|===
+| ID | Rule
+
+| BR-001 | Element ID format MUST match `^[a-zA-Z][a-zA-Z0-9_-]*$`. Dot is reserved as the hierarchy separator.
+| BR-002 | A child may only be added under a parent whose kind has `container: true`.
+| BR-003 | Element `kind` and (when set) relationship `kind` MUST exist in `specification`.
+| BR-004 | Two relationships are duplicates only if `from`, `to`, `kind`, and `label` all match.
+| BR-005 | The view filter (`include`/`exclude`/`scope`) defines which elements appear on a page; relationships appear iff both endpoints are visible (after lifting to ancestors).
+| BR-006 | When the same element field is changed in both surfaces since the last sync, the **model value wins** and a warning is emitted.
+| BR-007 | Newly created elements MUST be visually marked (red dashed border) so the human can position them.
+| BR-008 | Empty titles arriving via reverse sync MUST be ignored.
+| BR-009 | Forward sync MUST NOT relayout placed elements unless `--relayout` is given.
+| BR-010 | Reversing a connector in draw.io is treated as an in-place direction swap, not a delete + add — preserves `kind`, `label`, `description`.
+| BR-011 | The model file MUST be ≤ 10 MiB; element nesting MUST be ≤ 50 levels.
+| BR-012 | All file paths from the user (`--model`, `--template`, export `--output`) MUST be free of `..` components.
+| BR-013 | Sync state file MUST verify a self-checksum on load; on mismatch, the user MUST delete it and re-run sync.
+|===
+
+== Use Case Index
+
+* <<UC-001>> Initialize a new project
+* <<UC-002>> Validate the model
+* <<UC-003>> Add an element via CLI
+* <<UC-004>> Add a relationship via CLI
+* <<UC-005>> Synchronize model and diagram
+* <<UC-006>> Watch and continuously sync
+* <<UC-007>> Export view images (PNG / SVG)
+* <<UC-008>> Export element tables (AsciiDoc / Markdown)
+* <<UC-009>> Export view diagrams (PlantUML / Mermaid)
+
+[[UC-001]]
+== UC-001: Initialize a new project
+
+* **Goal:** Scaffold a working architecture model and matching draw.io diagram in an empty directory.
+* **Primary actor:** Architect / Developer.
+* **Trigger:** `bausteinsicht init`.
+* **Preconditions:** None of `architecture.jsonc`, `template.drawio`, `architecture.drawio`, `.bausteinsicht-sync` exist in the current directory.
+* **Postconditions (success):** All four files exist; an initial sync has populated the diagram with the sample model; a metadata/legend box is present so the next sync is a no-op.
+* **Main flow:**
+  . User runs `bausteinsicht init`.
+  . System checks each of the four target files; if any exists it errors out (BR — exit 2).
+  . System writes `architecture.jsonc` from the embedded sample model.
+  . System writes `template.drawio` from the embedded default template.
+  . System loads model and template, runs an initial forward sync, persists `architecture.drawio` and `.bausteinsicht-sync`.
+  . System prints the list of created files and "next steps".
+* **Exceptions:**
+  * Existing file → exit 2.
+  * I/O error during template/sample write → exit 2.
+
+[plantuml, init-flow, svg]
+....
+@startuml
+start
+:User runs `bausteinsicht init`;
+if (Any target file already exists?) then (yes)
+  :Print "file already exists";
+  stop
+else (no)
+  :Write architecture.jsonc (sample model);
+  :Write template.drawio (default template);
+  :Load model + template;
+  :Forward-sync into architecture.drawio
+  + create metadata / legend boxes;
+  :Save .bausteinsicht-sync;
+  :Print created files + next steps;
+  stop
+endif
+@enduml
+....
+
+[[UC-002]]
+== UC-002: Validate the model
+
+* **Goal:** Surface errors and warnings without modifying any file.
+* **Primary actor:** Architect, CI pipeline.
+* **Trigger:** `bausteinsicht validate [--model PATH] [--format text|json]`.
+* **Preconditions:** A model file exists (or auto-detect finds exactly one `*.jsonc`).
+* **Postconditions:** Model is unchanged; report of errors and warnings is printed.
+* **Main flow:**
+  . System resolves model path (`--model` or single `*.jsonc` in cwd).
+  . System loads the model (StripJSONC + unmarshal). On parse error → exit 2.
+  . System runs `ValidateWithWarnings` (BR-001..BR-004 over elements, relationships, views).
+  . If any errors → exit 1; else exit 0 (warnings allowed).
+* **Exceptions:**
+  * No `*.jsonc` or multiple `*.jsonc` and no `--model` → "no .jsonc file found" / "multiple .jsonc files" → exit 2.
+
+[plantuml, validate-flow, svg]
+....
+@startuml
+start
+:Resolve model path;
+if (Path resolved?) then (no)
+  :Print "no .jsonc / multiple .jsonc";
+  stop
+else (yes)
+endif
+:Load + StripJSONC;
+if (Parse OK?) then (no)
+  :Print parse error;
+  :exit 2;
+  stop
+else (yes)
+endif
+:Run ValidateWithWarnings;
+if (Errors > 0?) then (yes)
+  :Print errors + warnings;
+  :exit 1;
+  stop
+else (no)
+  :Print "Model is valid" + warnings;
+  :exit 0;
+  stop
+endif
+@enduml
+....
+
+[[UC-003]]
+== UC-003: Add an element via CLI
+
+* **Goal:** Insert a new element into the model with comments preserved.
+* **Primary actor:** Developer, AI agent.
+* **Trigger:** `bausteinsicht add element --id ID --kind K --title T [--parent P] [--technology TECH] [--description DESC]`.
+* **Preconditions:** Model loadable; ID matches BR-001; `K` exists in spec; if `P` given it resolves and its kind is a container (BR-002); ID does not already exist at that level.
+* **Postconditions:** Element is inserted; JSONC comments and indentation around the insertion point are preserved.
+* **Main flow:**
+  . System loads + validates model.
+  . System validates `--id` regex, `--kind`, `--title` non-empty.
+  . If `--parent` given, system resolves and asserts container kind.
+  . System asserts no duplicate at insertion site.
+  . System inserts via `model.PatchInsert` + `InsertObjectEntry` (preserves comments).
+  . On patch failure, falls back to a full save which still preserves the user preamble before the first `{`.
+  . System prints the new element (text or JSON).
+* **Exceptions:**
+  * Invalid ID regex → "invalid element ID" → exit 1.
+  * Unknown kind → "unknown element kind ...; valid kinds: ..." → exit 1.
+  * Empty title → "title must not be empty" → exit 1.
+  * Parent missing → "parent ... not found" → exit 1.
+  * Parent not a container → kind not allowing children → exit 1.
+  * Duplicate ID → exit 1.
+
+[plantuml, add-element, svg]
+....
+@startuml
+start
+:Load + validate model;
+:Check `--id` matches [a-zA-Z][a-zA-Z0-9_-]*;
+if (Valid?) then (no)
+  :exit 1;
+  stop
+else (yes)
+endif
+:Check kind in specification.elements;
+if (Known?) then (no)
+  :exit 1;
+  stop
+else (yes)
+endif
+if (`--parent` set?) then (yes)
+  :Resolve parent;
+  if (Found?) then (no)
+    :exit 1;
+    stop
+  else (yes)
+  endif
+  if (Parent kind has container=true?) then (no)
+    :exit 1;
+    stop
+  else (yes)
+  endif
+endif
+:Check no duplicate ID at insertion site;
+:PatchInsert `id`: {kind, title, ...} into model/parent.children;
+if (Patch OK?) then (yes)
+  :Done;
+else (no)
+  :Fallback Save (preserves preamble);
+endif
+:Print element (text|json);
+:exit 0;
+stop
+@enduml
+....
+
+[[UC-004]]
+== UC-004: Add a relationship via CLI
+
+* **Goal:** Append a new relationship without losing comments.
+* **Primary actor:** Developer, AI agent.
+* **Trigger:** `bausteinsicht add relationship --from F --to T [--label L] [--kind K] [--description D]`.
+* **Preconditions:** `F` and `T` resolve; `K` (if given) is in `specification.relationships`; the `(from, to, kind, label)` tuple is not already present (BR-004).
+* **Postconditions:** Relationship is appended in place at the end of the JSONC `relationships` array.
+* **Main flow:**
+  . Load + validate model.
+  . Resolve `--from` and `--to`. On miss: "element ... not found" → exit 1.
+  . If `--kind`, validate against `specification.relationships`.
+  . Reject exact duplicate (BR-004).
+  . `PatchInsert` + `AppendArrayEntry` to preserve comments.
+  . Fall back to full save if patch fails.
+
+[plantuml, add-relationship, svg]
+....
+@startuml
+start
+:Load + validate model;
+:Resolve --from;
+if (Found?) then (no)
+  :exit 1;
+  stop
+else (yes)
+endif
+:Resolve --to;
+if (Found?) then (no)
+  :exit 1;
+  stop
+else (yes)
+endif
+if (--kind set?) then (yes)
+  if (Kind in spec?) then (no)
+    :exit 1;
+    stop
+  else (yes)
+  endif
+endif
+if (Duplicate (from,to,kind,label)?) then (yes)
+  :exit 1;
+  stop
+else (no)
+endif
+:AppendArrayEntry on `relationships`;
+:Print relationship (text|json);
+:exit 0;
+stop
+@enduml
+....
+
+[[UC-005]]
+== UC-005: Synchronize model and diagram
+
+* **Goal:** Make model and draw.io agree, in both directions.
+* **Primary actor:** Architect, CI.
+* **Trigger:** `bausteinsicht sync [--relayout] [--format text|json] [--verbose]`.
+* **Preconditions:** Model loadable and valid (validate is run as a pre-flight); template available (default or `--template`).
+* **Postconditions:** Draw.io has one page per view (`view-<viewID>`); orphaned view pages removed; model is updated with reverse changes; sync state is rewritten.
+* **Main flow (success path):**
+  . Resolve and load model; **validate** (sync refuses to run if errors).
+  . Locate `architecture.drawio`; if missing/empty, recreate from template and discard stale state.
+  . Load sync state from `.bausteinsicht-sync`; verify checksum (BR-013).
+  . Ensure a draw.io page exists for every view; remove pages for deleted views; remember newly created page IDs.
+  . `sync.Run` orchestrates: detect changes (three-way), resolve conflicts (model wins, BR-006), apply forward (BR-007, BR-009), apply reverse (BR-008, BR-010), compute warnings.
+  . Save model: try comment-preserving patch save; fall back to full save (only valid for pure field updates per `ReversePatchOps`).
+  . Atomically save draw.io and sync state.
+  . Print summary (text or JSON).
+* **Exit codes:**
+  * `0`: clean run.
+  * `1`: conflicts were resolved (warnings printed) — see BR-006.
+  * `2`: validation/I-O failure.
+
+[plantuml, sync-flow, svg]
+....
+@startuml
+start
+:Resolve + load model;
+:Validate (errors -> exit 1);
+:Locate architecture.drawio;
+if (Missing/empty?) then (yes)
+  :Recreate from template;
+  :Discard stale sync state;
+else (no)
+  :Load drawio;
+endif
+:Load sync state;
+if (Checksum OK?) then (no)
+  :exit 2 ("delete .bausteinsicht-sync and re-run");
+  stop
+else (yes)
+endif
+:Ensure pages for all views;
+:Remove orphan view pages;
+:Detect changes (three-way diff);
+:Resolve conflicts (model wins);
+:Drop draw.io changes that lost;
+:Apply forward (model -> drawio);
+:Apply reverse (drawio -> model);
+:Compute warnings;
+if (Reverse changes patchable?) then (yes)
+  :PatchSave model;
+else (no)
+  :Full Save (preserves preamble);
+endif
+:Save drawio (atomic);
+:Save sync state (atomic, with sha256);
+:Print summary;
+if (Conflicts > 0?) then (yes)
+  :exit 1;
+else (no)
+  :exit 0;
+endif
+stop
+@enduml
+....
+
+[[UC-006]]
+== UC-006: Watch and continuously sync
+
+* **Goal:** Sync automatically while the user edits either surface.
+* **Primary actor:** Architect at the IDE.
+* **Trigger:** `bausteinsicht watch`.
+* **Preconditions:** Model file and `architecture.drawio` exist.
+* **Postconditions:** Process runs until `SIGINT`/`SIGTERM`; periodic `sync` runs occur on each file change.
+* **Main flow:**
+  . Detect model and drawio paths; subscribe to fsnotify events on both.
+  . On event, debounce 300 ms.
+  . Set "syncing" flag (re-entrancy guard); run `doSync`; clear flag.
+  . On atomic-rename file replacement, re-watch the file (exponential backoff up to 2 s).
+* **Exceptions:**
+  * Per-sync errors are logged to stderr; the watcher continues.
+
+[plantuml, watch-flow, svg]
+....
+@startuml
+start
+:Resolve model + drawio;
+:fsnotify.Add(model);
+:fsnotify.Add(drawio);
+repeat
+  :Wait for write/rename event;
+  :Debounce 300 ms;
+  if (Currently syncing?) then (yes)
+    :Skip event;
+  else (no)
+    :Set syncing=true;
+    :doSync();
+    :Set syncing=false;
+  endif
+  if (File missing after rename?) then (yes)
+    :Re-watch with exponential backoff (≤ 2 s);
+  endif
+repeat while (No SIGINT/SIGTERM)
+:Print "Stopped watching";
+stop
+@enduml
+....
+
+[[UC-007]]
+== UC-007: Export view images
+
+* **Goal:** Render view pages to PNG or SVG for embedding in docs.
+* **Primary actor:** Architect, CI.
+* **Trigger:** `bausteinsicht export [--image-format png|svg] [--view ID] [--output DIR] [--scale N]`.
+* **Preconditions:** A draw.io CLI binary is detected (`drawio-export`, `drawio` on PATH, or platform paths).
+* **Postconditions:** One image file per (selected) view in the output directory; filename `architecture-<view>.<ext>`.
+* **Main flow:**
+  . Validate `--image-format` (png|svg) — invalid → exit 2.
+  . Resolve model and load drawio.
+  . Detect draw.io binary; if missing → exit 2 with installation hint.
+  . Create output directory if needed; reject `..` paths (BR-012).
+  . For each (selected) view: locate page `view-<id>`; invoke draw.io export; collect file paths and per-view errors.
+  . Print results; exit 1 if any view export failed (others succeeded).
+
+[plantuml, export-flow, svg]
+....
+@startuml
+start
+:Validate --image-format;
+:Load model + drawio;
+:Detect draw.io CLI;
+if (Found?) then (no)
+  :exit 2;
+  stop
+else (yes)
+endif
+:Resolve --output (reject `..`);
+:Create output dir;
+repeat
+  :Pick next view;
+  :Find page view-<id>;
+  :Call draw.io CLI export;
+  if (OK?) then (yes)
+    :Add to results.files;
+  else (no)
+    :Add to results.errors;
+  endif
+repeat while (More views?)
+:Print results (text|json);
+if (Any error?) then (yes)
+  :exit 1;
+else (no)
+  :exit 0;
+endif
+stop
+@enduml
+....
+
+[[UC-008]]
+== UC-008: Export element tables
+
+* **Goal:** Generate AsciiDoc or Markdown tables of the elements visible on each view (or combined / single view).
+* **Primary actor:** Architect, doc generator.
+* **Trigger:** `bausteinsicht export-table [--view ID] [--table-format adoc|md] [--output DIR] [--combined]`.
+* **Preconditions:** Model loadable.
+* **Postconditions:** Either stdout output or files in output dir; with `--format json` rows are emitted as JSON regardless of `--table-format`.
+* **Main flow:**
+  . Validate `--table-format`.
+  . Load model.
+  . If `--combined`, render one deduplicated table; else if `--view`, one table; else one table per view.
+  . If global `--format json`, emit JSON rows array instead of tables.
+
+[plantuml, export-table, svg]
+....
+@startuml
+start
+:Validate --table-format;
+:Load model;
+if (--format json?) then (yes)
+  :Emit JSON rows array;
+  :exit 0;
+  stop
+else (no)
+endif
+if (--combined?) then (yes)
+  :Format combined table;
+elseif (--view?) then (yes)
+  :Format single view;
+else (no)
+  :Format every view;
+endif
+if (--output set?) then (yes)
+  :Write file(s);
+else (no)
+  :Print to stdout;
+endif
+:exit 0;
+stop
+@enduml
+....
+
+[[UC-009]]
+== UC-009: Export view diagrams (PlantUML / Mermaid)
+
+* **Goal:** Produce text-based diagrams of each view for embedding in arc42 / AsciiDoc.
+* **Primary actor:** Architect, doc generator.
+* **Trigger:** `bausteinsicht export-diagram [--view ID] [--diagram-format plantuml|mermaid] [--output DIR]`.
+* **Preconditions:** Model loadable.
+* **Postconditions:** `*.puml` or `*.mmd` files written, or stdout printed; JSON envelope when `--format json`.
+* **Main flow:**
+  . Validate `--diagram-format`.
+  . Load model.
+  . Detect C4 level (Component if any "component"; Container if any container or scope; otherwise Context) and partition elements relative to scope.
+  . Render in PlantUML C4 (`!include <C4/...>`) or Mermaid.
+
+[plantuml, export-diagram, svg]
+....
+@startuml
+start
+:Validate --diagram-format;
+:Load model;
+repeat
+  :Pick next view;
+  :Resolve view elements + relationships;
+  :Detect C4 level;
+  :Render in plantuml | mermaid;
+  if (--output set?) then (yes)
+    :Write *.puml | *.mmd;
+  else (no)
+    :Print to stdout;
+  endif
+repeat while (More views?)
+:exit 0;
+stop
+@enduml
+....

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -1,0 +1,488 @@
+= CLI Specification
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+
+This specification was reverse-engineered from the Cobra command definitions in `cmd/bausteinsicht/`, the integration tests in `cmd/bausteinsicht/*_test.go`, and the persistent flag setup in `cmd/bausteinsicht/root.go`.
+
+== Conventions
+
+* All commands are subcommands of the root `bausteinsicht` command.
+* Flags are processed by https://github.com/spf13/cobra[Cobra] / pflag — long flags (`--flag value`) and equals form (`--flag=value`) are both accepted.
+* Where a flag's "default" cell is empty, the flag is optional and the underlying behaviour treats absence as a distinct case.
+* Output channels: structured results go to **stdout**; warnings, conflicts, verbose progress, and errors go to **stderr**.
+* All commands respect the global flags below in addition to their own.
+
+== Global flags
+
+Defined in `cmd/bausteinsicht/root.go:50-53`.
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Default | Description
+
+| `--format` | string | `text` | Output format. Allowed values: `text`, `json` (case-insensitive). Invalid values fail in `PersistentPreRunE` with `unknown format "X": valid values are "text" and "json"`.
+| `--model` | string | _(empty)_ | Path to the JSONC model file. Auto-detected when unset (single `*.jsonc` in the current directory). Rejected if it contains `..` (SEC-001).
+| `--template` | string | _(empty)_ | Path to a draw.io template file. MUST end in `.drawio`. Rejected if it contains `..` (SEC-016).
+| `--verbose` | bool | `false` | Emit progress logs to stderr.
+| `--version` | flag | _(n/a)_ | Standard Cobra `--version` flag — prints `version` (set at build time, defaults to `"dev"`).
+| `-h`, `--help` | flag | _(n/a)_ | Standard Cobra help.
+|===
+
+=== Path containment (SEC-001 / SEC-016)
+
+`validatePathContainment` (`cmd/bausteinsicht/root.go:81-88`) cleans the path with `filepath.Clean` and rejects any component equal to `..`. Applies to `--model`, `--template`, and the `export --output` directory.
+
+== Exit codes
+
+Exit codes are produced via `exitWithCode` (`cmd/bausteinsicht/root.go:74-76`) and the standard cobra error wrapper:
+
+[cols="1,4", options="header"]
+|===
+| Code | Meaning
+| 0 | Success.
+| 1 | Validation, business-rule, or sync-conflict failure (the command ran, but produced a logical error). For `sync`, also emitted when conflicts were resolved.
+| 2 | Pre-flight or I/O failure: missing file, unparseable JSONC, missing draw.io binary, format flag rejected, init target file already exists, etc.
+|===
+
+When `--format json`, errors are emitted as a JSON object on stderr by `ExecuteRoot` (`root.go:93-115`):
+
+[source,json]
+----
+{"error":"<message>","code":<int>}
+----
+
+== Command summary
+
+[cols="1,3", options="header"]
+|===
+| Command | Purpose
+| `init` | Scaffold a new project (sample model, template, drawio, sync state).
+| `sync` | Bidirectional sync between model and `architecture.drawio`.
+| `validate` | Validate model; report errors and warnings.
+| `add element` | Insert an element with comment-preserving JSONC patch.
+| `add relationship` | Append a relationship with comment-preserving JSONC patch.
+| `watch` | Run `sync` continuously on file changes.
+| `export` | Export view pages as PNG/SVG via draw.io CLI.
+| `export-table` | Emit element tables as AsciiDoc / Markdown / JSON.
+| `export-diagram` | Emit view diagrams as PlantUML / Mermaid.
+|===
+
+== `bausteinsicht init`
+
+Source: `cmd/bausteinsicht/init.go`.
+
+Scaffolds a new project in the current directory.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht init [--format text|json] [--verbose]
+----
+
+=== Behaviour
+
+. Targets these files in the current directory: `architecture.jsonc`, `template.drawio`, `architecture.drawio`, `.bausteinsicht-sync`.
+. If any target already exists: error `file "<name>" already exists; remove it or use a different directory` → exit 2.
+. Writes `architecture.jsonc` from the embedded sample (`templates/sample-model.jsonc`, mode 0600).
+. Writes `template.drawio` from the embedded default template (mode 0600).
+. Loads model and template, runs an initial forward sync that populates pages and creates metadata/legend boxes (so the next `sync` is a no-op).
+. Persists `architecture.drawio` and `.bausteinsicht-sync` atomically.
+
+=== Output
+
+[%nowrap]
+[source]
+----
+text:
+  Initialized Bausteinsicht project:
+    - architecture.jsonc
+    - template.drawio
+    - architecture.drawio
+    - .bausteinsicht-sync
+
+  Next steps:
+    1. Edit architecture.jsonc to define your architecture
+    2. Run 'bausteinsicht sync' to update the draw.io diagram
+    3. Open architecture.drawio in draw.io to arrange elements
+
+json:
+  {"success":true,"files":["architecture.jsonc","template.drawio","architecture.drawio",".bausteinsicht-sync"]}
+----
+
+== `bausteinsicht sync`
+
+Source: `cmd/bausteinsicht/sync.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht sync [--relayout] [--model PATH] [--template PATH] [--format text|json] [--verbose]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Default | Description
+| `--relayout` | bool | `false` | Re-apply auto-layout to all view pages, resetting element positions.
+|===
+
+=== Pre-flight
+
+. Resolve model file (auto-detect if `--model` not given). Missing file → exit 2.
+. **Validate model** before any write. Errors → exit 1 with message `model validation failed with N error(s); fix the model before syncing`.
+. Locate `architecture.drawio` next to the model. Missing or no `<diagram>` → recreate from template, log warning, drop stale state.
+. Load `.bausteinsicht-sync`; verify checksum.
+
+=== Sync run
+
+. Ensure pages exist for every model view (`view-<viewID>`); remove orphan pages.
+. Run `sync.Run` (see `05_sync_specification.adoc`).
+. Save model with comment-preserving patch when only field updates apply; otherwise full save (the user's preamble before the first `{` is preserved).
+. Atomically save draw.io and the new sync state.
+. Print summary; if conflicts > 0 → exit 1.
+
+=== Output schema (JSON)
+
+Stable keys (`cmd/bausteinsicht/sync.go` `syncSummary`):
+
+[source,json]
+----
+{
+  "forward_added":   <int>,
+  "forward_updated": <int>,
+  "forward_deleted": <int>,
+  "reverse_added":   <int>,
+  "reverse_updated": <int>,
+  "reverse_deleted": <int>,
+  "metadata_updated":<int>,
+  "conflicts":       <int>
+}
+----
+
+=== Text output
+
+[source]
+----
+Forward (model → draw.io): 3 added, 1 updated, 0 deleted
+Reverse (draw.io → model): 0 added, 2 updated, 0 deleted
+Conflicts: 0 (resolved: model wins)
+----
+
+Or `Already in sync. No changes.` when nothing to do.
+
+== `bausteinsicht validate`
+
+Source: `cmd/bausteinsicht/validate.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht validate [--model PATH] [--format text|json]
+----
+
+=== Behaviour
+
+. Resolve model path (auto-detect when `--model` is empty).
+. Load and `ValidateWithWarnings`.
+. Errors → exit 1; warnings only → exit 0.
+
+=== Output schema (JSON)
+
+[source,json]
+----
+{
+  "valid":   <bool>,
+  "errors":  [ {"path":"<json-path>", "message":"<msg>"} ],
+  "warnings":[ {"path":"<json-path>", "message":"<msg>"} ]
+}
+----
+
+=== Text
+
+[source]
+----
+ERROR:   [model.foo] missing required field "kind"
+WARNING: [specification] no element kinds defined in specification
+Model is valid.   <-- only when no errors
+----
+
+== `bausteinsicht add element`
+
+Source: `cmd/bausteinsicht/add_element.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht add element \
+    --id ID --kind KIND --title TITLE \
+    [--parent PARENT.PATH] \
+    [--technology TECH] \
+    [--description DESC]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Required | Description
+| `--id`           | string | yes | Element ID. Validated against `^[a-zA-Z][a-zA-Z0-9_-]*$`.
+| `--kind`         | string | yes | Must exist in `specification.elements`.
+| `--title`        | string | yes | Must not be empty.
+| `--parent`       | string | no  | Dot-notation parent path (e.g. `onlineshop.api`). Parent's kind must have `container: true`.
+| `--technology`   | string | no  | Free-form text.
+| `--description`  | string | no  | Free-form text.
+|===
+
+=== Errors
+
+[cols="2,1", options="header"]
+|===
+| Message | Exit
+| `invalid element ID "X": must contain only letters, digits, hyphens, or underscores` | 1
+| `unknown element kind "X"; valid kinds: ...` | 1
+| `title must not be empty` | 1
+| `parent "X" not found` | 1
+| `parent kind "K" does not allow children (container: false)` | 1
+| `element "X" already exists ...` | 1
+| Model load / save failure | 2
+|===
+
+=== Output schema (JSON)
+
+[source,json]
+----
+{
+  "id":          "<dot.path>",
+  "kind":        "<kind>",
+  "title":       "<title>",
+  "technology":  "<tech>",
+  "description": "<desc>"
+}
+----
+
+=== Text
+
+`Added element 'onlineshop.api' (kind: container) to model.`
+
+== `bausteinsicht add relationship`
+
+Source: `cmd/bausteinsicht/add_relationship.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht add relationship \
+    --from FROM.PATH --to TO.PATH \
+    [--label LABEL] \
+    [--kind KIND] \
+    [--description DESC]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Required | Description
+| `--from`        | string | yes | Source element. Dot notation. Must resolve.
+| `--to`          | string | yes | Target element. Dot notation. Must resolve.
+| `--label`       | string | no  | Edge label.
+| `--kind`        | string | no  | Must exist in `specification.relationships` if given.
+| `--description` | string | no  | Free-form text.
+|===
+
+=== Errors
+
+* `element "X" not found` (from / to)
+* `unknown relationship kind "X" not defined in specification`
+* `relationship X → Y (kind K) already exists`
+
+=== Output schema (JSON)
+
+[source,json]
+----
+{
+  "from":        "<dot.path>",
+  "to":          "<dot.path>",
+  "label":       "<label>",
+  "kind":        "<kind>",
+  "description": "<desc>"
+}
+----
+
+== `bausteinsicht watch`
+
+Source: `cmd/bausteinsicht/watch.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht watch [--model PATH] [--template PATH] [--format text|json] [--verbose]
+----
+
+=== Behaviour
+
+. Resolve model + matching `architecture.drawio` (both must exist).
+. Subscribe via `internal/watcher` (300 ms debounce); on each event run the same logic as `sync`.
+. Print `[HH:MM:SS] Sync triggered by <file>` and the same summary line as `sync`.
+. Errors and warnings are reported but **do not** terminate the watcher.
+. Stops on `SIGINT` or `SIGTERM`.
+
+== `bausteinsicht export`
+
+Source: `cmd/bausteinsicht/export.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht export \
+    [--image-format png|svg] \
+    [--view VIEW_KEY] \
+    [--output DIR] \
+    [--embed-diagram] \
+    [--scale FLOAT]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Default | Description
+| `--image-format` | string | `png` | One of `png`, `svg`. Other values → exit 2.
+| `--view`         | string | _(all)_ | View key (without the `view-` page prefix). When omitted, exports all views.
+| `--output`       | string | `.` | Output directory. Path containment check (SEC-015): `..` rejected.
+| `--embed-diagram`| bool   | `false` | If `true`, draw.io is asked to embed the diagram XML into the output (SVG/PDF feature).
+| `--scale`        | float  | `1.0` | Scale factor passed to draw.io. Values > 1 require GPU access.
+|===
+
+=== Pre-flight
+
+* Detect draw.io CLI via `internal/export.DetectDrawioBinary` (search order: `drawio-export`, `drawio` on PATH, platform-specific paths in `internal/export/platform_*.go`).
+* On miss: exit 2 with message containing `https://www.drawio.com/`.
+
+=== Output
+
+* Files named `architecture-<view>.<png|svg>` (`view` is `filepath.Base`-cleaned).
+* JSON: `{"files":[...],"errors":[...],"success":true|false}`.
+* Per-view export errors are accumulated; partial success returns exit 1.
+
+== `bausteinsicht export-table`
+
+Source: `cmd/bausteinsicht/export_table.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht export-table \
+    [--view VIEW_KEY] \
+    [--table-format adoc|md] \
+    [--output DIR] \
+    [--combined]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Default | Description
+| `--view`         | string | _(all)_ | Single view to export.
+| `--table-format` | string | `adoc`  | One of `adoc`, `md` (Markdown). Invalid → exit 2.
+| `--output`       | string | _(stdout)_ | Output directory; if omitted, writes to stdout.
+| `--combined`     | bool   | `false` | Emit a single deduplicated table over all views.
+|===
+
+=== JSON override
+
+If global `--format json` is set, the command emits a JSON array of row objects regardless of `--table-format`:
+
+[source,json]
+----
+[
+  {"id":"customer","title":"Customer","kind":"actor","technology":"","description":"End user"}
+]
+----
+
+=== AsciiDoc shape
+
+[source,asciidoc]
+----
+=== <View Title>
+
+|===
+| Element | Kind | Technology | Description
+
+| customer
+| actor
+|
+| End user
+|===
+----
+
+=== Markdown shape
+
+[source,markdown]
+----
+### <View Title>
+
+| Element | Kind | Technology | Description |
+|---------|------|-----------|-------------|
+| customer | actor | | End user |
+----
+
+== `bausteinsicht export-diagram`
+
+Source: `cmd/bausteinsicht/export_diagram.go`.
+
+=== Synopsis
+
+[source,bash]
+----
+bausteinsicht export-diagram \
+    [--view VIEW_KEY] \
+    [--diagram-format plantuml|mermaid] \
+    [--output DIR]
+----
+
+=== Flags
+
+[cols="2,1,1,4", options="header"]
+|===
+| Flag | Type | Default | Description
+| `--view`           | string | _(all)_     | Restrict to one view.
+| `--diagram-format` | string | `plantuml`  | One of `plantuml`, `mermaid`. Invalid → exit 2.
+| `--output`         | string | _(stdout)_  | Output directory; if omitted, prints to stdout.
+|===
+
+=== JSON override
+
+Global `--format json` makes the command emit a JSON array:
+
+[source,json]
+----
+[ {"view":"<key>","format":"plantuml","source":"@startuml ...@enduml"} ]
+----
+
+=== File extensions
+
+* PlantUML → `.puml`
+* Mermaid  → `.mmd`
+
+=== C4 level detection
+
+`internal/diagram/diagram.go` `detectLevel`:
+
+* "Component" if any element has `kind == "component"`.
+* "Container" if any element has `container: true` or the view has a `scope`.
+* "Context"   otherwise.
+
+PlantUML output uses `!include <C4/C4_Context|C4_Container|C4_Component>`.

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -1,0 +1,451 @@
+= Data Models
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+
+This specification documents the JSONC architecture model, the sync state file, the draw.io extensions, and supporting types — all reverse-engineered from `internal/model/*.go`, `internal/sync/state.go`, `internal/drawio/*.go`, and the test fixtures in `internal/model/testdata/` and `templates/sample-model.jsonc`.
+
+== File inventory
+
+[cols="2,2,4", options="header"]
+|===
+| Filename | Path | Role
+| `architecture.jsonc` | working dir | Architecture model — single source of truth.
+| `template.drawio`    | working dir | draw.io template that defines element styles.
+| `architecture.drawio`| working dir | Generated/edited diagram with one page per view.
+| `.bausteinsicht-sync`| working dir | Sync state (last-synced field values, hashes, integrity checksum).
+| `bausteinsicht.schema.json` | (referenced via `$schema` URL) | JSON Schema for IDE autocompletion. _Referenced from `templates/sample-model.jsonc` but not present in the repo._
+|===
+
+== Architecture model — JSONC root
+
+Authoritative type: `BausteinsichtModel` in `internal/model/types.go:12-23`.
+
+[source,go]
+----
+type BausteinsichtModel struct {
+    Schema        string
+    Config        Config
+    Specification Specification
+    Model         map[string]Element
+    Relationships []Relationship
+    Views         map[string]View
+    ElementOrder  []string  // implicit: insertion order of specification.elements
+}
+----
+
+Top-level JSONC layout:
+
+[source,jsonc]
+----
+{
+  "$schema": "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json",
+
+  "config":         { ... },           // optional
+  "specification":  { ... },           // required
+  "model":          { ... },           // required (may be empty → warning)
+  "relationships":  [ ... ],           // optional, default []
+  "views":          { ... }            // optional, default {}
+}
+----
+
+JSONC features handled by `loader.StripJSONC`:
+
+* UTF-8 BOM
+* `// line comments`
+* `/* block comments */`
+* trailing commas before `}` or `]`
+
+Hard limits (`internal/model/loader.go`, `internal/model/resolve.go`):
+
+* `MaxModelFileSize = 10 * 1024 * 1024` bytes (10 MiB).
+* `MaxElementDepth = 50` levels of nesting.
+
+== `config`
+
+`internal/model/types.go:4-9`.
+
+[source,go]
+----
+type Config struct {
+    Metadata *bool  // enable / disable metadata box (per-view)
+    Legend   *bool  // enable / disable legend box (per-view)
+    Author   string
+    Repo     string
+}
+----
+
+* Both flags use `*bool` so that "unset" is distinct from `false`.
+* `Author` and `Repo` are rendered into the metadata box (`internal/sync/metadata.go`).
+
+[source,jsonc]
+----
+"config": {
+  "metadata": true,
+  "legend":   true,
+  "author":   "Architecture Guild",
+  "repo":     "https://github.com/example/onlineshop"
+}
+----
+
+== `specification`
+
+`internal/model/types.go:25-39`.
+
+[source,go]
+----
+type Specification struct {
+    Elements      map[string]ElementKind
+    Relationships map[string]RelationshipKind
+}
+type ElementKind struct {
+    Notation    string  // C4 notation label
+    Description string
+    Container   bool    // may have children
+}
+type RelationshipKind struct {
+    Notation string
+    Dashed   bool
+}
+----
+
+[NOTE]
+====
+**Definition order matters.** The order in which kinds appear in `specification.elements` becomes their layer order in the layered layout. `loader.extractElementOrder` reads them with a streaming JSON decoder to preserve insertion order. (`internal/model/loader.go:51-99`, `internal/sync/layout.go`.)
+====
+
+[source,jsonc]
+----
+"specification": {
+  "elements": {
+    "actor":     { "notation": "Actor" },
+    "system":    { "notation": "Software System", "container": true },
+    "container": { "notation": "Container",       "container": true },
+    "component": { "notation": "Component",       "container": true }
+  },
+  "relationships": {
+    "uses":  { "notation": "uses" },
+    "async": { "notation": "publishes/subscribes", "dashed": true }
+  }
+}
+----
+
+== `model.<id>` — Element
+
+`internal/model/types.go:41-49`.
+
+[source,go]
+----
+type Element struct {
+    Kind        string
+    Title       string
+    Description string
+    Technology  string
+    Tags        []string             // declared but no consumer in v1 — see Open Questions
+    Children    map[string]Element
+    Metadata    map[string]string    // declared but no consumer in v1 — see Open Questions
+}
+----
+
+Required fields for validation: `kind`, `title`. `kind` must reference a key in `specification.elements`. `children` is allowed only if the kind has `container: true`.
+
+[source,jsonc]
+----
+"model": {
+  "customer": {
+    "kind": "actor",
+    "title": "Customer",
+    "description": "End user"
+  },
+  "onlineshop": {
+    "kind": "system",
+    "title": "Online Shop",
+    "children": {
+      "api": {
+        "kind": "container",
+        "title": "REST API",
+        "technology": "Go"
+      }
+    }
+  }
+}
+----
+
+=== Element ID rules
+
+* Object key in JSONC.
+* CLI input regex: `^[a-zA-Z][a-zA-Z0-9_-]*$` (`cmd/bausteinsicht/add_element.go:15`).
+* Reference path uses `.` as separator: `onlineshop.api`. Therefore the ID itself must not contain a dot.
+
+== `relationships`
+
+`internal/model/types.go:51-57`.
+
+[source,go]
+----
+type Relationship struct {
+    From        string
+    To          string
+    Label       string
+    Kind        string
+    Description string
+}
+----
+
+* `From` and `To` are dot-notation references; both must resolve to a model element.
+* `Kind` (when set) must be a key in `specification.relationships`.
+* Duplicates are forbidden when **all** of `(from, to, kind, label)` match.
+
+[source,jsonc]
+----
+"relationships": [
+  { "from": "customer",          "to": "onlineshop.api", "label": "uses",   "kind": "uses" },
+  { "from": "onlineshop.api",    "to": "onlineshop.db",  "label": "writes", "kind": "uses" }
+]
+----
+
+== `views`
+
+`internal/model/types.go:59-66`.
+
+[source,go]
+----
+type View struct {
+    Title       string
+    Scope       string
+    Include     []string
+    Exclude     []string
+    Description string
+    Layout      string  // "" | "layered" | "grid" | "none"
+}
+----
+
+[cols="1,4", options="header"]
+|===
+| Field | Semantics
+| `title`       | Required. Used as draw.io page name and metadata-box header.
+| `scope`       | Optional. Element drawn as boundary swimlane. Must resolve.
+| `include`     | Patterns selecting elements (see below). Empty `include` ⇒ empty view.
+| `exclude`     | Patterns subtracting elements after `include`.
+| `description` | Optional. Rendered into the metadata box.
+| `layout`      | One of `""` (treated as `"layered"`), `"layered"`, `"grid"`, `"none"`.
+|===
+
+=== Pattern semantics (`internal/model/resolve.go:72-121`)
+
+[cols="1,3,3", options="header"]
+|===
+| Pattern | Matches | Example
+| `**` | Every element in the model | `**`
+| `*`  | Every top-level element (no `.`) | `*`
+| `prefix.*` | Direct children of `prefix` | `onlineshop.*`
+| `prefix.**`| All descendants of `prefix` | `onlineshop.**`
+| `exact.path`| Exact element | `onlineshop.api.catalog`
+|===
+
+[source,jsonc]
+----
+"views": {
+  "containers": {
+    "title":   "Container View",
+    "scope":   "onlineshop",
+    "include": ["customer", "onlineshop.*", "payment-provider"],
+    "layout":  "layered"
+  }
+}
+----
+
+== Sync state — `.bausteinsicht-sync`
+
+Authoritative type: `SyncState` in `internal/sync/state.go:17-25`.
+
+[source,go]
+----
+type SyncState struct {
+    Checksum         string                       // "sha256:<hex>" of the rest of the file
+    Timestamp        string                       // ISO-8601
+    ModelHash        string                       // "sha256:<hex>" of the model file
+    DrawioHash       string                       // "sha256:<hex>" of the drawio file
+    Elements         map[string]ElementState      // key = dot-path
+    Relationships    []RelationshipState
+    RenderedElements map[string]bool              // which IDs are actually on a page
+}
+
+type ElementState struct {
+    Title, Description, Technology, Kind string
+}
+
+type RelationshipState struct {
+    From, To string
+    Index    int
+    Label    string
+    Kind     string
+}
+----
+
+The `Checksum` is computed by marshaling the rest of the struct, hashing with SHA-256, and storing as `sha256:<hex>`. On load, a checksum mismatch fails with the message `sync state corrupted (checksum mismatch); delete .bausteinsicht-sync and re-run sync` (`internal/sync/state.go:46-93`).
+
+[source,json]
+----
+{
+  "checksum":   "sha256:7a1f...",
+  "timestamp":  "2026-05-01T12:34:56Z",
+  "modelHash":  "sha256:...",
+  "drawioHash": "sha256:...",
+  "elements": {
+    "customer":            {"title":"Customer","description":"End user","technology":"","kind":"actor"},
+    "onlineshop.api":      {"title":"REST API","description":"...","technology":"Go","kind":"container"}
+  },
+  "relationships": [
+    {"from":"customer","to":"onlineshop.api","index":0,"label":"uses","kind":"uses"}
+  ],
+  "renderedElements": {
+    "customer": true,
+    "onlineshop.api": true
+  }
+}
+----
+
+== Draw.io document — Bausteinsicht extensions
+
+The XML follows the standard draw.io schema with `<mxfile>` / `<diagram>` / `<mxGraphModel>` / `<root>` / `<object>` / `<mxCell>` (`internal/drawio/document.go`).
+
+Bausteinsicht layers two custom attributes onto each element's `<object>`:
+
+[cols="2,4", options="header"]
+|===
+| Attribute | Meaning
+| `bausteinsicht_id`   | Dot-path of the model element (matches the JSONC key path).
+| `bausteinsicht_kind` | Reference to a key in `specification.elements`.
+|===
+
+Optional element attributes:
+
+* `technology` — verbatim from the model.
+* `tooltip`    — the description.
+* `link`       — drill-down hint (e.g. `data:page/id,view-containers`).
+
+Each connector is a regular `<mxCell edge="1">` whose `id` is `rel-<from>-<to>-<index>` (`internal/drawio/connector.go:21-23`).
+
+Newly created elements receive an extra style segment:
+
+[source]
+----
+strokeColor=#FF0000;dashed=1;
+----
+
+(`internal/sync/forward.go` `newElementMarker`).
+
+== Draw.io template — recognised attributes
+
+Authoritative type: `TemplateSet` in `internal/drawio/template.go:36-41`.
+
+* The template MUST be an `<mxfile>` document with `bausteinsicht_template_version` (defaults to 1; `CurrentTemplateVersion = 1`).
+* Each `<object>` carrying `bausteinsicht_template="<kind>"` defines the style for that element kind. The associated `<mxCell>` provides the draw.io style string and default geometry.
+* Sub-cell templates (children of the template object with id suffixes `-title`, `-tech`, `-desc`) declare per-line styles for grouped-text elements; their absence selects the legacy HTML-label rendering.
+* The template can also provide boundary styles (rendered around scope elements) and a default connector style.
+
+== HTML labels
+
+`internal/drawio/label.go`.
+
+`GenerateLabel(title, technology, description)` produces:
+
+[source,html]
+----
+<b>Title</b><br>
+<font color="#CCCCCC"><i>[Technology]</i></font><br>
+<font color="#BBBBBB" style="font-size:11px">Description</font>
+----
+
+* All values are passed through `escapeHTML` for `&`, `<`, `>`, `"` (SEC-008).
+* Empty lines are omitted.
+* Description is truncated at `maxLabelDescLen = 60` runes with `…` (or 120 in the sub-cell variant) to fit the element box.
+
+== Validation errors and warnings — JSON shapes
+
+`internal/model/validate.go:8-22`.
+
+[source,go]
+----
+type ValidationError struct {
+    Path    string  // e.g. "model.foo.title", "relationships[2]", "views.context.include"
+    Message string
+}
+type ValidationWarning struct {
+    Path    string
+    Message string
+}
+type ValidationResult struct {
+    Errors   []ValidationError
+    Warnings []ValidationWarning
+}
+----
+
+Error messages observable in `internal/model/validate.go`:
+
+* `invalid element ID "X": must not be empty or whitespace`
+* `missing required field "kind"` / `missing required field "title"`
+* `unknown kind "X"`
+* `kind "K" does not allow children (container: false)`
+* `from "X" does not resolve to an existing element`
+* `to "X" does not resolve to an existing element`
+* `unknown relationship kind "X"`
+* `duplicate relationship X → Y (first at relationships[I])`
+* `invalid layout "X" (must be "layered", "grid", "none", or empty)`
+* `scope "X" does not resolve to an existing element`
+* `element "X" does not exist`
+
+Warnings:
+
+* `no element kinds defined in specification`
+* `model is empty (no elements defined)`
+
+== Test fixtures
+
+=== `internal/model/testdata/minimal-model.jsonc`
+
+[source,jsonc]
+----
+{
+  "specification": {
+    "elements": {
+      "system": { "notation": "System" }
+    }
+  },
+  "model": {
+    "root": { "kind": "system", "title": "Root" }
+  },
+  "relationships": [],
+  "views": {}
+}
+----
+
+=== `internal/model/testdata/valid-model.jsonc`
+
+Demonstrates the full set of JSONC features (line comments, trailing commas, nested specification entries) and acts as the canonical happy-path input for the loader and validator.
+
+=== `internal/model/testdata/invalid-json.jsonc`
+
+Triggers the unmarshaler — an unquoted key inside `specification.elements` — to verify that `Load` surfaces a parse error.
+
+=== `templates/sample-model.jsonc`
+
+Embedded by `templates/embed.go` and emitted by `bausteinsicht init`. Contains 10 element kinds, a 3-level hierarchy (`onlineshop.api.catalog`), 14 relationships, and three views (`context`, `containers`, `components`). The full text is in `examples/online-shop/architecture.jsonc`.
+
+== JSON output schemas — index
+
+[cols="2,4", options="header"]
+|===
+| Command | Schema reference
+| `init`            | `{"success":bool,"files":[string]}`
+| `sync`            | `{"forward_added":int, "forward_updated":int, "forward_deleted":int, "reverse_added":int, "reverse_updated":int, "reverse_deleted":int, "metadata_updated":int, "conflicts":int}`
+| `validate`        | `{"valid":bool, "errors":[{path,message}], "warnings":[{path,message}]}`
+| `add element`     | `{"id":string,"kind":string,"title":string,"technology":string,"description":string}`
+| `add relationship`| `{"from":string,"to":string,"label":string,"kind":string,"description":string}`
+| `export`          | `{"files":[string],"errors":[string],"success":bool}`
+| `export-table`    | `[{id,title,kind,technology,description}]`
+| `export-diagram`  | `[{view,format,source}]`
+| _(error envelope)_| `{"error":string,"code":int}` on stderr
+|===

--- a/src/docs/spec/04_acceptance_criteria.adoc
+++ b/src/docs/spec/04_acceptance_criteria.adoc
@@ -1,0 +1,472 @@
+= Acceptance Criteria
+:toc: left
+:toclevels: 2
+:sectnums:
+:icons: font
+
+Gherkin-style scenarios derived from the project's tests (~400 `Test*` functions across `cmd/bausteinsicht/`, `internal/sync/`, `internal/model/`, `internal/drawio/`, `internal/diagram/`, `internal/table/`, `internal/export/`, `internal/watcher/`).
+Each scenario references the use case it satisfies and points to the source test by name.
+
+== Conventions
+
+* `Given` describes pre-state observable from the file system or model.
+* `When` is a single CLI invocation (or sync operation).
+* `Then` describes a single observable post-condition; multiple assertions are split into separate `Then`/`And` clauses.
+* Test names cited in `// test:` comments come from the actual Go test files.
+
+== UC-001 — Initialize project
+
+=== AC-001-01: A fresh directory yields four files
+
+* **Given** an empty directory.
+* **When** I run `bausteinsicht init`.
+* **Then** files `architecture.jsonc`, `template.drawio`, `architecture.drawio`, `.bausteinsicht-sync` exist.
+* **And** the exit code is `0`.
+* `// test: TestInitCreatesFiles, TestInitTemplateFileExists, TestInitDrawioFilesExist`
+
+=== AC-001-02: Refuse to overwrite
+
+* **Given** `architecture.jsonc` already exists in the directory.
+* **When** I run `bausteinsicht init`.
+* **Then** the command exits with code `2` and the message contains `already exists`.
+* `// test: TestInitFailsIfFilesExist`
+
+=== AC-001-03: Initial model validates
+
+* **Given** the directory was scaffolded by `bausteinsicht init`.
+* **When** I run `bausteinsicht validate`.
+* **Then** validation passes (exit `0`, `valid: true`).
+* `// test: TestInitGeneratesValidModel`
+
+=== AC-001-04: Initial drawio is a valid draw.io file
+
+* **Given** the directory was scaffolded by `bausteinsicht init`.
+* **When** I parse `architecture.drawio`.
+* **Then** the file has an `<mxfile>` root with at least one `<diagram>` element.
+* `// test: TestInitGeneratesValidDrawio`
+
+=== AC-001-05: Initial sync state is loadable
+
+* **Given** the directory was scaffolded by `bausteinsicht init`.
+* **When** I load `.bausteinsicht-sync`.
+* **Then** the SHA-256 self-checksum verifies.
+* `// test: TestInitSyncStateValid`
+
+=== AC-001-06: JSON output
+
+* **When** I run `bausteinsicht init --format json`.
+* **Then** stdout is a JSON object with `success: true` and a `files` array of length 4.
+* `// test: TestInitJSONOutput`
+
+== UC-002 — Validate
+
+=== AC-002-01: Valid model exits 0
+
+* **Given** a valid model.
+* **When** I run `bausteinsicht validate`.
+* **Then** the exit code is `0` and the text output is `Model is valid.`.
+
+=== AC-002-02: Unknown kind is reported
+
+* **Given** an element references a kind that is not in `specification.elements`.
+* **When** I run `bausteinsicht validate --format json`.
+* **Then** the JSON has `valid: false`.
+* **And** at least one error has `message` containing `unknown kind`.
+
+=== AC-002-03: Children under a non-container kind are rejected
+
+* **Given** an element of a non-container kind has a `children` map.
+* **When** I run `bausteinsicht validate`.
+* **Then** the validator emits `kind "K" does not allow children (container: false)`.
+
+=== AC-002-04: Patterns in `include` are not flagged as missing IDs
+
+* **Given** a view has `include: ["onlineshop.*"]`.
+* **When** I run `bausteinsicht validate`.
+* **Then** no error is emitted for the pattern (only literal IDs are checked).
+
+=== AC-002-05: Auto-detect picks the only `*.jsonc`
+
+* **Given** the directory contains exactly one `*.jsonc` file.
+* **When** I run `bausteinsicht validate` without `--model`.
+* **Then** that file is loaded.
+
+=== AC-002-06: Auto-detect fails when ambiguous
+
+* **Given** the directory contains two or more `*.jsonc` files.
+* **When** I run `bausteinsicht validate` without `--model`.
+* **Then** the command exits non-zero and the error contains `multiple .jsonc files`.
+
+== UC-003 — Add element
+
+=== AC-003-01: Add a top-level element
+
+* **Given** a valid model that does not contain an element with id `payment`.
+* **When** I run `bausteinsicht add element --id payment --kind system --title "Payment Service"`.
+* **Then** the model now has `model.payment` with `kind: system`, `title: "Payment Service"`.
+* `// test: TestAddElementTopLevel`
+
+=== AC-003-02: Add a nested element
+
+* **Given** the model has `onlineshop` (kind `system`, container).
+* **When** I run `bausteinsicht add element --id api --kind container --title "REST API" --parent onlineshop`.
+* **Then** the model has `model.onlineshop.children.api`.
+* `// test: TestAddElementNested`
+
+=== AC-003-03: Reject invalid IDs
+
+* **Given** the user provides `--id "1bad-id"` (starts with a digit) or `--id "has.dot"`.
+* **When** I run `bausteinsicht add element ... `.
+* **Then** the command exits with code `1` and the message contains `invalid element ID`.
+* `// test: TestAddElementInvalidIDs`
+
+=== AC-003-04: Accept valid IDs
+
+* **Given** IDs matching `[a-zA-Z][a-zA-Z0-9_-]*`.
+* **When** I run `bausteinsicht add element ...`.
+* **Then** the element is added.
+* `// test: TestAddElementValidIDs`
+
+=== AC-003-05: Reject empty title
+
+* **When** I run `bausteinsicht add element --id x --kind system --title ""`.
+* **Then** the command exits non-zero with `title must not be empty`.
+* `// test: TestAddElementEmptyTitle`
+
+=== AC-003-06: Reject unknown kind
+
+* **When** I run `bausteinsicht add element --id x --kind nonsense --title "X"`.
+* **Then** the command exits non-zero with `unknown element kind`.
+* `// test: TestAddElementInvalidKind`
+
+=== AC-003-07: Reject duplicates
+
+* **Given** `model.foo` already exists.
+* **When** I run `bausteinsicht add element --id foo --kind system --title "..."`.
+* **Then** the command exits non-zero.
+* `// test: TestAddElementDuplicateID, TestAddElementDuplicateNestedID`
+
+=== AC-003-08: Reject child under non-container parent
+
+* **Given** the parent's kind has `container: false`.
+* **When** I run `bausteinsicht add element --parent <parent> ...`.
+* **Then** the command exits non-zero.
+* `// test: TestAddElementNonContainerParentRejected`
+
+=== AC-003-09: Comments survive
+
+* **Given** the JSONC model file has line comments around the `model` block.
+* **When** I run `bausteinsicht add element ...`.
+* **Then** every existing comment is preserved verbatim in the saved file.
+* `// test: TestAddElementPreservesComments`
+
+=== AC-003-10: JSON output schema
+
+* **When** I run `bausteinsicht add element --format json ...`.
+* **Then** stdout is `{"id":..., "kind":..., "title":..., "technology":..., "description":...}`.
+* `// test: TestAddElementJSONOutput, TestAddElementJSONOutputIncludesAllFields`
+
+=== AC-003-11: JSON error envelope
+
+* **When** an error is raised in `--format json` mode.
+* **Then** stderr emits `{"error":<msg>,"code":<int>}`.
+* `// test: TestAddElementJSONErrorOutput, TestAddElementTextErrorOutput`
+
+== UC-004 — Add relationship
+
+=== AC-004-01: Add a relationship
+
+* **When** I run `bausteinsicht add relationship --from customer --to onlineshop --kind uses --label "browses"`.
+* **Then** an element of `relationships` is appended.
+* `// test: TestAddRelationshipValid`
+
+=== AC-004-02: Reject missing endpoints
+
+* **Given** `customer` does not exist.
+* **When** I add a relationship from `customer`.
+* **Then** the command exits non-zero with `element "customer" not found`.
+* `// test: TestAddRelationshipNonExistentFrom, TestAddRelationshipNonExistentTo`
+
+=== AC-004-03: Reject unknown kind
+
+* **When** the `--kind` is not in `specification.relationships`.
+* **Then** the command exits non-zero with `unknown relationship kind`.
+* `// test: TestAddRelationshipInvalidKind`
+
+=== AC-004-04: Reject exact duplicates only
+
+* **Given** a relationship `(from, to, kind, label)` exists.
+* **When** I run `add relationship` with the same `(from, to, kind, label)`.
+* **Then** the command rejects the duplicate.
+* **And When** I run `add relationship` with a *different* kind.
+* **Then** the new relationship is accepted.
+* `// test: TestAddRelationshipDuplicateBlocked, TestAddRelationshipDifferentKindAllowed`
+
+=== AC-004-05: Description is persisted
+
+* **When** I add a relationship with `--description "channel A"`.
+* **Then** the saved model contains the description verbatim.
+* `// test: TestAddRelationshipWithDescription`
+
+=== AC-004-06: JSON output
+
+* **When** I run `bausteinsicht add relationship --format json ...`.
+* **Then** stdout is `{"from":..., "to":..., "label":..., "kind":..., "description":...}`.
+* `// test: TestAddRelationshipJSONOutput`
+
+== UC-005 — Sync
+
+=== AC-005-01: Sync after init reports no changes
+
+* **Given** the directory was just scaffolded by `init`.
+* **When** I run `bausteinsicht sync`.
+* **Then** the summary shows `Already in sync. No changes.`.
+* `// test: TestSyncAfterInit`
+
+=== AC-005-02: Detect a model addition and create a new draw.io element
+
+* **Given** the architect added a new element to `architecture.jsonc`.
+* **When** I run `bausteinsicht sync`.
+* **Then** the JSON summary has `forward_added >= 1`.
+* `// test: TestSyncDetectsModelChanges, TestRun_ModelAddedElement`
+
+=== AC-005-03: Reverse-sync a draw.io title change into the model
+
+* **Given** the architect changed an element label in `architecture.drawio`.
+* **When** I run `bausteinsicht sync`.
+* **Then** the JSONC model's `title` is updated to match the new label.
+* `// test: TestRun_DrawioModifiedTitle`
+
+=== AC-005-04: Conflicts are resolved with model-wins
+
+* **Given** the same field changed in both surfaces since the last sync.
+* **When** I run `bausteinsicht sync`.
+* **Then** the model value remains.
+* **And** a warning is printed naming the field, both values, and the last-synced value.
+* **And** the exit code is `1`.
+* `// test: TestRun_ConflictModelWins`
+
+=== AC-005-05: Comments survive a round-trip
+
+* **Given** the JSONC model has comments and trailing commas.
+* **When** I edit a label in draw.io and run `sync`.
+* **Then** every comment in the model is preserved.
+* `// test: TestSyncPreservesJSONCComments`
+
+=== AC-005-06: Concurrent edits in both surfaces
+
+* **Given** changes occurred on both sides since the last sync (no conflicts).
+* **When** I run `bausteinsicht sync`.
+* **Then** both forward and reverse sets are applied and reported.
+* `// test: TestSyncConcurrentModelAndDrawioChanges`
+
+=== AC-005-07: A page that is not a Bausteinsicht view is preserved
+
+* **Given** the user added an extra page in draw.io.
+* **When** I run `bausteinsicht sync`.
+* **Then** that page is left untouched.
+* `// test: TestRun_NonViewPagesPreserved, TestSyncPreservesUserAddedDrawioElement`
+
+=== AC-005-08: Orphan view pages are removed
+
+* **Given** a view present in the previous sync was removed from the model.
+* **When** I run `bausteinsicht sync`.
+* **Then** its `view-<id>` page is removed from the diagram.
+* `// test: TestRun_OrphanedViewPageRemoved, TestSyncRemovesOrphanedViewPages`
+
+=== AC-005-09: Adding a new view does not delete model elements
+
+* **Given** a new `view` is added that filters elements differently.
+* **When** I run `bausteinsicht sync`.
+* **Then** no element is removed from the model just because a previous view excluded it.
+* `// test: TestRun_AddingNewViewDoesNotDeleteElements, TestRun_RenamingViewDoesNotDeleteElements`
+
+=== AC-005-10: New view page is populated on first sync
+
+* **Given** a fresh view was added.
+* **When** I run `bausteinsicht sync`.
+* **Then** the corresponding draw.io page exists and contains the included elements.
+* `// test: TestRun_NewViewPageGetsPopulated`
+
+=== AC-005-11: Missing/empty drawio is rebuilt
+
+* **Given** `architecture.drawio` is missing or contains no `<diagram>`.
+* **When** I run `bausteinsicht sync`.
+* **Then** the file is recreated from the template and the stale state is dropped.
+* `// (cmd/bausteinsicht/sync.go branch — not all paths have a dedicated test name)`
+
+=== AC-005-12: Path traversal in --model is rejected
+
+* **When** I run `bausteinsicht --model ../etc/passwd validate`.
+* **Then** the command exits with an error containing `directory traversal`.
+* `// test: TestRootCmd_RejectsModelPathTraversal, TestValidatePathContainment`
+
+=== AC-005-13: Path traversal in --template is rejected
+
+* **When** I run `bausteinsicht --template ../tpl.drawio sync`.
+* **Then** the command exits with an error containing `directory traversal`.
+* `// test: TestRootCmd_RejectsTemplatePathTraversal`
+
+=== AC-005-14: Template extension is enforced
+
+* **Given** `--template foo.txt` is passed.
+* **Then** the command rejects with `must have a .drawio extension`.
+* `// test: TestRootCmd_RejectsNonDrawioTemplate, TestRootCmd_AcceptsDrawioTemplate, TestRootCmd_AcceptsEmptyTemplate`
+
+=== AC-005-15: Format flag is case-insensitive
+
+* **When** I pass `--format JSON` or `--format Text`.
+* **Then** the format is accepted.
+* `// test: TestRootCmd_AcceptsJsonCaseInsensitive, TestRootCmd_AcceptsTextCaseInsensitive, TestRootCmd_AcceptsJsonLowercase, TestRootCmd_AcceptsTextFormat`
+
+=== AC-005-16: Unknown format is rejected
+
+* **When** I pass `--format yaml`.
+* **Then** the command exits non-zero with `unknown format`.
+* `// test: TestRootCmd_RejectsInvalidFormat`
+
+=== AC-005-17: Sync produces stable JSON summary
+
+* **When** I run `bausteinsicht sync --format json`.
+* **Then** stdout is a JSON object with the eight stable keys (see Data Models §"JSON output schemas").
+* `// test: TestSyncJSONOutput`
+
+=== AC-005-18: Multiple relationships between the same pair are supported
+
+* **Given** two relationships with the same `from`/`to` but different `label` or `kind`.
+* **When** I run `bausteinsicht sync`.
+* **Then** both connectors are rendered separately on each view they belong to.
+* `// test: TestRun_MultipleRelsSamePair`
+
+=== AC-005-19: Warnings about invisible elements
+
+* **Given** an element exists in the model but is excluded from every view.
+* **When** I run `bausteinsicht sync`.
+* **Then** a warning is printed naming the element.
+* `// test: TestRun_WarnsAboutInvisibleElements, TestRun_NoWarningWithoutViews`
+
+=== AC-005-20: Round-trip on every supported field
+
+* **Given** a model with elements and relationships.
+* **When** I forward-sync, edit in draw.io, reverse-sync, and reload.
+* **Then** title/description/technology and label changes are preserved on both sides.
+* `// test: TestRun_FullRoundTrip`
+
+== UC-006 — Watch
+
+=== AC-006-01: Refuse to start without a model file
+
+* **Given** the current directory has no `*.jsonc`.
+* **When** I run `bausteinsicht watch`.
+* **Then** the command exits non-zero.
+* `// test: TestWatchNoModelFile`
+
+=== AC-006-02: Refuse to start without a draw.io file
+
+* **Given** the model exists but `architecture.drawio` does not.
+* **When** I run `bausteinsicht watch`.
+* **Then** the command exits non-zero.
+* `// test: TestWatchMissingDrawioFile`
+
+=== AC-006-03: Watch is registered as a subcommand
+
+* `// test: TestWatchCommandRegistered`
+
+== UC-007 — Export images
+
+=== AC-007-01: Default scale is 1.0
+
+* **When** I look at the parsed flag set of `export`.
+* **Then** `--scale` defaults to `1.0`.
+* `// test: TestExportCmd_DefaultScaleIsOne`
+
+=== AC-007-02: draw.io detection
+
+* **When** the platform binary is missing.
+* **Then** the command exits with code `2` and the message references the draw.io download URL.
+* `// (internal/export.DetectDrawioBinary, internal/export/platform_*.go)`
+
+== UC-008 — Export tables
+
+=== AC-008-01: AsciiDoc and Markdown shapes match the table layouts in the data-models doc.
+
+`// test: see internal/table/table_test.go (AsciiDoc and Markdown formatters tested per row).`
+
+== UC-009 — Export diagrams
+
+=== AC-009-01: PlantUML to stdout
+
+* **When** I run `bausteinsicht export-diagram --diagram-format plantuml`.
+* **Then** stdout starts with `@startuml` and ends with `@enduml`.
+* `// test: TestExportDiagram_PlantUMLToStdout`
+
+=== AC-009-02: Mermaid to stdout
+
+* **When** I run `bausteinsicht export-diagram --diagram-format mermaid`.
+* **Then** stdout is a Mermaid diagram.
+* `// test: TestExportDiagram_MermaidToStdout`
+
+=== AC-009-03: Write to file
+
+* **When** I run `bausteinsicht export-diagram --output dist`.
+* **Then** files `<view>.puml` (or `.mmd`) are created in `dist/`.
+* `// test: TestExportDiagram_WriteToFile, TestExportDiagram_MermaidFile`
+
+=== AC-009-04: Invalid format
+
+* **When** I run `bausteinsicht export-diagram --diagram-format dot`.
+* **Then** the command exits non-zero.
+* `// test: TestExportDiagram_InvalidFormat`
+
+=== AC-009-05: Invalid view
+
+* **When** I run `bausteinsicht export-diagram --view does-not-exist`.
+* **Then** the command exits non-zero.
+* `// test: TestExportDiagram_InvalidView`
+
+== Cross-cutting (forward sync internals)
+
+The following acceptance criteria are tested at the engine level (`internal/sync/forward_*_test.go`) and protect the _semantics_ of the sync output — they are guarantees the CLI relies on.
+
+=== AC-X-01: Element lands on the correct view page
+
+* `// test: TestApplyForward_ElementOnCorrectViewPage`
+
+=== AC-X-02: A relationship is rendered only on a page where both endpoints are visible
+
+* `// test: TestApplyForward_RelationshipOnlyOnPageWithBothEndpoints`
+
+=== AC-X-03: Relationship lifting
+
+* When an endpoint is not on a view but its ancestor is, the connector is lifted to the ancestor.
+* `// test: TestApplyForward_RelationshipLifting, TestApplyForward_RelationshipLiftingDedup, TestApplyForward_DirectRelSuppressesLifted`
+
+=== AC-X-04: Scope boundary is drawn around scope children
+
+* `// test: TestApplyForward_ScopeBoundingBox, TestApplyForward_ScopeBoundaryUpdatedOnModify, TestApplyForward_ConnectorToScopeElement`
+
+=== AC-X-05: Deletes propagate to all view pages
+
+* Deleting an element in the model removes it (and its connectors) from every view page.
+* `// test: TestApplyForward_DeletedElementRemovedFromViewPages, TestApplyForward_DeletedRelationshipRemovedFromViewPages, TestApplyForward_DeleteElementRemovesConnectors`
+
+=== AC-X-06: Drill-down navigation
+
+* Container elements get a drill-down link to the page that scopes them.
+* `// test: TestApplyForward_DrillDownNavigationLinks, TestApplyForward_BackNavigationButton`
+
+=== AC-X-07: Newly included element on an existing page is positioned and connected
+
+* `// test: TestApplyForward_NewlyIncludedElementOnExistingPage, TestApplyForward_NewlyIncludedElementGetsConnectors`
+
+=== AC-X-08: `exclude` removes an element from a page without touching the model
+
+* `// test: TestExcludeRemovesElementFromPage`
+
+=== AC-X-09: No-views fallback puts everything on the first page
+
+* `// test: TestApplyForward_NoViewsFallback`
+
+== Performance budget (informative)
+
+The benchmarks `BenchmarkSyncRun`, `BenchmarkLoadModel`, and `BenchmarkFlattenElements` (in `internal/{sync,model}/bench_test.go`) provide reference numbers at n=10/100/500 elements but do not assert thresholds. They serve as regression guards rather than acceptance criteria.

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -1,0 +1,296 @@
+= Sync Specification
+:toc: left
+:toclevels: 3
+:sectnums:
+:icons: font
+
+This document specifies the bidirectional synchronization algorithm.
+Authoritative implementation is in `internal/sync/`.
+
+== Goals
+
+* **Idempotence:** running `sync` twice in a row with no edits in between MUST produce no changes (`Already in sync. No changes.`).
+* **Round-trip fidelity:** edits made on either surface (JSONC model, draw.io diagram) MUST round-trip across a `sync` invocation, subject to the conflict policy.
+* **Comment preservation:** JSONC comments and trailing-comma formatting MUST survive a sync that only changes element fields.
+* **Explainability:** every change MUST be classified (`forward_added`, `reverse_updated`, `metadata_updated`, …) and every conflict MUST be reported with old / new / last-synced values.
+
+== Inputs and outputs
+
+[cols="1,2,4", options="header"]
+|===
+| Surface | File | Role
+
+| Model         | `architecture.jsonc` | Source of element/relationship/view definitions.
+| Diagram       | `architecture.drawio`| Visual surface; carries layout + label edits.
+| State         | `.bausteinsicht-sync`| Last-synced field values + file hashes + integrity checksum.
+| Template      | `template.drawio` (or `--template`) | Element/connector styles.
+|===
+
+== High-level algorithm
+
+`internal/sync/engine.go::Run` (paraphrased):
+
+. **Detect changes** (three-way diff between model, draw.io, and last-synced state) → `ChangeSet`.
+. **Resolve conflicts** with the configured `ConflictResolver` (default `ModelWinsResolver`) → `[]ResolvedConflict`.
+. **Drop draw.io changes that lost** the conflict from the change set.
+. **Apply forward** (model → draw.io) → `ForwardResult`.
+. **Apply reverse** (draw.io → model) → `ReverseResult`.
+. **Compute warnings** (e.g., elements that are visible on no view).
+. Return a `SyncResult` carrying all of the above.
+
+[plantuml, sync-pipeline, svg]
+....
+@startuml
+skinparam handwritten false
+start
+:Load model;
+:Load draw.io document;
+:Load .bausteinsicht-sync state;
+:Detect changes (three-way);
+:ConflictResolver.Resolve();
+note right
+  default: ModelWinsResolver
+  emits a warning per resolved conflict
+end note
+:Drop draw.io changes that lost;
+fork
+  :ApplyForward
+  (model → drawio);
+fork again
+  :ApplyReverse
+  (drawio → model);
+end fork
+:Compute visible-elements warnings;
+:Compose SyncResult;
+stop
+@enduml
+....
+
+== Three-way diff (`internal/sync/diff.go`)
+
+For each element `e` (identified by its dot-path) and field `f ∈ {title, description, technology, kind}`:
+
+* let `M(e,f)` = current value in the model;
+* let `D(e,f)` = current value parsed from draw.io (HTML label parsed by `drawio.ParseLabel`);
+* let `S(e,f)` = value at last sync (from state).
+
+Classification:
+
+[cols="1,1,1,3", options="header"]
+|===
+| `M==S` | `D==S` | Result | Meaning
+
+| yes | yes | (no change)            | both surfaces match the snapshot.
+| no  | yes | model-side change      | propagate model → drawio (`forward_updated`).
+| yes | no  | drawio-side change     | propagate drawio → model (`reverse_updated`).
+| no  | no  | conflict, M ≠ D        | resolved by `ConflictResolver` (BR-006).
+|===
+
+Element addition / deletion is detected by the difference between the union of element ids in `M`, `D`, and `S`. Special handling:
+
+* **Newly created view pages** — elements that are visible *only* on a brand-new page MUST NOT be classified as `Deleted` from draw.io. The diff computes `computeNewPageOnlyElements()` and excludes them.
+* **Cross-view inconsistencies** — different drawio pages may carry slightly different cell content for the same element; the diff resolves to the model value.
+* **Unmanaged drawio elements** — elements added in draw.io that have no `bausteinsicht_id` are ignored (kept on the page; not synced into the model).
+
+For relationships, the matching key is `(from, to, kind, label, index)` where `index` is the position in the model's `relationships` array — used to disambiguate when several relationships share the same `(from, to)` pair.
+
+=== Visible elements / lifting
+
+`computeVisibleElements()` and `computeVisibleRelationships()` define which elements / connectors should appear on at least one page.
+
+* If no views are defined, *all* elements are visible (legacy "single page" mode).
+* If views are defined, the union of all views' resolved element sets is the visibility set.
+* For relationships: if either endpoint is not visible on a view, the diff tries to **lift** the connector to the closest visible ancestor before deciding the relationship is missing. This prevents view-filter changes from being interpreted as relationship deletions.
+
+== Conflict resolution
+
+=== Conflict shape (`internal/sync/conflict.go`)
+
+[source,go]
+----
+type Conflict struct {
+    ElementID     string
+    Field         string  // "title" | "description" | "technology"
+    ModelValue    string
+    DrawioValue   string
+    LastSyncValue string
+}
+----
+
+=== Default policy: model wins
+
+`ModelWinsResolver` (the only implementation) always returns the model value. Each resolution emits a `ResolvedConflict` whose `Warning` reads:
+
+[source]
+----
+Conflict detected for element "<id>":
+  Field: <field>
+  Model value:   "<model>"
+  draw.io value: "<drawio>"
+  Last sync:     "<state>"
+  → Keeping model value. Edit draw.io manually if needed.
+----
+
+When at least one conflict is reported, `bausteinsicht sync` exits with code **1** (success-but-warnings).
+
+`ConflictResolver` is an interface, allowing future "draw.io wins" or "interactive" resolvers; only `ModelWins` is shipped today.
+
+== Forward sync (`internal/sync/forward.go`)
+
+Per-view rendering:
+
+. For every model view `v`, ensure a draw.io page exists with id `view-<v>`.
+. Resolve elements via `model.ResolveView(v)` (`include` ∪ scope, minus `exclude`).
+. **Compute layout** (`internal/sync/layout.go`):
+  ** `layered` — the default. Element kinds are assigned to tiers using the order they appear in `specification.elements`. Actors (or other "external" kinds) are placed at the top, the scope boundary in the middle, the rest at the bottom. Children of the scope are laid out inside the boundary using a BFS placement.
+  ** `grid` — a regular grid.
+  ** `none` — every element at origin (0,0).
+. **Place / update / remove** mxCells:
+  ** New elements get the marker style `strokeColor=#FF0000;dashed=1;`.
+  ** Existing elements: position is preserved unless `--relayout`.
+  ** Deleted elements are removed; their connectors (any cell with matching `source`/`target` cell id) are also removed.
+. **Connectors** are recreated/updated; the canonical id is `rel-<from>-<to>-<index>`.
+. **Metadata box** (`metadata-<viewID>`) and **Legend box** (`legend-<viewID>`) are created or refreshed when `config.metadata` / `config.legend` are not explicitly disabled.
+
+`ForwardResult` (`internal/sync/forward.go:28-37`) reports:
+
+[source,go]
+----
+type ForwardResult struct {
+    ElementsCreated   int
+    ElementsUpdated   int
+    ElementsDeleted   int
+    ConnectorsCreated int
+    ConnectorsUpdated int
+    ConnectorsDeleted int
+    MetadataUpdated   int
+    Warnings          []string
+}
+----
+
+=== Layout invariants
+
+* `layeredLayout` uses the page width derived from the existing draw.io geometry (default A4 landscape, 1169 px) and an element gap of 60.
+* The scope boundary is sized by the bounding box of its children, with a minimum of 400×300.
+* Boundary inner padding is 60.
+* These constants live in `internal/sync/layout.go::layoutConfig`.
+
+== Reverse sync (`internal/sync/reverse.go`)
+
+`ApplyReverse` walks `cs.DrawioElementChanges` and `cs.DrawioRelationshipChanges`:
+
+* **Modified element field** (title / description / technology): updates the model element in place.
+* **Deleted element**: removes the element from the model (only if its absence is consistent across views and not a view-filter side-effect).
+* **Added element**: only happens when an element with a `bausteinsicht_id` was injected through a tool that knows the schema; such elements are added under the appropriate parent.
+* **Empty-title rule (BR-008):** an empty title coming from a draw.io edit is rejected and yields the warning `Element "<id>": ignoring empty title from draw.io`.
+* **Direction swaps (BR-010):** when the change set contains `Deleted(A→B)` and `Added(B→A)` for the same conceptual edge, `applyRelSwap` updates the existing relationship in-place to keep `kind`, `label`, and `description`.
+
+`ReverseResult` (`internal/sync/reverse.go:14-22`) mirrors the forward shape (`ElementsCreated/Updated/Deleted` + `RelationshipsCreated/Updated/Deleted` + `Warnings`).
+
+== Saving
+
+Two save paths in `cmd/bausteinsicht/sync.go::saveModel`:
+
+. **Patch save** — when `ReversePatchOps` (`internal/sync/patchops.go`) determines that all reverse changes are pure field updates, the saver produces a list of `(jsonPath, newValue)` pairs and applies them via `model.PatchValue`. JSONC comments and formatting around each value are preserved.
+. **Full save** — for structural changes (add/delete elements or relationships) the saver falls back to `model.Save`. The user's pre-`{` preamble (banner comments, license header, etc.) is read back and re-prepended.
+
+`internal/sync/patchops.go::elementFieldPath`:
+
+[source]
+----
+("onlineshop.api", "technology") -> ["model", "onlineshop", "children", "api", "technology"]
+----
+
+== State management
+
+State file: `.bausteinsicht-sync` (`internal/sync/state.go`).
+
+[source,go]
+----
+type SyncState struct {
+    Checksum         string                       // self sha256
+    Timestamp        string                       // ISO-8601
+    ModelHash        string
+    DrawioHash       string
+    Elements         map[string]ElementState
+    Relationships    []RelationshipState
+    RenderedElements map[string]bool
+}
+----
+
+* **Self-checksum:** computed by marshaling without `Checksum`, hashing, and storing as `sha256:<hex>`. Mismatch on load = `sync state corrupted (checksum mismatch); delete .bausteinsicht-sync and re-run sync`.
+* **File hashes:** SHA-256 of model and draw.io files. Used to short-circuit "no change" runs and to detect the pathological "drawio file emptied" case.
+* **`RenderedElements`:** records which IDs were actually placed on a draw.io page. Used to disambiguate "deleted in draw.io" from "filtered out by view".
+* **Atomicity:** state is written to a temp file in the same directory and renamed over the destination.
+
+== Edge cases
+
+[cols="1,3", options="header"]
+|===
+| Case | Handling
+
+| The drawio file does not exist or has no `<diagram>`.
+| `cmd/bausteinsicht/sync.go` recreates it from the template, logs `WARNING: Draw.io file not found, recreating from template` (or `... no diagram pages, recreating structure`), and discards the stale sync state.
+
+| The architect deletes a view from the model.
+| `sync` removes the corresponding `view-<id>` page after the diff. Elements that survive on other views remain.
+
+| The architect deletes a model element that was already deleted in draw.io.
+| The diff classifies it as already-applied; no extra action.
+
+| A relationship's source or target is missing on a view.
+| Lifting tries to attach the connector to the closest visible ancestor; if that succeeds, no `Deleted` is recorded.
+
+| The architect renames a view.
+| The old `view-<oldid>` page is removed and a fresh `view-<newid>` page is created. (Visual layout on the old page is **not** carried over.)
+
+| Two relationships share `(from, to)` but differ in `kind` or `label`.
+| Both are valid; matched by `(from, to, kind, label, index)` and rendered as separate connectors with id `rel-<from>-<to>-<i>`.
+
+| The architect reverses a connector in draw.io.
+| Detected as a `Deleted(A→B)` + `Added(B→A)` pair; `applyRelSwap` updates the existing relationship in place to preserve `kind`, `label`, `description`.
+
+| The architect adds a draw.io page without a `bausteinsicht_id` page id (i.e. not `view-*`).
+| `sync` ignores it and leaves it untouched.
+
+| The architect adds an mxCell to a view page without a `bausteinsicht_id`.
+| Forward sync does not touch it. It is treated as user content.
+
+| `--relayout` is passed.
+| Every element on every view page is re-positioned by the layout engine, even those previously moved by hand.
+
+| The model file is empty or `null`.
+| Loader returns `model file is empty or contains a null JSON root`.
+
+| The model file exceeds 10 MiB.
+| Loader returns `file size X exceeds limit of Y bytes`.
+
+| Element nesting exceeds 50.
+| `FlattenElements` returns an error before any sync logic runs.
+
+| The user clears an element title in draw.io (BR-008).
+| The empty title is dropped; warning emitted; no model write.
+|===
+
+== Determinism and threading
+
+* Iteration order over Go maps is randomized; the sync engine sorts ids before emitting changes so that the JSON summary is stable.
+* `bausteinsicht watch` serializes sync runs through a mutex and a `syncing` flag (re-entrancy guard); fsnotify events that arrive while a sync is in progress are dropped (the next event after the sync ends will trigger a re-sync).
+* `make test-race` runs the entire test suite with `-race`; benchmarks are in `internal/sync/bench_test.go`.
+
+== Error envelope
+
+When `--format json` is set, all error returns are emitted to stderr by `cmd/bausteinsicht/root.go::ExecuteRoot`:
+
+[source,json]
+----
+{"error":"<message>","code":1}
+----
+
+The `code` field mirrors the process exit code (1 or 2).
+
+== Extension points
+
+* `ConflictResolver` interface — allows alternative resolution strategies (draw.io wins, interactive, three-way merge).
+* `bausteinsicht_template_version` — versioned template format.
+* `Element.Tags` and `Element.Metadata` — declared in `types.go` but not currently used by the sync engine; reserved for future filters / annotations (see Open Questions).


### PR DESCRIPTION
Adds a complete documentation set under `src/docs/`, derived from the current codebase, CLI surface, error messages, and tests:

- PRD-001 with FR/NFR IDs traceable to code
- Specification: use cases (Cockburn + PlantUML activity diagrams), CLI spec, data models, acceptance criteria (Gherkin tied to test names), and a dedicated sync specification
- arc42: master file plus all 12 chapters with C4 PlantUML views; six Nygard ADRs (DSL, CLI framework, sync strategy, conflict policy, XML library, embedded templates), each with a Pugh matrix
- OPEN_QUESTIONS.adoc enumerating every assumption that could not be verified from the code alone