### PR TITLE
fix(lint): resolve staticcheck issues breaking main CI

### DIFF
--- a/cmd/bausteinsicht/graph.go
+++ b/cmd/bausteinsicht/graph.go
@@ -95,7 +95,7 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 		fmt.Fprintf(&sb, "Cycles Found: %d\n", len(result.Cycles))
 		sb.WriteString("--------\n")
 		for idx, cycle := range result.Cycles {
-			sb.WriteString(fmt.Sprintf("Cycle %d (length %d): %s\n", idx+1, cycle.Length, strings.Join(cycle.Elements, " → ")))
+			fmt.Fprintf(&sb, "Cycle %d (length %d): %s\n", idx+1, cycle.Length, strings.Join(cycle.Elements, " → "))
 		}
 		sb.WriteString("\n")
 	} else {
@@ -114,9 +114,9 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 				cycleCount++
 			}
 		}
-		sb.WriteString(fmt.Sprintf("Strongly Connected Components: %d\n", len(result.Components)))
+		fmt.Fprintf(&sb, "Strongly Connected Components: %d\n", len(result.Components))
 		if cycleCount > 0 {
-			sb.WriteString(fmt.Sprintf("  (includes %d cycle(s))\n", cycleCount))
+			fmt.Fprintf(&sb, "  (includes %d cycle(s))\n", cycleCount)
 		}
 		sb.WriteString("--------\n")
 		for _, comp := range result.Components {

--- a/cmd/bausteinsicht/graph.go
+++ b/cmd/bausteinsicht/graph.go
@@ -121,7 +121,7 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 		sb.WriteString("--------\n")
 		for _, comp := range result.Components {
 			if comp.IsCycle {
-				sb.WriteString(fmt.Sprintf("Component %d (CYCLE): %v\n", comp.ID+1, comp.Elements))
+				fmt.Fprintf(&sb, "Component %d (CYCLE): %v\n", comp.ID+1, comp.Elements)
 			}
 		}
 		sb.WriteString("\n")
@@ -149,8 +149,8 @@ func formatGraphReport(result *graph.GraphAnalysis, cyclesOnly, showCentrality b
 			if len(elemName) > 22 {
 				elemName = elemName[:19] + "..."
 			}
-			sb.WriteString(fmt.Sprintf("%-22s | %9d | %10d | %11.2f | %9.2f\n",
-				elemName, c.InDegree, c.OutDegree, c.Betweenness, c.Closeness))
+			fmt.Fprintf(&sb, "%-22s | %9d | %10d | %11.2f | %9.2f\n",
+				elemName, c.InDegree, c.OutDegree, c.Betweenness, c.Closeness)
 		}
 		sb.WriteString("\n")
 	}

--- a/cmd/bausteinsicht/health.go
+++ b/cmd/bausteinsicht/health.go
@@ -97,17 +97,17 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 	// Model stats
 	sb.WriteString("Model Statistics\n")
 	sb.WriteString("----------------\n")
-	sb.WriteString(fmt.Sprintf("Elements: %d\n", score.ElementCnt))
-	sb.WriteString(fmt.Sprintf("Relationships: %d\n", score.RelCnt))
-	sb.WriteString(fmt.Sprintf("Views: %d\n\n", score.ViewCnt))
+	fmt.Fprintf(&sb, "Elements: %d\n", score.ElementCnt)
+	fmt.Fprintf(&sb, "Relationships: %d\n", score.RelCnt)
+	fmt.Fprintf(&sb, "Views: %d\n\n", score.ViewCnt)
 
 	// Category scores
 	sb.WriteString("Category Scores\n")
 	sb.WriteString("---------------\n")
 	for _, cat := range score.Categories {
-		sb.WriteString(fmt.Sprintf("%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100))
+		fmt.Fprintf(&sb, "%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100)
 		if cat.Details != "" {
-			sb.WriteString(fmt.Sprintf("  Details: %s\n", cat.Details))
+			fmt.Fprintf(&sb, "  Details: %s\n", cat.Details)
 		}
 	}
 
@@ -118,10 +118,10 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 
 		for _, cat := range score.Categories {
 			if len(cat.Findings) > 0 {
-				sb.WriteString(fmt.Sprintf("\n%s (%d findings):\n", cat.Category, len(cat.Findings)))
+				fmt.Fprintf(&sb, "\n%s (%d findings):\n", cat.Category, len(cat.Findings))
 				for _, f := range cat.Findings {
-					sb.WriteString(fmt.Sprintf("  [%s] %s\n", f.Severity, f.Title))
-					sb.WriteString(fmt.Sprintf("         %s\n", f.Message))
+					fmt.Fprintf(&sb, "  [%s] %s\n", f.Severity, f.Title)
+					fmt.Fprintf(&sb, "         %s\n", f.Message)
 				}
 			}
 		}

--- a/cmd/bausteinsicht/health.go
+++ b/cmd/bausteinsicht/health.go
@@ -102,8 +102,8 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 	sb.WriteString(fmt.Sprintf("Views: %d\n\n", score.ViewCnt))
 
 	// Category scores
-	sb.WriteString(fmt.Sprintf("Category Scores\n"))
-	sb.WriteString(fmt.Sprintf("---------------\n"))
+	sb.WriteString("Category Scores\n")
+	sb.WriteString("---------------\n")
 	for _, cat := range score.Categories {
 		sb.WriteString(fmt.Sprintf("%s: %.1f/100 (weight: %.0f%%)\n", cat.Category, cat.Score, cat.Weight*100))
 		if cat.Details != "" {
@@ -113,8 +113,8 @@ func formatHealthReport(score *health.HealthScore, summaryOnly bool) string {
 
 	// Findings
 	if len(score.Categories) > 0 {
-		sb.WriteString(fmt.Sprintf("\nFindings\n"))
-		sb.WriteString(fmt.Sprintf("--------\n"))
+		sb.WriteString("\nFindings\n")
+		sb.WriteString("--------\n")
 
 		for _, cat := range score.Categories {
 			if len(cat.Findings) > 0 {

--- a/internal/graph/types.go
+++ b/internal/graph/types.go
@@ -35,9 +35,7 @@ type GraphAnalysis struct {
 
 // NodeInfo holds temporary computation data for graph algorithms.
 type NodeInfo struct {
-	index     int
-	lowlink   int
-	onStack   bool
-	inDegree  int
-	outDegree int
+	index   int
+	lowlink int
+	onStack bool
 }

--- a/internal/health/analyzer.go
+++ b/internal/health/analyzer.go
@@ -199,7 +199,8 @@ func (a *Analyzer) scoreDeprecation(elems map[string]*model.Element) CategorySco
 	active := 0
 
 	for id, elem := range elems {
-		if elem.Status == model.StatusDeprecated {
+		switch elem.Status {
+		case model.StatusDeprecated:
 			deprecated++
 			findings = append(findings, Finding{
 				Category: CategoryDeprecation,
@@ -208,7 +209,7 @@ func (a *Analyzer) scoreDeprecation(elems map[string]*model.Element) CategorySco
 				Message:  fmt.Sprintf("element %q is marked as deprecated", id),
 				Elements: []string{id},
 			})
-		} else if elem.Status == model.StatusDeployed || elem.Status == "" {
+		case model.StatusDeployed, "":
 			active++
 		}
 	}


### PR DESCRIPTION
## Summary
- Fixes 9 staticcheck lint issues introduced by PRs #368 and #369 that are currently breaking `main` branch CI
- `cmd/bausteinsicht/graph.go`: use `fmt.Fprintf` instead of `WriteString(fmt.Sprintf(...))` (QF1012)
- `cmd/bausteinsicht/health.go`: remove unnecessary `fmt.Sprintf` on string literals (S1039)  
- `internal/health/analyzer.go`: use tagged switch on `elem.Status` (QF1003)
- `internal/graph/types.go`: remove unused `inDegree`/`outDegree` fields from `NodeInfo` (unused)

## Test plan
- [ ] CI passes (lint + build + tests)
- [ ] No functional changes — all fixes are purely code style/cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)