### PR TITLE
docs(site): showcase governance, evolution and interop features on landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,10 @@ The security report at `src/docs/security/2026-03-01-security-review.adoc` is a 
 - Automated tool results change
 
 ### Future Ideas (Out of Scope for v1)
-- As-Is / To-Be architecture comparison
-- Structurizr/LikeC4 import
 - CI/CD validation pipeline
+- XMI import from Enterprise Architect (issue #401)
+
+(As-Is/To-Be comparison and Structurizr/LikeC4 import are implemented — see the `diff` and `import` commands.)
 
 ## Risk Radar Assessment
 

--- a/src/docs/landingpage.gsp
+++ b/src/docs/landingpage.gsp
@@ -62,7 +62,8 @@
                         </h4>
                         <p class="card-text">
                             JSON model format that LLMs read and write natively.
-                            CLI commands let AI agents modify your architecture.
+                            CLI commands and an interactive REPL let AI agents
+                            and humans modify your architecture.
                             IDE autocompletion via JSON Schema — no plugin needed.
                         </p>
                     </div>
@@ -130,13 +131,69 @@
             </div>
         </div>
 
-        <!-- Comparison -->
+        <!-- More than diagrams -->
+        <h2 style="text-align: center; margin-bottom: 2rem; color: #1a365d;">More than diagrams</h2>
+
+        <div class="row row-cols-1 row-cols-md-3 mb-4">
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
+                    <div class="card-body">
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128737;&#65039;</span>
+                            Governance
+                        </h4>
+                        <p class="card-text">
+                            <code>lint</code> checks your architecture constraints,
+                            <code>health</code> scores the model,
+                            <code>graph</code> finds dependency cycles, and
+                            <code>stale</code> detects forgotten elements.
+                            Architecture Decision Records managed right next to the model.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
+                    <div class="card-body">
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128200;</span>
+                            Evolution
+                        </h4>
+                        <p class="card-text">
+                            Versioned snapshots with <code>diff</code> and <code>restore</code>.
+                            Compare as-is and to-be architectures.
+                            Generate an architecture changelog between any two points in time.
+                            Your architecture history becomes first-class.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="col mb-4">
+                <div class="card h-100 shadow-sm border-0" style="border-left: 4px solid #2d5a87 !important;">
+                    <div class="card-body">
+                        <h4 class="card-title" style="color: #1a365d;">
+                            <span style="font-size: 1.5rem; margin-right: 0.5rem;">&#128268;</span>
+                            Interop &amp; Export
+                        </h4>
+                        <p class="card-text">
+                            Import from Structurizr DSL and LikeC4.
+                            Export to C4-PlantUML, Mermaid, DOT, D2, Structurizr DSL,
+                            sequence diagrams, AsciiDoc/Markdown tables, and PNG/SVG —
+                            plus metric heatmap overlays on your diagrams.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Migration -->
         <div class="text-center mb-4 p-4">
-            <h4 style="color: #1a365d;">Inspired by the best, built for draw.io</h4>
+            <h4 style="color: #1a365d;">Migrating from Structurizr or LikeC4?</h4>
             <p class="text-muted">
                 Bausteinsicht takes the best ideas from
                 <strong>Structurizr</strong> and <strong>LikeC4</strong>
-                and combines them with the world's most popular free diagramming tool.
+                and combines them with the world's most popular free diagramming tool —
+                and <code>bausteinsicht import</code> brings your existing model along.
             </p>
         </div>
 


### PR DESCRIPTION
## What

The landing page still only sold the bidirectional-sync story while the CLI has grown to 30 commands. This PR brings it up to date:

- New **"More than diagrams"** section with three cards:
  - **Governance** — `lint`, `health`, `graph`, `stale`, ADR management
  - **Evolution** — versioned snapshots with diff/restore, as-is/to-be comparison, architecture changelog
  - **Interop & Export** — import from Structurizr DSL/LikeC4; export to C4-PlantUML, Mermaid, DOT, D2, Structurizr DSL, sequence diagrams, tables, PNG/SVG; metric heatmap overlays
- The Structurizr/LikeC4 paragraph is reframed from "inspired by" to a **migration path** (`bausteinsicht import`)
- The LLM-Friendly card now mentions the interactive REPL
- CLAUDE.md: removed implemented features (as-is/to-be diff, Structurizr/LikeC4 import) from the Future Ideas list; added the planned XMI import (#401)

All command names and formats verified against the current `--help` output. Existing hero, the four core feature cards, and the "How it works" example are unchanged. Static HTML only, no JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
