### PR TITLE
feat: Relationship Cardinality & Data Flow Annotations (#289)

### DIFF
--- a/cmd/bausteinsicht/graph.go
+++ b/cmd/bausteinsicht/graph.go
@@ -95,7 +95,7 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 		fmt.Fprintf(&sb, "Cycles Found: %d\n", len(result.Cycles))
 		sb.WriteString("--------\n")
 		for idx, cycle := range result.Cycles {
-			sb.WriteString(fmt.Sprintf("Cycle %d (length %d): %s\n", idx+1, cycle.Length, strings.Join(cycle.Elements, " → ")))
+			fmt.Fprintf(&sb, "Cycle %d (length %d): %s\n", idx+1, cycle.Length, strings.Join(cycle.Elements, " → "))
 		}
 		sb.WriteString("\n")
 	} else {
@@ -114,9 +114,9 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 				cycleCount++
 			}
 		}
-		sb.WriteString(fmt.Sprintf("Strongly Connected Components: %d\n", len(result.Components)))
+		fmt.Fprintf(&sb, "Strongly Connected Components: %d\n", len(result.Components))
 		if cycleCount > 0 {
-			sb.WriteString(fmt.Sprintf("  (includes %d cycle(s))\n", cycleCount))
+			fmt.Fprintf(&sb, "  (includes %d cycle(s))\n", cycleCount)
 		}
 		sb.WriteString("--------\n")
 		for _, comp := range result.Components {

--- a/cmd/bausteinsicht/graph.go
+++ b/cmd/bausteinsicht/graph.go
@@ -121,7 +121,7 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 		sb.WriteString("--------\n")
 		for _, comp := range result.Components {
 			if comp.IsCycle {
-				sb.WriteString(fmt.Sprintf("Component %d (CYCLE): %v\n", comp.ID+1, comp.Elements))
+				fmt.Fprintf(&sb, "Component %d (CYCLE): %v\n", comp.ID+1, comp.Elements)
 			}
 		}
 		sb.WriteString("\n")
@@ -149,8 +149,8 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 			if len(elemName) > 22 {
 				elemName = elemName[:19] + "..."
 			}
-			sb.WriteString(fmt.Sprintf("%-22s | %9d | %10d | %11.2f | %9.2f\n",
-				elemName, c.InDegree, c.OutDegree, c.Betweenness, c.Closeness))
+			fmt.Fprintf(&sb, "%-22s | %9d | %10d | %11.2f | %9.2f\n",
+				elemName, c.InDegree, c.OutDegree, c.Betweenness, c.Closeness)
 		}
 		sb.WriteString("\n")
 	}

--- a/cmd/bausteinsicht/health.go
+++ b/cmd/bausteinsicht/health.go
@@ -97,17 +97,17 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 	// Model stats
 	sb.WriteString("Model Statistics\n")
 	sb.WriteString("----------------\n")
-	sb.WriteString(fmt.Sprintf("Elements: %d\n", score.ElementCnt))
-	sb.WriteString(fmt.Sprintf("Relationships: %d\n", score.RelCnt))
-	sb.WriteString(fmt.Sprintf("Views: %d\n\n", score.ViewCnt))
+	fmt.Fprintf(&sb, "Elements: %d\n", score.ElementCnt)
+	fmt.Fprintf(&sb, "Relationships: %d\n", score.RelCnt)
+	fmt.Fprintf(&sb, "Views: %d\n\n", score.ViewCnt)
 
 	// Category scores
 	sb.WriteString("Category Scores\n")
 	sb.WriteString("---------------\n")
 	for _, cat := range score.Categories {
-		sb.WriteString(fmt.Sprintf("%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100))
+		fmt.Fprintf(&sb, "%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100)
 		if cat.Details != "" {
-			sb.WriteString(fmt.Sprintf("  Details: %s\n", cat.Details))
+			fmt.Fprintf(&sb, "  Details: %s\n", cat.Details)
 		}
 	}
 
@@ -118,10 +118,10 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 
 		for _, cat := range score.Categories {
 			if len(cat.Findings) > 0 {
-				sb.WriteString(fmt.Sprintf("\n%s (%d findings):\n", cat.Category, len(cat.Findings)))
+				fmt.Fprintf(&sb, "\n%s (%d findings):\n", cat.Category, len(cat.Findings))
 				for _, f := range cat.Findings {
-					sb.WriteString(fmt.Sprintf("  [%s] %s\n", f.Severity, f.Title))
-					sb.WriteString(fmt.Sprintf("         %s\n", f.Message))
+					fmt.Fprintf(&sb, "  [%s] %s\n", f.Severity, f.Title)
+					fmt.Fprintf(&sb, "         %s\n", f.Message)
 				}
 			}
 		}

--- a/cmd/bausteinsicht/health.go
+++ b/cmd/bausteinsicht/health.go
@@ -102,8 +102,8 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 	sb.WriteString(fmt.Sprintf("Views: %d\n\n", score.ViewCnt))
 
 	// Category scores
-	sb.WriteString(fmt.Sprintf("Category Scores\n"))
-	sb.WriteString(fmt.Sprintf("---------------\n"))
+	sb.WriteString("Category Scores\n")
+	sb.WriteString("---------------\n")
 	for _, cat := range score.Categories {
 		sb.WriteString(fmt.Sprintf("%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100))
 		if cat.Details != "" {
@@ -113,8 +113,8 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 
 	// Findings
 	if len(score.Categories) > 0 {
-		sb.WriteString(fmt.Sprintf("\nFindings\n"))
-		sb.WriteString(fmt.Sprintf("--------\n"))
+		sb.WriteString("\nFindings\n")
+		sb.WriteString("--------\n")
 
 		for _, cat := range score.Categories {
 			if len(cat.Findings) > 0 {

--- a/internal/graph/types.go
+++ b/internal/graph/types.go
@@ -35,9 +35,7 @@ type GraphAnalysis struct {
 
 // NodeInfo holds temporary computation data for graph algorithms.
 type NodeInfo struct {
-	index     int
-	lowlink   int
-	onStack   bool
-	inDegree  int
-	outDegree int
+	index   int
+	lowlink int
+	onStack bool
 }

--- a/internal/health/analyzer.go
+++ b/internal/health/analyzer.go
@@ -199,7 +199,8 @@ func (a *Analyzer) scoreDeprecation(elems map[string]*model.Element) CategorySco
 	active := 0
 
 	for id, elem := range elems {
-		if elem.Status == model.StatusDeprecated {
+		switch elem.Status {
+		case model.StatusDeprecated:
 			deprecated++
 			findings = append(findings, Finding{
 				Category: CategoryDeprecation,
@@ -208,7 +209,7 @@ func (a *Analyzer) scoreDeprecation(elems map[string]*model.Element) CategorySco
 				Message:  fmt.Sprintf("element %q is marked as deprecated", id),
 				Elements: []string{id},
 			})
-		} else if elem.Status == model.StatusDeployed || elem.Status == "" {
+		case model.StatusDeployed, "":
 			active++
 		}
 	}

--- a/internal/model/cardinality_test.go
+++ b/internal/model/cardinality_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestValidateCardinality(t *testing.T) {
+	tests := []struct {
+		name          string
+		cardinality   string
+		shouldBeValid bool
+	}{
+		{"OneToOne", "1:1", true},
+		{"OneToMany", "1:N", true},
+		{"ManyToMany", "N:N", true},
+		{"Empty", "", true}, // cardinality is optional
+		{"Invalid", "1:0", false},
+		{"Invalid", "M:N", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &BausteinsichtModel{
+				Specification: Specification{
+					Elements: map[string]ElementKind{
+						"system": {Notation: "box"},
+					},
+				},
+				Model: map[string]Element{
+					"a": {Kind: "system", Title: "A"},
+					"b": {Kind: "system", Title: "B"},
+				},
+				Relationships: []Relationship{
+					{From: "a", To: "b", Cardinality: tt.cardinality},
+				},
+			}
+
+			errs := Validate(m)
+			hasError := len(errs) > 0
+
+			if tt.shouldBeValid && hasError {
+				t.Errorf("expected valid cardinality %q, got error: %v", tt.cardinality, errs)
+			}
+			if !tt.shouldBeValid && !hasError {
+				t.Errorf("expected invalid cardinality %q to have error", tt.cardinality)
+			}
+		})
+	}
+}
+
+func TestValidateDataFlow(t *testing.T) {
+	tests := []struct {
+		name          string
+		dataFlow      string
+		shouldBeValid bool
+	}{
+		{"Sync", "sync", true},
+		{"Async", "async", true},
+		{"RequestResponse", "request/response", true},
+		{"PublishSubscribe", "publish/subscribe", true},
+		{"Empty", "", true}, // dataFlow is optional
+		{"Invalid", "callback", false},
+		{"Invalid", "stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &BausteinsichtModel{
+				Specification: Specification{
+					Elements: map[string]ElementKind{
+						"system": {Notation: "box"},
+					},
+				},
+				Model: map[string]Element{
+					"a": {Kind: "system", Title: "A"},
+					"b": {Kind: "system", Title: "B"},
+				},
+				Relationships: []Relationship{
+					{From: "a", To: "b", DataFlow: tt.dataFlow},
+				},
+			}
+
+			errs := Validate(m)
+			hasError := len(errs) > 0
+
+			if tt.shouldBeValid && hasError {
+				t.Errorf("expected valid dataFlow %q, got error: %v", tt.dataFlow, errs)
+			}
+			if !tt.shouldBeValid && !hasError {
+				t.Errorf("expected invalid dataFlow %q to have error", tt.dataFlow)
+			}
+		})
+	}
+}
+
+func TestCardinalityAnnotations(t *testing.T) {
+	m := &BausteinsichtModel{
+		Specification: Specification{
+			Elements: map[string]ElementKind{
+				"service": {Notation: "component"},
+			},
+		},
+		Model: map[string]Element{
+			"api":      {Kind: "service", Title: "API"},
+			"database": {Kind: "service", Title: "Database"},
+		},
+		Relationships: []Relationship{
+			{From: "api", To: "database", Cardinality: "1:N", DataFlow: "sync", Label: "queries"},
+		},
+	}
+
+	errs := Validate(m)
+	if len(errs) > 0 {
+		t.Fatalf("expected valid model, got errors: %v", errs)
+	}
+
+	rel := m.Relationships[0]
+	if rel.Cardinality != "1:N" {
+		t.Errorf("expected cardinality 1:N, got %q", rel.Cardinality)
+	}
+	if rel.DataFlow != "sync" {
+		t.Errorf("expected dataFlow sync, got %q", rel.DataFlow)
+	}
+}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -53,6 +53,34 @@ func DecisionBadgeColor(status ADRStatus) string {
 	}
 }
 
+// Relationship cardinality values
+const (
+	CardinalityOneToOne   = "1:1"
+	CardinalityOneToMany  = "1:N"
+	CardinalityManyToMany = "N:N"
+)
+
+var ValidCardinalities = []string{
+	CardinalityOneToOne,
+	CardinalityOneToMany,
+	CardinalityManyToMany,
+}
+
+// Data flow annotation values
+const (
+	DataFlowSync             = "sync"
+	DataFlowAsync            = "async"
+	DataFlowRequestResponse  = "request/response"
+	DataFlowPublishSubscribe = "publish/subscribe"
+)
+
+var ValidDataFlows = []string{
+	DataFlowSync,
+	DataFlowAsync,
+	DataFlowRequestResponse,
+	DataFlowPublishSubscribe,
+}
+
 // Config holds top-level configuration for diagram generation.
 type Config struct {
 	Metadata *bool  `json:"metadata,omitempty"`
@@ -225,6 +253,8 @@ type Relationship struct {
 	Kind        string   `json:"kind,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Decisions   []string `json:"decisions,omitempty"`
+	Cardinality string   `json:"cardinality,omitempty"`
+	DataFlow    string   `json:"dataFlow,omitempty"`
 }
 
 type View struct {

--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -153,6 +153,40 @@ func validateRelationships(m *BausteinsichtModel) []ValidationError {
 			}
 		}
 
+		// Validate cardinality
+		if rel.Cardinality != "" {
+			valid := false
+			for _, c := range ValidCardinalities {
+				if rel.Cardinality == c {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				errs = append(errs, ValidationError{
+					Path:    path,
+					Message: fmt.Sprintf("invalid cardinality %q (valid: %v)", rel.Cardinality, ValidCardinalities),
+				})
+			}
+		}
+
+		// Validate data flow
+		if rel.DataFlow != "" {
+			valid := false
+			for _, df := range ValidDataFlows {
+				if rel.DataFlow == df {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				errs = append(errs, ValidationError{
+					Path:    path,
+					Message: fmt.Sprintf("invalid dataFlow %q (valid: %v)", rel.DataFlow, ValidDataFlows),
+				})
+			}
+		}
+
 		// Detect fully duplicate relationships (same from, to, kind, and label). (#117, #142)
 		// Multiple relationships between the same pair are allowed if they
 		// differ in kind or label.

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -185,12 +185,10 @@
     "Relationship": {
       "properties": {
         "cardinality": {
-          "type": "string",
-          "enum": ["1:1", "1:N", "N:N"]
+          "type": "string"
         },
         "dataFlow": {
-          "type": "string",
-          "enum": ["sync", "async", "request/response", "publish/subscribe"]
+          "type": "string"
         },
         "decisions": {
           "items": {

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -184,6 +184,14 @@
     },
     "Relationship": {
       "properties": {
+        "cardinality": {
+          "type": "string",
+          "enum": ["1:1", "1:N", "N:N"]
+        },
+        "dataFlow": {
+          "type": "string",
+          "enum": ["sync", "async", "request/response", "publish/subscribe"]
+        },
         "decisions": {
           "items": {
             "type": "string"


### PR DESCRIPTION
Fixes #289

## Summary
Adds support for cardinality and data flow annotations on relationships, enabling precise communication of integration patterns and data relationship semantics in architecture models.

## Changes
- **internal/model/types.go**: 
  - Added Cardinality field to Relationship struct (supports 1:1, 1:N, N:N)
  - Added DataFlow field to Relationship struct (supports sync, async, request/response, publish/subscribe)
  - Added ValidCardinalities and ValidDataFlows constant lists
- **internal/model/validate.go**: 
  - Extended validateRelationships() to validate cardinality values
  - Extended validateRelationships() to validate dataFlow values
  - Provides clear error messages for invalid values
- **internal/model/cardinality_test.go**:
  - Comprehensive tests for valid/invalid cardinality values
  - Comprehensive tests for valid/invalid dataFlow values
  - Tests for annotation combinations

## Design
- **Optional Fields**: Both cardinality and dataFlow are optional, maintaining backward compatibility
- **Validation**: Invalid values are caught during model validation
- **Flexible**: Supports various integration patterns (synchronous, asynchronous, pub/sub)
- **Extensible**: Easy to add new cardinality or data flow types

## Example Usage
```jsonc
{
  "relationships": [
    {
      "from": "service1",
      "to": "service2",
      "label": "queries database",
      "cardinality": "1:N",
      "dataFlow": "sync"
    },
    {
      "from": "eventBus",
      "to": "consumers",
      "cardinality": "1:N",
      "dataFlow": "publish/subscribe"
    }
  ]
}
```

## Test Plan
- [x] Unit tests: All cardinality and dataFlow values tested
- [x] Validation: Invalid cardinality and dataFlow values rejected
- [x] Backward compatibility: Relationships without annotations still valid
- [x] Build succeeds: go build ./cmd/bausteinsicht
- [x] Tests pass: go test ./internal/model/...

🤖 Generated with [Claude Code](https://claude.com/claude-code)