### PR TITLE
feat(harness): doc-check skill — spec/architecture gate at ticket start and review

### DIFF
--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -6,11 +6,11 @@ description: >
   'review': verifies that docs, implementation, and tests are consistent before merge.
 license: MIT
 compatibility:
-  os: [linux, macos, windows]
+  os: [linux, macos]
   tools: []
 metadata:
   author: docToolchain
-  version: "1.0"
+  version: "1.1"
 allowed-tools: Bash Read Write Edit Glob Grep
 argument-hint: "start [#<issue-number>] | review"
 ---
@@ -26,7 +26,7 @@ spec and architecture documents are always kept in sync with implementation and 
 |------|---------|--------------|
 | `src/docs/spec/01_use_cases.adoc` | User-facing use cases | New CLI command or user-visible behavior added |
 | `src/docs/spec/02_cli_specification.adoc` | CLI command reference | Any `--flag`, command name, or output format changes |
-| `src/docs/spec/03_data_models.adoc` | JSONC model schema | `internal/model/types.go` changes |
+| `src/docs/spec/03_data_models.adoc` | JSONC model schema | `internal/model/types.go` or `schemas/bausteinsicht.schema.json` changes |
 | `src/docs/spec/04_acceptance_criteria.adoc` | Acceptance criteria per feature | New feature scope |
 | `src/docs/spec/05_sync_specification.adoc` | Sync engine behavior spec | `internal/sync/` changes |
 | `src/docs/arc42/chapters/05_building_block_view.adoc` | Package/component structure | New package added or renamed |
@@ -42,17 +42,29 @@ spec and architecture documents are always kept in sync with implementation and 
 
 1. **Gather scope**
    - If an issue number was given: read it with `gh issue view <N> --json title,body,labels`
+     - If the body is empty, infer scope from title + labels + branch name
    - If no issue: use `git branch --show-current` and `git log main...HEAD --oneline` to infer scope from branch name and commits
+   - Check if implementation commits already exist on this branch: `git diff main...HEAD --name-only -- '*.go' ':!*_test.go'`
+     - If Go files are already changed: note "running start post-implementation (catch-up mode)" — proceed normally but skip the docs-first claim
    - Summarize in one sentence what will change
 
 2. **Map scope to docs** — for each doc in the table above, decide: **needs update / no change needed / unsure**
-   Use these rules:
-   - New or changed `cmd/bausteinsicht/*.go` file → check spec/02, spec/01
-   - Changes to `internal/model/types.go` or schema → check spec/03
-   - Changes to `internal/sync/` → check spec/05
-   - New `internal/<pkg>/` directory → check arc42/05 and arc42/06
-   - A new user-facing behavior without an existing acceptance criterion → check spec/04
-   - A significant design tradeoff (new library, new format, new algorithm) → new ADR
+
+   Use these rules (apply **all** that match, not just the first):
+
+   | If the scope touches… | Check these docs |
+   |----------------------|-----------------|
+   | New or changed `cmd/bausteinsicht/*.go` | spec/01, spec/02 |
+   | `internal/model/types.go` or `schemas/bausteinsicht.schema.json` or `internal/schema/` | spec/03 |
+   | `internal/sync/` | spec/05 |
+   | Any other existing `internal/<pkg>/` with user-visible output change | spec/01, spec/02 |
+   | New `internal/<pkg>/` directory | arc42/05, arc42/06 |
+   | New user-facing behavior without an existing acceptance criterion | spec/04 |
+   | A significant design tradeoff (new library, new format, new algorithm) | new ADR |
+
+   **Catch-all:** Any change to an existing `internal/` package that alters CLI-visible behavior,
+   output format, or public API → check spec/01 and spec/02. When in doubt, flag as "unsure"
+   rather than "no change needed."
 
 3. **For each doc that needs update:**
    - Read the current content of that doc
@@ -72,9 +84,9 @@ spec and architecture documents are always kept in sync with implementation and 
 5. **Commit** all doc changes with:
    ```
    docs: update spec/architecture for <scope>
-
-   Closes (partial): #<issue>
    ```
+   If an issue number is known, append: `Closes (partial): #<issue>`
+   Omit the trailer if no issue number was provided.
 
 ## Mode: `review`
 
@@ -94,23 +106,34 @@ spec and architecture documents are always kept in sync with implementation and 
    - `impl`: changed `.go` files (non-test)
    - `tests`: changed `_test.go` files
    - `docs`: changed files under `src/docs/`
-   - `schema`: changed `schemas/`
+   - `schema`: changed files under `schemas/` or `internal/schema/`
 
 3. **Check consistency** — answer each question:
 
    **A. Implementation coverage in docs**
-   For each changed impl file: is there a doc that describes the new/changed behavior?
-   - `cmd/bausteinsicht/*.go` → look for matching content in `spec/02_cli_specification.adoc`
-   - `internal/model/types.go` → look for matching content in `spec/03_data_models.adoc`
-   - `internal/sync/*.go` → look for matching content in `spec/05_sync_specification.adoc`
-   - `internal/<new-pkg>/` → look for matching content in `arc42/05_building_block_view.adoc`
+   For each changed impl file and each changed schema file: is there a doc that describes the new/changed behavior?
+   - `cmd/bausteinsicht/*.go` → look for matching content in `spec/02_cli_specification.adoc` and `spec/01_use_cases.adoc`
+   - `internal/model/types.go` or `schemas/bausteinsicht.schema.json` or `internal/schema/` → look in `spec/03_data_models.adoc`
+   - `internal/sync/*.go` → look in `spec/05_sync_specification.adoc`
+   - Any other `internal/<pkg>/*.go` that adds/removes/renames a user-visible output or CLI flag → look in `spec/01` and `spec/02`
+   - New `internal/<pkg>/` directory → look in `arc42/05_building_block_view.adoc`
 
    **B. Doc coverage in tests**
    For each new acceptance criterion or spec section added in docs: is there a test exercising it?
-   - Grep the test files for the feature name or flag name mentioned in the doc change
+   - Grep the test files for the feature name or flag name mentioned in the doc change:
+     ```bash
+     grep -rn "<feature-name>" --include="*_test.go" .
+     ```
 
-   **C. No stale docs**
-   For each deleted or renamed symbol (function, flag, struct) in impl: is the old name still referenced in docs?
+   **C. No stale docs** — check for renamed/deleted symbols still referenced in docs:
+   ```bash
+   # Find deleted/renamed exported symbols
+   git diff main...HEAD -- '*.go' ':!*_test.go' | grep '^-' | grep -oE '(func|type|const) [A-Z][A-Za-z]+' | awk '{print $2}' | sort -u
+   # Then grep docs for each name
+   grep -rn "<OldSymbolName>" src/docs/
+   ```
+   A stale reference to a removed/renamed symbol in docs is always ❌.
+   A changed-but-undocumented symbol is ⚠️ — unless it is a CLI flag, command name, or public schema field, in which case it is ❌.
 
 4. **Output a review report:**
 

--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: doc-check
+description: >
+  Checks and updates spec/architecture documentation at ticket start and at review.
+  'start': identifies which docs need updating for a ticket and applies the updates.
+  'review': verifies that docs, implementation, and tests are consistent before merge.
+license: MIT
+compatibility:
+  os: [linux, macos, windows]
+  tools: []
+metadata:
+  author: docToolchain
+  version: "1.0"
+allowed-tools: Bash Read Write Edit Glob Grep
+argument-hint: "start [#<issue-number>] | review"
+---
+
+# Doc-Check Skill
+
+You are a documentation consistency guardian for the Bausteinsicht project. You ensure that
+spec and architecture documents are always kept in sync with implementation and tests.
+
+## Project Doc Structure
+
+| Path | Content | Update when… |
+|------|---------|--------------|
+| `src/docs/spec/01_use_cases.adoc` | User-facing use cases | New CLI command or user-visible behavior added |
+| `src/docs/spec/02_cli_specification.adoc` | CLI command reference | Any `--flag`, command name, or output format changes |
+| `src/docs/spec/03_data_models.adoc` | JSONC model schema | `internal/model/types.go` changes |
+| `src/docs/spec/04_acceptance_criteria.adoc` | Acceptance criteria per feature | New feature scope |
+| `src/docs/spec/05_sync_specification.adoc` | Sync engine behavior spec | `internal/sync/` changes |
+| `src/docs/arc42/chapters/05_building_block_view.adoc` | Package/component structure | New package added or renamed |
+| `src/docs/arc42/chapters/06_runtime_view.adoc` | Data flows and runtime behavior | New data flow or runtime path |
+| `src/docs/arc42/chapters/08_concepts.adoc` | Cross-cutting concepts | New cross-cutting pattern |
+| `src/docs/arc42/ADRs/` | Architecture decisions | New significant design decision |
+
+## Mode: `start`
+
+**Usage:** `/doc-check start` or `/doc-check start #<issue-number>`
+
+### Steps
+
+1. **Gather scope**
+   - If an issue number was given: read it with `gh issue view <N> --json title,body,labels`
+   - If no issue: use `git branch --show-current` and `git log main...HEAD --oneline` to infer scope from branch name and commits
+   - Summarize in one sentence what will change
+
+2. **Map scope to docs** — for each doc in the table above, decide: **needs update / no change needed / unsure**
+   Use these rules:
+   - New or changed `cmd/bausteinsicht/*.go` file → check spec/02, spec/01
+   - Changes to `internal/model/types.go` or schema → check spec/03
+   - Changes to `internal/sync/` → check spec/05
+   - New `internal/<pkg>/` directory → check arc42/05 and arc42/06
+   - A new user-facing behavior without an existing acceptance criterion → check spec/04
+   - A significant design tradeoff (new library, new format, new algorithm) → new ADR
+
+3. **For each doc that needs update:**
+   - Read the current content of that doc
+   - Write the specific section that needs to change (add/update only the affected section — do not rewrite the whole doc)
+   - Keep AsciiDoc format; follow existing heading levels and style
+   - Note: if an ADR is needed, create `src/docs/arc42/ADRs/ADR-NNN-Name.adoc` using Nygard format with a Weighted Pugh Matrix
+
+4. **Report**
+   Print a table:
+   ```
+   | Doc | Status | Change made |
+   |-----|--------|-------------|
+   | spec/02_cli_specification.adoc | UPDATED | Added --threshold flag to stale command |
+   | arc42/ADRs/ | NO CHANGE | No new design decision |
+   ```
+
+5. **Commit** all doc changes with:
+   ```
+   docs: update spec/architecture for <scope>
+
+   Closes (partial): #<issue>
+   ```
+
+## Mode: `review`
+
+**Usage:** `/doc-check review`
+
+### Steps
+
+1. **Get the diff**
+   ```bash
+   git diff main...HEAD --name-only
+   git diff main...HEAD -- src/docs/
+   git diff main...HEAD -- '*.go' ':!*_test.go'
+   git diff main...HEAD -- '*_test.go'
+   ```
+
+2. **Classify changed files** into four buckets:
+   - `impl`: changed `.go` files (non-test)
+   - `tests`: changed `_test.go` files
+   - `docs`: changed files under `src/docs/`
+   - `schema`: changed `schemas/`
+
+3. **Check consistency** — answer each question:
+
+   **A. Implementation coverage in docs**
+   For each changed impl file: is there a doc that describes the new/changed behavior?
+   - `cmd/bausteinsicht/*.go` → look for matching content in `spec/02_cli_specification.adoc`
+   - `internal/model/types.go` → look for matching content in `spec/03_data_models.adoc`
+   - `internal/sync/*.go` → look for matching content in `spec/05_sync_specification.adoc`
+   - `internal/<new-pkg>/` → look for matching content in `arc42/05_building_block_view.adoc`
+
+   **B. Doc coverage in tests**
+   For each new acceptance criterion or spec section added in docs: is there a test exercising it?
+   - Grep the test files for the feature name or flag name mentioned in the doc change
+
+   **C. No stale docs**
+   For each deleted or renamed symbol (function, flag, struct) in impl: is the old name still referenced in docs?
+
+4. **Output a review report:**
+
+   ```
+   ## Doc-Check Review
+
+   ### ✅ Covered
+   - `internal/stale/detector.go` → `spec/02_cli_specification.adoc` section "stale" updated
+   - New acceptance criterion in spec/04 → test `TestDetect_DeterministicOrder` covers it
+
+   ### ⚠️ Gaps (non-blocking)
+   - `internal/graph/analyzer.go` changed but no doc update found — verify if user-visible
+
+   ### ❌ Inconsistencies (blocking)
+   - Flag `--threshold` added in `stale.go:45` but missing from `spec/02_cli_specification.adoc`
+   - Old name `MarkElements` still referenced in `spec/05` but renamed to `MarkInDrawio` in code
+
+   ### Verdict
+   PASS / NEEDS DOCS / FAIL
+   ```
+
+   Verdict rules:
+   - **PASS**: no ❌ findings
+   - **NEEDS DOCS**: only ⚠️ gaps (suggest doc updates but do not block)
+   - **FAIL**: any ❌ inconsistency found — list exactly what needs to be fixed
+
+5. If verdict is **NEEDS DOCS** or **FAIL**: offer to fix the gaps immediately.

--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -10,7 +10,7 @@ compatibility:
   tools: []
 metadata:
   author: docToolchain
-  version: "1.1"
+  version: "1.2"
 allowed-tools: Bash Read Write Edit Glob Grep
 argument-hint: "start [#<issue-number>] | review"
 ---
@@ -20,18 +20,21 @@ argument-hint: "start [#<issue-number>] | review"
 You are a documentation consistency guardian for the Bausteinsicht project. You ensure that
 spec and architecture documents are always kept in sync with implementation and tests.
 
+**Requires Claude Code.** If running manually (no Claude Code), use the PR template checklist
+as the fallback — it covers the same doc gates.
+
 ## Project Doc Structure
 
 | Path | Content | Update when… |
 |------|---------|--------------|
 | `src/docs/spec/01_use_cases.adoc` | User-facing use cases | New CLI command or user-visible behavior added |
-| `src/docs/spec/02_cli_specification.adoc` | CLI command reference | Any `--flag`, command name, or output format changes |
+| `src/docs/spec/02_cli_specification.adoc` | CLI command reference | Any `--flag`, command name, subcommand rename, or output format changes |
 | `src/docs/spec/03_data_models.adoc` | JSONC model schema | `internal/model/types.go` or `schemas/bausteinsicht.schema.json` changes |
 | `src/docs/spec/04_acceptance_criteria.adoc` | Acceptance criteria per feature | New feature scope |
 | `src/docs/spec/05_sync_specification.adoc` | Sync engine behavior spec | `internal/sync/` changes |
 | `src/docs/arc42/chapters/05_building_block_view.adoc` | Package/component structure | New package added or renamed |
-| `src/docs/arc42/chapters/06_runtime_view.adoc` | Data flows and runtime behavior | New data flow or runtime path |
-| `src/docs/arc42/chapters/08_concepts.adoc` | Cross-cutting concepts | New cross-cutting pattern |
+| `src/docs/arc42/chapters/06_runtime_view.adoc` | Data flows and runtime behavior | New data flow or runtime path within existing or new packages |
+| `src/docs/arc42/chapters/08_concepts.adoc` | Cross-cutting concepts | New cross-cutting pattern (error handling, caching, etc.) |
 | `src/docs/arc42/ADRs/` | Architecture decisions | New significant design decision |
 
 ## Mode: `start`
@@ -44,36 +47,40 @@ spec and architecture documents are always kept in sync with implementation and 
    - If an issue number was given: read it with `gh issue view <N> --json title,body,labels`
      - If the body is empty, infer scope from title + labels + branch name
    - If no issue: use `git branch --show-current` and `git log main...HEAD --oneline` to infer scope from branch name and commits
-   - Check if implementation commits already exist on this branch: `git diff main...HEAD --name-only -- '*.go' ':!*_test.go'`
-     - If Go files are already changed: note "running start post-implementation (catch-up mode)" — proceed normally but skip the docs-first claim
+   - Check if implementation commits already exist on this branch:
+     ```bash
+     git diff main...HEAD --name-only -- '*.go' ':!*_test.go'
+     ```
+     If Go files are already changed: note "running start post-implementation (catch-up mode)" — proceed normally but skip the docs-first claim
    - Summarize in one sentence what will change
 
 2. **Map scope to docs** — for each doc in the table above, decide: **needs update / no change needed / unsure**
 
-   Use these rules (apply **all** that match, not just the first):
+   Apply **all** rules that match (not just the first):
 
    | If the scope touches… | Check these docs |
    |----------------------|-----------------|
-   | New or changed `cmd/bausteinsicht/*.go` | spec/01, spec/02 |
+   | New or changed `cmd/bausteinsicht/*.go` (non-test) | spec/01, spec/02 |
    | `internal/model/types.go` or `schemas/bausteinsicht.schema.json` or `internal/schema/` | spec/03 |
    | `internal/sync/` | spec/05 |
-   | Any other existing `internal/<pkg>/` with user-visible output change | spec/01, spec/02 |
    | New `internal/<pkg>/` directory | arc42/05, arc42/06 |
+   | New runtime data flow within an existing package | arc42/06 |
+   | New cross-cutting pattern (error handling, logging, concurrency model) | arc42/08 |
+   | Any other existing `internal/<pkg>/` with user-visible output change | spec/01, spec/02 |
    | New user-facing behavior without an existing acceptance criterion | spec/04 |
    | A significant design tradeoff (new library, new format, new algorithm) | new ADR |
 
    **Catch-all:** Any change to an existing `internal/` package that alters CLI-visible behavior,
-   output format, or public API → check spec/01 and spec/02. When in doubt, flag as "unsure"
+   output format, or exported API → check spec/01 and spec/02. When in doubt, flag as "unsure"
    rather than "no change needed."
 
 3. **For each doc that needs update:**
    - Read the current content of that doc
    - Write the specific section that needs to change (add/update only the affected section — do not rewrite the whole doc)
    - Keep AsciiDoc format; follow existing heading levels and style
-   - Note: if an ADR is needed, create `src/docs/arc42/ADRs/ADR-NNN-Name.adoc` using Nygard format with a Weighted Pugh Matrix
+   - If an ADR is needed, create `src/docs/arc42/ADRs/ADR-NNN-Name.adoc` using Nygard format with a Weighted Pugh Matrix
 
 4. **Report**
-   Print a table:
    ```
    | Doc | Status | Change made |
    |-----|--------|-------------|
@@ -111,29 +118,43 @@ spec and architecture documents are always kept in sync with implementation and 
 3. **Check consistency** — answer each question:
 
    **A. Implementation coverage in docs**
-   For each changed impl file and each changed schema file: is there a doc that describes the new/changed behavior?
-   - `cmd/bausteinsicht/*.go` → look for matching content in `spec/02_cli_specification.adoc` and `spec/01_use_cases.adoc`
-   - `internal/model/types.go` or `schemas/bausteinsicht.schema.json` or `internal/schema/` → look in `spec/03_data_models.adoc`
-   - `internal/sync/*.go` → look in `spec/05_sync_specification.adoc`
-   - Any other `internal/<pkg>/*.go` that adds/removes/renames a user-visible output or CLI flag → look in `spec/01` and `spec/02`
-   - New `internal/<pkg>/` directory → look in `arc42/05_building_block_view.adoc`
+   Apply the same routing table as `start` step 2 to each changed impl/schema file:
+   - `cmd/bausteinsicht/*.go` → `spec/02` and `spec/01`
+   - `internal/model/types.go` / `schemas/` / `internal/schema/` → `spec/03`
+   - `internal/sync/*.go` → `spec/05`
+   - New `internal/<pkg>/` directory → `arc42/05`, `arc42/06`
+   - New runtime data flow in existing package → `arc42/06`
+   - New cross-cutting pattern → `arc42/08`
+   - Any other `internal/<pkg>/` with user-visible change → `spec/01`, `spec/02`
+   - Significant design tradeoff → new ADR in `src/docs/arc42/ADRs/`
 
    **B. Doc coverage in tests**
-   For each new acceptance criterion or spec section added in docs: is there a test exercising it?
-   - Grep the test files for the feature name or flag name mentioned in the doc change:
-     ```bash
-     grep -rn "<feature-name>" --include="*_test.go" .
-     ```
-
-   **C. No stale docs** — check for renamed/deleted symbols still referenced in docs:
+   For each new acceptance criterion or spec section added: is there a test covering it?
    ```bash
-   # Find deleted/renamed exported symbols
-   git diff main...HEAD -- '*.go' ':!*_test.go' | grep '^-' | grep -oE '(func|type|const) [A-Z][A-Za-z]+' | awk '{print $2}' | sort -u
-   # Then grep docs for each name
-   grep -rn "<OldSymbolName>" src/docs/
+   grep -rn "<feature-name>" --include="*_test.go" .
    ```
-   A stale reference to a removed/renamed symbol in docs is always ❌.
-   A changed-but-undocumented symbol is ⚠️ — unless it is a CLI flag, command name, or public schema field, in which case it is ❌.
+
+   **C. No stale docs** — check for renamed/deleted exported symbols still referenced in docs.
+
+   Two-pass extraction (handles both top-level funcs and methods):
+   ```bash
+   # Pass 1: top-level func/type/const (e.g. "func ParseV2(")
+   git diff main...HEAD -- '*.go' ':!*_test.go' \
+     | grep '^-' \
+     | grep -E '^-\s*(func|type|const)\s+[A-Z]' \
+     | grep -oE '\b[A-Z][A-Za-z0-9_]+' | sort -u
+
+   # Pass 2: methods (e.g. "func (r *Receiver) MethodName(")
+   git diff main...HEAD -- '*.go' ':!*_test.go' \
+     | grep '^-' \
+     | grep -E '^-\s*func\s+\(' \
+     | grep -oE '\)\s+[A-Z][A-Za-z0-9_]+' \
+     | grep -oE '[A-Z][A-Za-z0-9_]+' | sort -u
+   ```
+   Then for each extracted symbol: `grep -rn "<Symbol>" src/docs/`
+
+   - Stale reference to a removed/renamed symbol in docs → always ❌
+   - Changed-but-undocumented symbol → ⚠️, **except**: CLI flag, command name, public schema field → ❌
 
 4. **Output a review report:**
 
@@ -157,7 +178,7 @@ spec and architecture documents are always kept in sync with implementation and 
 
    Verdict rules:
    - **PASS**: no ❌ findings
-   - **NEEDS DOCS**: only ⚠️ gaps (suggest doc updates but do not block)
-   - **FAIL**: any ❌ inconsistency found — list exactly what needs to be fixed
+   - **NEEDS DOCS**: only ⚠️ gaps (suggest updates but do not block)
+   - **FAIL**: any ❌ found — list exactly what needs to be fixed
 
 5. If verdict is **NEEDS DOCS** or **FAIL**: offer to fix the gaps immediately.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,13 +30,15 @@ Closes #XXX
   - Ran `make check` locally
   - No new warnings/errors
   
-- [ ] **Documentation** — run `/doc-check review` for automated check, or fill in manually:
+- [ ] **Documentation** — run `/doc-check review` (Claude Code) or fill in manually:
   - [ ] `spec/01_use_cases.adoc` — updated / N/A (reason: )
-  - [ ] `spec/02_cli_specification.adoc` — updated / N/A (reason: ) ← required if any `--flag` or command changed
-  - [ ] `spec/03_data_models.adoc` — updated / N/A (reason: ) ← required if `types.go` or schema changed
+  - [ ] `spec/02_cli_specification.adoc` — updated / N/A (reason: ) ← required if any `--flag`, command, subcommand rename, or output format changed
+  - [ ] `spec/03_data_models.adoc` — updated / N/A (reason: ) ← required if `types.go` or `schemas/bausteinsicht.schema.json` changed
   - [ ] `spec/04_acceptance_criteria.adoc` — updated / N/A (reason: )
   - [ ] `spec/05_sync_specification.adoc` — updated / N/A (reason: ) ← required if `internal/sync/` changed
   - [ ] `arc42/05_building_block_view.adoc` — updated / N/A (reason: ) ← required if new package added
+  - [ ] `arc42/06_runtime_view.adoc` — updated / N/A (reason: ) ← required if new data flow or runtime path added
+  - [ ] `arc42/08_concepts.adoc` — updated / N/A (reason: ) ← required if new cross-cutting pattern introduced
   - [ ] New ADR created / N/A (reason: )
 
 ## Testing

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,12 +30,14 @@ Closes #XXX
   - Ran `make check` locally
   - No new warnings/errors
   
-- [ ] **Documentation** — run `/doc-check review` to verify, or answer manually:
-  - [ ] `src/docs/spec/02_cli_specification.adoc` — updated if CLI flags/commands changed, or N/A
-  - [ ] `src/docs/spec/03_data_models.adoc` — updated if `internal/model/types.go` changed, or N/A
-  - [ ] `src/docs/spec/05_sync_specification.adoc` — updated if `internal/sync/` changed, or N/A
-  - [ ] `src/docs/arc42/chapters/05_building_block_view.adoc` — updated if new package added, or N/A
-  - [ ] New ADR created if a significant design decision was made, or N/A
+- [ ] **Documentation** — run `/doc-check review` for automated check, or fill in manually:
+  - [ ] `spec/01_use_cases.adoc` — updated / N/A (reason: )
+  - [ ] `spec/02_cli_specification.adoc` — updated / N/A (reason: ) ← required if any `--flag` or command changed
+  - [ ] `spec/03_data_models.adoc` — updated / N/A (reason: ) ← required if `types.go` or schema changed
+  - [ ] `spec/04_acceptance_criteria.adoc` — updated / N/A (reason: )
+  - [ ] `spec/05_sync_specification.adoc` — updated / N/A (reason: ) ← required if `internal/sync/` changed
+  - [ ] `arc42/05_building_block_view.adoc` — updated / N/A (reason: ) ← required if new package added
+  - [ ] New ADR created / N/A (reason: )
 
 ## Testing
 <!-- How was this tested? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,10 +30,12 @@ Closes #XXX
   - Ran `make check` locally
   - No new warnings/errors
   
-- [ ] **Documentation**
-  - Updated README if new feature
-  - Updated arc42 if architecture changed
-  - Added/updated code comments where needed
+- [ ] **Documentation** — run `/doc-check review` to verify, or answer manually:
+  - [ ] `src/docs/spec/02_cli_specification.adoc` — updated if CLI flags/commands changed, or N/A
+  - [ ] `src/docs/spec/03_data_models.adoc` — updated if `internal/model/types.go` changed, or N/A
+  - [ ] `src/docs/spec/05_sync_specification.adoc` — updated if `internal/sync/` changed, or N/A
+  - [ ] `src/docs/arc42/chapters/05_building_block_view.adoc` — updated if new package added, or N/A
+  - [ ] New ADR created if a significant design decision was made, or N/A
 
 ## Testing
 <!-- How was this tested? -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ internal/watcher/      # File-system watcher (fsnotify) for --watch mode
 When starting work on a ticket:
 1. Run `/doc-check start #<issue>` — identifies which spec/architecture docs need updating and applies them before implementation begins (docs-first approach)
 
+> `/doc-check` is a Claude Code skill. Without Claude Code, use the Documentation checklist in the PR template as the manual fallback.
+
 ### PR Merge Policy
 Before merging any PR:
 1. **Doc check** — run `/doc-check review` to verify spec/architecture is consistent with implementation and tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,10 +123,15 @@ internal/watcher/      # File-system watcher (fsnotify) for --watch mode
 
 ## Workflow Rules
 
+### Ticket Start
+When starting work on a ticket:
+1. Run `/doc-check start #<issue>` — identifies which spec/architecture docs need updating and applies them before implementation begins (docs-first approach)
+
 ### PR Merge Policy
 Before merging any PR:
-1. **Security review** on the changes
-2. **Code review** on the changes
+1. **Doc check** — run `/doc-check review` to verify spec/architecture is consistent with implementation and tests
+2. **Security review** on the changes
+3. **Code review** on the changes
 
 ### Security Report
 The security report at `src/docs/security/2026-03-01-security-review.adoc` is a living document. Update it (with a Changelog entry) whenever:


### PR DESCRIPTION
## Summary

Implements Option C from #426 — combines a new Claude Code skill with an enhanced PR template.

- **New skill** `.claude/skills/doc-check/SKILL.md` with two modes:
  - `/doc-check start [#issue]` — maps ticket scope to relevant spec/arc42 docs and updates them before implementation starts (docs-first)
  - `/doc-check review` — verifies docs, implementation, and tests are consistent; outputs PASS / NEEDS DOCS / FAIL verdict with specific gaps
- **PR template** — replaces the vague "Updated arc42 if architecture changed" checkbox with a concrete per-doc checklist (exact file paths) and a reference to `/doc-check review`
- **CLAUDE.md** — adds `/doc-check start` as mandatory first step when picking up a ticket; promotes doc-check to step 1 in the PR merge policy

## How it works

```
/doc-check start #426
→ reads issue, maps scope to docs, updates spec/arc42, commits

/doc-check review
→ diffs impl vs docs vs tests, reports gaps, offers to fix
```

## Test plan

- [ ] `/doc-check start` invoked on a ticket with a CLI change → `spec/02_cli_specification.adoc` updated
- [ ] `/doc-check start` invoked on a ticket with no doc impact → reports "NO CHANGE" for all docs
- [ ] `/doc-check review` on a branch with matching docs+impl → PASS
- [ ] `/doc-check review` on a branch with a flag in code but not in spec → FAIL with specific gap listed
- [ ] PR template shows correct doc checklist on new PRs

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)