### PR TITLE
fix(sonar): exclude all *_test.go from coverage analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,10 +16,8 @@ sonar.exclusions=vendor,.git,.devcontainer
 sonar.go.coverage.reportPaths=coverage.out
 
 # Coverage Thresholds
-sonar.coverage.exclusions=**/cmd/**/*_test.go,**/*_integration_test.go,**/testdata/**
-sonar.coverage.minBranchCoverageRatio=85
-sonar.coverage.minCoverageRatio=85
-sonar.coverage.minLinesCovered=10000
+sonar.coverage.exclusions=**/*_test.go,**/testdata/**
+sonar.test.inclusions=**/*_test.go
 
 # Quality Gate Configuration
 sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary

- The `sonar-project.properties` from branch 357 only excluded `**/cmd/**/*_test.go` from coverage analysis
- Go test files in `internal/` were treated as uncovered production code, dropping new-code coverage below 80% on any PR that adds or modifies internal tests
- Removed non-standard `sonar.coverage.min*` properties (coverage thresholds belong in the Quality Gate config, not in project properties)

## Changes

| Before | After |
|--------|-------|
| `sonar.coverage.exclusions=**/cmd/**/*_test.go,...` | `sonar.coverage.exclusions=**/*_test.go,**/testdata/**` |
| *(missing)* | `sonar.test.inclusions=**/*_test.go` |

## Test plan

- [ ] CI runs SonarCloud on this PR — new-code coverage should reflect only production code
- [ ] PRs #333, #379, #384 already carry this fix via their own commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)