### PR TITLE
feat: Metric Overlays — Heatmap on Architecture Diagram (#294)

### DIFF
--- a/cmd/bausteinsicht/overlay.go
+++ b/cmd/bausteinsicht/overlay.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+	"github.com/docToolchain/Bausteinsicht/internal/overlay"
+	"github.com/spf13/cobra"
+)
+
+func newOverlayCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "overlay",
+		Short: "Apply or remove metric heatmap overlays on architecture diagrams",
+		Long:  "Load external metrics (error rate, coverage, etc.) from JSON and overlay them as a heatmap on draw.io elements. Original styles are preserved.",
+	}
+
+	cmd.AddCommand(newOverlayApplyCmd())
+	cmd.AddCommand(newOverlayRemoveCmd())
+	cmd.AddCommand(newOverlayListCmd())
+
+	return cmd
+}
+
+func newOverlayApplyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply <metrics-file>",
+		Short: "Apply metric heatmap to draw.io diagram",
+		Long:  "Load metrics from JSON file and apply heatmap colors to elements. Original colors are saved in metadata.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			metricsPath := args[0]
+			modelPath, _ := cmd.Flags().GetString("model")
+			metricKey, _ := cmd.Flags().GetString("metric")
+			outputPath, _ := cmd.Flags().GetString("output")
+
+			m, err := model.Load(modelPath)
+			if err != nil {
+				return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+			}
+
+			drawioPath := outputPath
+			if drawioPath == "" {
+				drawioPath = filepath.Join(filepath.Dir(modelPath), "architecture.drawio")
+			}
+
+			mf, err := overlay.LoadMetricsFile(metricsPath)
+			if err != nil {
+				return exitWithCode(fmt.Errorf("loading metrics: %w", err), 2)
+			}
+
+			if metricKey == "" {
+				if len(mf.Metrics) > 0 && len(mf.Metrics[0].Values) > 0 {
+					for k := range mf.Metrics[0].Values {
+						metricKey = k
+						break
+					}
+				}
+				if metricKey == "" {
+					return exitWithCode(fmt.Errorf("no metrics found in file"), 2)
+				}
+			}
+
+			if err := overlay.Apply(drawioPath, mf, metricKey, overlay.DefaultColorScheme); err != nil {
+				return exitWithCode(fmt.Errorf("applying overlay: %w", err), 2)
+			}
+
+			format, _ := cmd.Flags().GetString("format")
+			if format == "json" {
+				out, _ := json.Marshal(map[string]interface{}{
+					"status":  "applied",
+					"metric":  metricKey,
+					"file":    drawioPath,
+					"model":   m.Specification,
+				})
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "✅ Overlay applied: %s (metric: %s)\n", drawioPath, metricKey)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("metric", "", "Metric key to visualize (default: first available)")
+	cmd.Flags().String("output", "", "Output draw.io file (default: architecture.drawio)")
+	return cmd
+}
+
+func newOverlayRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Remove metric overlay from diagram (restore original colors)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			modelPath, _ := cmd.Flags().GetString("model")
+			outputPath, _ := cmd.Flags().GetString("output")
+
+			_, err := model.Load(modelPath)
+			if err != nil {
+				return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+			}
+
+			drawioPath := outputPath
+			if drawioPath == "" {
+				drawioPath = filepath.Join(filepath.Dir(modelPath), "architecture.drawio")
+			}
+
+			if err := overlay.Remove(drawioPath); err != nil {
+				return exitWithCode(fmt.Errorf("removing overlay: %w", err), 2)
+			}
+
+			format, _ := cmd.Flags().GetString("format")
+			if format == "json" {
+				out, _ := json.Marshal(map[string]interface{}{
+					"status": "removed",
+					"file":   drawioPath,
+				})
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "✅ Overlay removed: %s (original colors restored)\n", drawioPath)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().String("output", "", "Output draw.io file (default: architecture.drawio)")
+	return cmd
+}
+
+func newOverlayListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <metrics-file>",
+		Short: "List available metrics in file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			metricsPath := args[0]
+
+			mf, err := overlay.LoadMetricsFile(metricsPath)
+			if err != nil {
+				return exitWithCode(fmt.Errorf("loading metrics: %w", err), 2)
+			}
+
+			format, _ := cmd.Flags().GetString("format")
+			if format == "json" {
+				out, _ := json.Marshal(map[string]interface{}{
+					"source":              mf.Meta.Source,
+					"generated":           mf.Meta.Generated,
+					"metric_descriptions": mf.Meta.MetricDescriptions,
+					"element_count":       len(mf.Metrics),
+				})
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
+			} else {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "📊 Metrics from: %s (%s)\n\n", mf.Meta.Source, mf.Meta.Generated)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Available metrics (%d elements):\n", len(mf.Metrics))
+				for metric, desc := range mf.Meta.MetricDescriptions {
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  • %s: %s\n", metric, desc)
+				}
+			}
+			return nil
+		},
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -76,6 +76,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newWorkspaceCmd())
 	rootCmd.AddCommand(newHealthCmd())
 	rootCmd.AddCommand(newGraphCmd())
+	rootCmd.AddCommand(newOverlayCmd())
 
 	return rootCmd
 }

--- a/internal/overlay/apply.go
+++ b/internal/overlay/apply.go
@@ -1,0 +1,155 @@
+package overlay
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/beevik/etree"
+)
+
+const OriginalFillAttr = "data-original-fill"
+
+func LoadMetricsFile(path string) (*MetricsFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading metrics file: %w", err)
+	}
+	var mf MetricsFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, fmt.Errorf("parsing metrics file: %w", err)
+	}
+	return &mf, nil
+}
+
+func Apply(drawioPath string, metrics *MetricsFile, metricKey string, scheme ColorScheme) error {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(drawioPath); err != nil {
+		return fmt.Errorf("reading draw.io file: %w", err)
+	}
+
+	extracted, err := ExtractMetric(metrics.Metrics, metricKey)
+	if err != nil {
+		return fmt.Errorf("extracting metric %q: %w", metricKey, err)
+	}
+
+	if len(extracted) == 0 {
+		return fmt.Errorf("no elements found for metric %q", metricKey)
+	}
+
+	higherIsBetter := IsMetricBetter(metricKey)
+	normalized := Normalize(extracted, higherIsBetter)
+
+	root := doc.Root()
+	for _, page := range root.FindElements(".//mxGraphModel/root/mxCell") {
+		elementID := page.SelectAttrValue("id", "")
+		if elementID == "" || elementID == "0" || elementID == "1" {
+			continue
+		}
+
+		if normVal, ok := normalized[elementID]; ok {
+			applyColor(page, normVal, scheme)
+		}
+	}
+
+	if err := doc.WriteToFile(drawioPath); err != nil {
+		return fmt.Errorf("writing draw.io file: %w", err)
+	}
+	return nil
+}
+
+func Remove(drawioPath string) error {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(drawioPath); err != nil {
+		return fmt.Errorf("reading draw.io file: %w", err)
+	}
+
+	root := doc.Root()
+	for _, cell := range root.FindElements(".//mxGraphModel/root/mxCell") {
+		originalFill := cell.SelectAttrValue(OriginalFillAttr, "")
+		if originalFill != "" {
+			geometry := cell.FindElement("mxGeometry")
+			if geometry != nil {
+				style := geometry.SelectAttrValue("style", "")
+				if style != "" {
+					style = updateStyleFill(style, originalFill)
+					geometry.CreateAttr("style", style)
+				}
+			}
+			cell.RemoveAttr(OriginalFillAttr)
+		}
+	}
+
+	if err := doc.WriteToFile(drawioPath); err != nil {
+		return fmt.Errorf("writing draw.io file: %w", err)
+	}
+	return nil
+}
+
+func applyColor(cell *etree.Element, normalized float64, scheme ColorScheme) {
+	color := ColorForValue(normalized, scheme)
+
+	geometry := cell.FindElement("mxGeometry")
+	if geometry == nil {
+		return
+	}
+
+	style := geometry.SelectAttrValue("style", "")
+	originalFill := geometry.SelectAttrValue("fillColor", "")
+
+	if originalFill == "" {
+		originalFill = "#ffffff"
+	}
+	if cell.SelectAttrValue(OriginalFillAttr, "") == "" {
+		cell.CreateAttr(OriginalFillAttr, originalFill)
+	}
+
+	style = updateStyleFill(style, color)
+	geometry.CreateAttr("style", style)
+}
+
+func updateStyleFill(style, color string) string {
+	if style == "" {
+		return "fillColor=" + color
+	}
+
+	result := ""
+	hasKey := false
+	for _, part := range parseStyleParts(style) {
+		if len(part) > 0 && startsWithKey(part, "fillColor") {
+			result += "fillColor=" + color + ";"
+			hasKey = true
+		} else {
+			if part != "" {
+				result += part + ";"
+			}
+		}
+	}
+	if !hasKey {
+		result += "fillColor=" + color + ";"
+	}
+	return result
+}
+
+func parseStyleParts(style string) []string {
+	var result []string
+	var current string
+	for _, ch := range style {
+		if ch == ';' {
+			if current != "" {
+				result = append(result, current)
+				current = ""
+			}
+		} else {
+			current += string(ch)
+		}
+	}
+	if current != "" {
+		result = append(result, current)
+	}
+	return result
+}
+
+func startsWithKey(part, key string) bool {
+	return len(part) >= len(key) && part[:len(key)] == key
+}

--- a/internal/overlay/normalize.go
+++ b/internal/overlay/normalize.go
@@ -1,0 +1,92 @@
+package overlay
+
+import (
+	"cmp"
+	"slices"
+)
+
+func IsMetricBetter(metricName string) bool {
+	goodMetrics := map[string]bool{
+		"coverage":       true,
+		"uptime":         true,
+		"deploy_freq":    true,
+		"success_rate":   true,
+		"availability":   true,
+	}
+	badMetrics := map[string]bool{
+		"error_rate":     true,
+		"latency":        true,
+		"p99":            true,
+		"p99_ms":         true,
+		"response_time":  true,
+		"cpu_usage":      true,
+		"memory_usage":   true,
+		"error_count":    true,
+		"failures":       true,
+	}
+
+	if goodMetrics[metricName] {
+		return true
+	}
+	if badMetrics[metricName] {
+		return false
+	}
+	return false
+}
+
+func Normalize(metrics []NormalizedMetric, higherIsBetter bool) map[string]float64 {
+	if len(metrics) == 0 {
+		return make(map[string]float64)
+	}
+
+	values := make([]float64, len(metrics))
+	for i, m := range metrics {
+		values[i] = m.Value
+	}
+
+	min := slices.Min(values)
+	max := slices.Max(values)
+	span := max - min
+
+	result := make(map[string]float64)
+	for _, m := range metrics {
+		normalized := 0.0
+		if span > 0 {
+			normalized = (m.Value - min) / span
+		}
+		if !higherIsBetter {
+			normalized = 1 - normalized
+		}
+		result[m.ElementID] = normalized
+	}
+	return result
+}
+
+func ColorForValue(normalized float64, scheme ColorScheme) string {
+	switch {
+	case normalized < 0.25:
+		return scheme.Green
+	case normalized < 0.50:
+		return scheme.Yellow
+	case normalized < 0.75:
+		return scheme.Orange
+	default:
+		return scheme.Red
+	}
+}
+
+func ExtractMetric(metrics []ElementMetric, metricKey string) ([]NormalizedMetric, error) {
+	result := make([]NormalizedMetric, 0, len(metrics))
+	for _, m := range metrics {
+		if val, ok := m.Values[metricKey]; ok {
+			result = append(result, NormalizedMetric{
+				ElementID: m.ElementID,
+				Value:     val,
+			})
+		}
+	}
+	slices.SortFunc(result, func(a, b NormalizedMetric) int {
+		return cmp.Compare(a.ElementID, b.ElementID)
+	})
+	return result, nil
+}

--- a/internal/overlay/normalize_test.go
+++ b/internal/overlay/normalize_test.go
@@ -1,0 +1,130 @@
+package overlay
+
+import (
+	"testing"
+)
+
+func TestNormalize_HigherIsBetter(t *testing.T) {
+	metrics := []NormalizedMetric{
+		{ElementID: "a", Value: 50},
+		{ElementID: "b", Value: 100},
+		{ElementID: "c", Value: 0},
+	}
+
+	result := Normalize(metrics, true)
+
+	if result["c"] != 0 {
+		t.Errorf("expected c=0 (lowest), got %f", result["c"])
+	}
+	if result["b"] != 1 {
+		t.Errorf("expected b=1 (highest), got %f", result["b"])
+	}
+	if result["a"] != 0.5 {
+		t.Errorf("expected a=0.5 (middle), got %f", result["a"])
+	}
+}
+
+func TestNormalize_LowerIsBetter(t *testing.T) {
+	metrics := []NormalizedMetric{
+		{ElementID: "a", Value: 50},
+		{ElementID: "b", Value: 100},
+		{ElementID: "c", Value: 0},
+	}
+
+	result := Normalize(metrics, false)
+
+	if result["c"] != 1 {
+		t.Errorf("expected c=1 (lowest value, best), got %f", result["c"])
+	}
+	if result["b"] != 0 {
+		t.Errorf("expected b=0 (highest value, worst), got %f", result["b"])
+	}
+	if result["a"] != 0.5 {
+		t.Errorf("expected a=0.5 (middle), got %f", result["a"])
+	}
+}
+
+func TestNormalize_AllSameValues(t *testing.T) {
+	metrics := []NormalizedMetric{
+		{ElementID: "a", Value: 50},
+		{ElementID: "b", Value: 50},
+		{ElementID: "c", Value: 50},
+	}
+
+	result := Normalize(metrics, true)
+
+	if result["a"] != 0 || result["b"] != 0 || result["c"] != 0 {
+		t.Errorf("expected all 0 when values are identical, got %v", result)
+	}
+}
+
+func TestColorForValue(t *testing.T) {
+	tests := []struct {
+		normalized float64
+		expected   string
+	}{
+		{0.1, "#d5e8d4"},  // Green
+		{0.3, "#fff2cc"},  // Yellow
+		{0.6, "#ffe6cc"},  // Orange
+		{0.9, "#f8cecc"},  // Red
+	}
+
+	for _, tc := range tests {
+		result := ColorForValue(tc.normalized, DefaultColorScheme)
+		if result != tc.expected {
+			t.Errorf("normalized=%f: expected %s, got %s", tc.normalized, tc.expected, result)
+		}
+	}
+}
+
+func TestIsMetricBetter(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"coverage", true},
+		{"uptime", true},
+		{"deploy_freq", true},
+		{"error_rate", false},
+		{"latency", false},
+		{"p99_ms", false},
+		{"unknown_metric", false},
+	}
+
+	for _, tc := range tests {
+		result := IsMetricBetter(tc.name)
+		if result != tc.expected {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, result)
+		}
+	}
+}
+
+func TestExtractMetric(t *testing.T) {
+	metrics := []ElementMetric{
+		{
+			ElementID: "service-b",
+			Values:    map[string]float64{"error_rate": 2.0, "coverage": 95},
+		},
+		{
+			ElementID: "service-a",
+			Values:    map[string]float64{"error_rate": 5.0, "coverage": 80},
+		},
+	}
+
+	result, err := ExtractMetric(metrics, "error_rate")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Errorf("expected 2 results, got %d", len(result))
+	}
+
+	if result[0].ElementID != "service-a" || result[1].ElementID != "service-b" {
+		t.Errorf("expected sorted by elementID, got %+v", result)
+	}
+
+	if result[0].Value != 5.0 || result[1].Value != 2.0 {
+		t.Errorf("expected correct values, got %+v", result)
+	}
+}

--- a/internal/overlay/types.go
+++ b/internal/overlay/types.go
@@ -1,5 +1,9 @@
 package overlay
 
+import (
+	"encoding/json"
+)
+
 type MetricsFile struct {
 	Meta    MetaInfo       `json:"meta"`
 	Metrics []ElementMetric `json:"metrics"`
@@ -13,7 +17,26 @@ type MetaInfo struct {
 
 type ElementMetric struct {
 	ElementID string             `json:"elementId"`
-	Values    map[string]float64 `json:"values,flatten"`
+	Values    map[string]float64
+}
+
+func (em *ElementMetric) UnmarshalJSON(data []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	em.Values = make(map[string]float64)
+	for key, val := range raw {
+		if key == "elementId" {
+			if str, ok := val.(string); ok {
+				em.ElementID = str
+			}
+		} else if num, ok := val.(float64); ok {
+			em.Values[key] = num
+		}
+	}
+	return nil
 }
 
 type NormalizedMetric struct {

--- a/internal/overlay/types.go
+++ b/internal/overlay/types.go
@@ -1,0 +1,36 @@
+package overlay
+
+type MetricsFile struct {
+	Meta    MetaInfo       `json:"meta"`
+	Metrics []ElementMetric `json:"metrics"`
+}
+
+type MetaInfo struct {
+	Generated           string            `json:"generated"`
+	Source              string            `json:"source"`
+	MetricDescriptions  map[string]string `json:"metric_descriptions"`
+}
+
+type ElementMetric struct {
+	ElementID string             `json:"elementId"`
+	Values    map[string]float64 `json:"values,flatten"`
+}
+
+type NormalizedMetric struct {
+	ElementID string
+	Value     float64
+}
+
+type ColorScheme struct {
+	Green  string
+	Yellow string
+	Orange string
+	Red    string
+}
+
+var DefaultColorScheme = ColorScheme{
+	Green:  "#d5e8d4",
+	Yellow: "#fff2cc",
+	Orange: "#ffe6cc",
+	Red:    "#f8cecc",
+}


### PR DESCRIPTION
Closes #294

## Summary
- Implemented metric heatmap overlay system for architecture diagrams
- Load external metrics (error rate, coverage, deployment freq, etc.) from JSON
- Automatic normalization across elements with intelligent higher-is-better detection
- Non-destructive: original colors preserved in metadata and restorable
- Color scale: green→yellow→orange→red based on normalized metric values

## CLI Usage
```bash
bausteinsicht overlay apply metrics.json --metric error_rate
bausteinsicht overlay remove
bausteinsicht overlay list metrics.json
```

## Test plan
- [x] All unit tests pass (6/6 normalize, color, extraction tests)
- [x] Build passes with no errors
- [x] Normalization algorithm verified for higher-is-better and lower-is-better metrics
- [x] Color assignment correct across 4-level scale
- [x] Metric extraction handles missing keys gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)