### PR TITLE
fix(ci): add pages: write to job-level permissions

### DIFF
--- a/.github/workflows/publish-test-reports.yml
+++ b/.github/workflows/publish-test-reports.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}/test-reports/


### PR DESCRIPTION
## Summary
- The `publish-reports` job was failing with HTTP 403 on the "Deploy to GitHub Pages" step
- Job-level `permissions` override top-level permissions — `pages: write` was declared at the top level but missing from the job level, so the effective permission set lacked it
- Fix: add `pages: write` to the job-level `permissions` block

## Test plan
- [ ] Next `publish-test-reports` run completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)