### PR TITLE
fix(ci): correct broken SHA pins in publish-test-reports workflow

### DIFF
--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Download test report artifact
-        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816ea7201 # v3
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3
         with:
           workflow: go.yml
           workflow_conclusion: success
@@ -72,7 +72,7 @@ jobs:
           EOF
 
       - name: Setup Pages
-        uses: actions/configure-pages@8621a4fbcff3ef4a4f215528626f2362a96a3e5d # v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3


### PR DESCRIPTION
## Summary
- Fixes two invalid SHA pins in `.github/workflows/publish-test-reports.yml` that caused all deployments to fail with "Unable to resolve action"
- `dawidd6/action-download-artifact@v3`: SHA had a typo in the last 6 characters (`ea7201` → `f540fe`)  
- `actions/configure-pages@v4`: SHA pointed to a non-existent commit, replaced with correct v4 SHA

The workflow has been failing on every push to `main` since it was introduced.

## Test plan
- [ ] `publish-test-reports` workflow completes successfully after next main CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)