### PR TITLE
fix(model): correct $schema URL path from schema/ to schemas/

### DIFF
--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -646,7 +646,7 @@ func slugify(s string) string {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-const schemaURL = "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json"
+const schemaURL = "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schemas/bausteinsicht.schema.json"
 
 // Import reads the LikeC4 DSL file at path and returns an ImportResult.
 func Import(path string) (*importer.ImportResult, error) {

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -676,7 +676,7 @@ func slugify(s string) string {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-const schemaURL = "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json"
+const schemaURL = "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schemas/bausteinsicht.schema.json"
 
 // ImportSource parses a Structurizr DSL string directly (useful for testing).
 func ImportSource(src string) (*importer.ImportResult, error) {

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -2,6 +2,7 @@ package templates_test
 
 import (
 	"encoding/xml"
+	"os"
 	"strings"
 	"testing"
 
@@ -43,6 +44,27 @@ func TestSampleModelValidJSON(t *testing.T) {
 	if !strings.HasPrefix(s, "{") || !strings.HasSuffix(s, "}") {
 		t.Fatalf("SampleModel does not look like a JSON object: starts=%q ends=%q",
 			s[:min(20, len(s))], s[max(0, len(s)-20):])
+	}
+}
+
+// TestSampleModelSchemaURLPathExists guards against the $schema URL drifting
+// from the actual repo directory layout. The bug (#414) was that the embedded
+// sample model referenced ".../main/schema/..." (singular) while the repo
+// directory is "schemas/" (plural), so the scaffolded $schema URL 404'd and
+// out-of-the-box IDE support broke. This test pins the URL's path component to
+// the real on-disk schema file so the two cannot diverge again.
+func TestSampleModelSchemaURLPathExists(t *testing.T) {
+	content := string(templates.SampleModel)
+	if !strings.Contains(content, "/schemas/bausteinsicht.schema.json") {
+		t.Fatalf("SampleModel $schema URL does not reference /schemas/bausteinsicht.schema.json; content head:\n%s",
+			content[:min(200, len(content))])
+	}
+	if strings.Contains(content, "/main/schema/") {
+		t.Fatal("SampleModel $schema URL references singular /main/schema/ which 404s; must be /main/schemas/")
+	}
+	// The path component the URL points at must actually exist in the repo.
+	if _, err := os.Stat("../schemas/bausteinsicht.schema.json"); err != nil {
+		t.Fatalf("schemas/bausteinsicht.schema.json does not exist in repo: %v", err)
 	}
 }
 

--- a/templates/sample-model.jsonc
+++ b/templates/sample-model.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json",
+  "$schema": "https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schemas/bausteinsicht.schema.json",
 
   // Specification: define the element kinds and relationship types used in this model.
   // The order of element kinds determines the layer order in auto-layout


### PR DESCRIPTION
Closes #414

## What was broken
`templates/sample-model.jsonc` (line 2) referenced the JSON Schema at:

```
https://raw.githubusercontent.com/docToolchain/Bausteinsicht/main/schema/bausteinsicht.schema.json
```

But the repo directory is `schemas/` (plural) — there is no `schema/` dir, so the URL returns **404**. Every `bausteinsicht init` project therefore shipped a dead `$schema` link, breaking out-of-the-box IDE autocompletion/validation (quality goal #2 — IDE Support).

The same dead URL was also hardcoded in both importers:
- `internal/importer/likec4/likec4.go` (`schemaURL` const)
- `internal/importer/structurizr/structurizr.go` (`schemaURL` const)

## The fix
Corrected the path from `main/schema/` to `main/schemas/` in all three places. One-character change per site; no adjacent refactoring.

## How it was verified
- **New regression test** `TestSampleModelSchemaURLPathExists` (`templates/embed_test.go`): asserts the embedded sample model's `$schema` contains `/schemas/bausteinsicht.schema.json`, rejects the singular `/main/schema/`, and asserts `schemas/bausteinsicht.schema.json` actually exists on disk — so the URL and the directory layout can't drift apart again.
- **Red→Green:** the test failed before the fix (referenced singular `schema/`) and passes after.
- **Mutation check:** reverting the `sample-model.jsonc` fix made the new test FAIL again; restoring it returned to PASS — confirming the test guards the fix.
- **Full suite:** `go build ./...` and `go test ./...` all green.
- **gofmt:** the new/modified test file `templates/embed_test.go` is gofmt-clean. (The two importer files show pre-existing gofmt findings that already exist on `main` and are out of scope for this one-character bug fix.)

## Note (out of scope)
`grep 'main/schema/'` also matches two non-init doc/example artifacts (`src/docs/arc42/architecture.jsonc`, `examples/online-shop/architecture.jsonc`). They were left untouched to keep this PR to the three scaffolding/importer sites named in the issue; they can be swept in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)