### PR TITLE
fix(sync): validate relationship endpoints during reverse sync (#329)

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -42,7 +42,7 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResul
 		if swaps[relSwapKey{ch.From, ch.To, ch.Type}] {
 			continue // handled as part of a swap pair
 		}
-		applyRelationshipChange(ch, m, result)
+		applyRelationshipChange(ch, m, flatModel, result)
 	}
 
 	// Apply swaps: update direction in-place, preserving kind/label/description.
@@ -195,7 +195,7 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 	}
 }
 
-func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, result *ReverseResult) {
+func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
 		updated := false
@@ -245,6 +245,18 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 		}
 
 	case Added:
+		// Validate that both endpoints exist in the model before adding (#329).
+		// Prevents stale relationships from old draw.io files being imported after model replacement.
+		if _, fromExists := flatModel[ch.From]; !fromExists {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Relationship %q->%q rejected: From element %q does not exist in model", ch.From, ch.To, ch.From))
+			return
+		}
+		if _, toExists := flatModel[ch.To]; !toExists {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Relationship %q->%q rejected: To element %q does not exist in model", ch.From, ch.To, ch.To))
+			return
+		}
 		m.Relationships = append(m.Relationships, model.Relationship{
 			From:  ch.From,
 			To:    ch.To,

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -291,7 +291,8 @@ func TestApplyReverse_EmptyTitleSkipped(t *testing.T) {
 }
 
 func TestApplyReverse_RelationshipAdded(t *testing.T) {
-	m := emptyModel()
+	m := modelWithRel("x", "y", "")
+	m.Relationships = []model.Relationship{} // clear the initial relationship for this test
 	cs := relChangeSet("x", "y", Added, "", "", "uses")
 
 	r := ApplyReverse(cs, m)
@@ -305,6 +306,33 @@ func TestApplyReverse_RelationshipAdded(t *testing.T) {
 	}
 	if r.RelationshipsCreated != 1 {
 		t.Errorf("expected RelationshipsCreated=1, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", r.Warnings)
+	}
+}
+
+// TestApplyReverse_RelationshipAddedStaleElementsRejected verifies that
+// relationships referencing non-existent elements are rejected during reverse sync (#329).
+func TestApplyReverse_RelationshipAddedStaleElementsRejected(t *testing.T) {
+	m := modelWithRel("x", "y", "")
+	m.Relationships = []model.Relationship{} // clear the initial relationship for this test
+	cs := relChangeSet("nonexistent", "y", Added, "", "", "uses")
+
+	r := ApplyReverse(cs, m)
+
+	if len(m.Relationships) != 0 {
+		t.Fatalf("expected 0 relationships (stale rejected), got %d", len(m.Relationships))
+	}
+	if r.RelationshipsCreated != 0 {
+		t.Errorf("expected RelationshipsCreated=0, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) == 0 {
+		t.Errorf("expected warning about stale relationship, got none")
+	}
+	warnText := strings.Join(r.Warnings, "; ")
+	if !strings.Contains(warnText, "nonexistent") || !strings.Contains(warnText, "does not exist") {
+		t.Errorf("expected warning mentioning non-existent element, got: %s", warnText)
 	}
 }
 


### PR DESCRIPTION
## Summary

When replacing model content and running sync, reverse sync would import relationships from the old draw.io file referencing non-existent elements in the new model, causing validation errors.

## Solution

- Validate that both From and To elements exist in the model before adding a relationship during reverse sync
- Reject stale relationships with a warning instead of silently adding broken references  
- Preserve existing relationship updates/deletions (they already work correctly)
- Add test to prevent regression

## Testing

All sync tests passing, including new test for stale relationship rejection.

Fixes: #329