### PR TITLE
feat(docs): inject GoatCounter analytics into the published site

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -82,6 +82,13 @@ jobs:
           EOF
           fi
 
+      # Deploy-only web analytics (GoatCounter). No-op when the secret is unset
+      # (forks, local builds), so the snippet never ends up in the templates.
+      - name: Inject analytics
+        env:
+          GOATCOUNTER_ENDPOINT: ${{ secrets.GOATCOUNTER_ENDPOINT }}
+        run: ./scripts/injectAnalytics.sh build/microsite/output
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/scripts/goatcounter-snippet.html
+++ b/scripts/goatcounter-snippet.html
@@ -1,0 +1,9 @@
+<!-- GoatCounter analytics — injected at deploy time only, never part of the templates.
+     Pinned to count.v5.js with Subresource Integrity (sha384) so a CDN compromise of
+     gc.zgo.at cannot inject altered code. When bumping the version, update both the
+     src URL and the integrity hash from https://www.goatcounter.com/help/countjs-versions
+     and re-verify with: openssl dgst -sha384 -binary count.vN.js | openssl base64 -A -->
+<script data-goatcounter="__GOATCOUNTER_ENDPOINT__"
+        async src="https://gc.zgo.at/count.v5.js"
+        crossorigin="anonymous"
+        integrity="sha384-atnOLvQb9t+jTSipvd75X2yginT4PjVbqDdlJAmxMm+wYElFmeR6EmLP5bYeoRVQ"></script>

--- a/scripts/injectAnalytics.sh
+++ b/scripts/injectAnalytics.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# injectAnalytics.sh TARGET_DIR
+#
+# Inject the GoatCounter analytics snippet into every *.html below TARGET_DIR,
+# right before the first </head>. This runs at deploy time only (see .ci.sh →
+# publish_doc), so the snippet never ends up in the jBake templates or in a
+# locally generated site.
+#
+# The endpoint is taken from the GOATCOUNTER_ENDPOINT environment variable
+# (a GitHub Actions secret). If it is empty or unset, this script is a no-op,
+# so forks and local builds without the secret stay analytics-free.
+
+set -o nounset -o pipefail -o errexit
+
+TARGET_DIR="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SNIPPET_TEMPLATE="${SCRIPT_DIR}/goatcounter-snippet.html"
+
+if [ -z "${GOATCOUNTER_ENDPOINT:-}" ]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT not set — skipping analytics injection."
+    exit 0
+fi
+
+# The endpoint is substituted into a double-quoted HTML attribute. Require a clean
+# https:// URL so a misconfigured secret cannot break the markup or inject content.
+# Fail the build rather than publish broken or unsafe HTML.
+endpoint_re='^https://[^[:space:]"'\''<>]+$'
+if [[ ! "${GOATCOUNTER_ENDPOINT}" =~ $endpoint_re ]]; then
+    echo "injectAnalytics: GOATCOUNTER_ENDPOINT must be a plain https:// URL without quotes or angle brackets." >&2
+    exit 1
+fi
+
+if [ -z "${TARGET_DIR}" ] || [ ! -d "${TARGET_DIR}" ]; then
+    echo "injectAnalytics: target directory '${TARGET_DIR}' does not exist." >&2
+    exit 1
+fi
+
+if [ ! -f "${SNIPPET_TEMPLATE}" ]; then
+    echo "injectAnalytics: snippet template '${SNIPPET_TEMPLATE}' not found." >&2
+    exit 1
+fi
+
+# Substitute the placeholder with the real endpoint (bash replace handles the
+# slashes in the URL safely, unlike a sed expression).
+template="$(cat "${SNIPPET_TEMPLATE}")"
+snippet="${template//__GOATCOUNTER_ENDPOINT__/${GOATCOUNTER_ENDPOINT}}"
+
+# Hand the resolved snippet to awk via a temp file so multi-line content and
+# any special characters survive untouched.
+snippet_file="$(mktemp)"
+trap 'rm -f "${snippet_file}"' EXIT
+printf '%s\n' "${snippet}" > "${snippet_file}"
+
+injected=0
+skipped=0
+nohead=0
+
+while IFS= read -r -d '' file; do
+    if grep -q 'data-goatcounter' "${file}"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    # awk exits non-zero when it found no </head> to insert before, so the file
+    # is left untouched and counted separately instead of as an injection.
+    if awk -v snippetfile="${snippet_file}" '
+        BEGIN {
+            snippet = ""
+            while ((getline line < snippetfile) > 0) {
+                snippet = snippet line "\n"
+            }
+        }
+        # Insert immediately before the first </head>, even when it shares a
+        # line with other markup (minified / single-line HTML). index()/substr()
+        # avoid sub()s special handling of & and \ in the replacement.
+        !done {
+            p = index($0, "</head>")
+            if (p > 0) {
+                printf "%s%s%s\n", substr($0, 1, p - 1), snippet, substr($0, p)
+                done = 1
+                next
+            }
+        }
+        { print }
+        END { exit(done ? 0 : 1) }
+    ' "${file}" > "${file}.tmp"; then
+        mv "${file}.tmp" "${file}"
+        injected=$((injected + 1))
+    else
+        rm -f "${file}.tmp"
+        nohead=$((nohead + 1))
+        echo "injectAnalytics: no </head> in '${file}', left unchanged." >&2
+    fi
+done < <(find "${TARGET_DIR}" -type f -name '*.html' -print0)
+
+echo "injectAnalytics: injected into ${injected} file(s), skipped ${skipped} already-instrumented, ${nohead} without </head>."


### PR DESCRIPTION
## What

Adds privacy-friendly GoatCounter web analytics to the published documentation site, adopting the proven pattern from [docToolchain](https://github.com/docToolchain/docToolchain) (`scripts/goatcounter-snippet.html` + `scripts/injectAnalytics.sh`, copied verbatim):

- The snippet is **injected at deploy time only** — it never appears in templates or local builds.
- Pinned to `count.v5.js` with a Subresource Integrity hash, so a CDN compromise of gc.zgo.at cannot inject altered code.
- The endpoint comes from the `GOATCOUNTER_ENDPOINT` repository secret. **Unset secret → no-op**, so forks and local builds stay analytics-free.
- The endpoint is validated (`https://` URL, no quotes/angle brackets) — a misconfigured secret fails the build instead of publishing broken HTML.
- Injection runs after the test-report download in `gh-pages.yml`, so the report pages are counted too.

## Verified locally

- No-op without the secret ✅
- Malformed endpoint rejected with exit 1 ✅
- Snippet injected before `</head>`, idempotent on re-run (skips already-instrumented files) ✅
- Workflow YAML validates ✅

## Prerequisite before this takes effect

The repository secret `GOATCOUNTER_ENDPOINT` must be set (e.g. `https://<code>.goatcounter.com/count`). Until then the deploy behaves exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
