### PR TITLE
fix(export): implement --drawio-path flag and BAUSTEINSICHT_DRAWIO_PATH env var (#420)

### DIFF
--- a/cmd/bausteinsicht/export.go
+++ b/cmd/bausteinsicht/export.go
@@ -24,6 +24,7 @@ func newExportCmd() *cobra.Command {
 	cmd.Flags().String("output", ".", "Output directory")
 	cmd.Flags().Bool("embed-diagram", false, "Embed draw.io XML source in output")
 	cmd.Flags().Float64("scale", 1.0, "Export scale factor (e.g. 2.0 for retina, 3.0 for print); scale > 1 requires hardware GPU")
+	cmd.Flags().String("drawio-path", "", "Path to the draw.io CLI binary (overrides "+export.DrawioPathEnvVar+" and auto-detection)")
 	return cmd
 }
 
@@ -42,6 +43,7 @@ func runExport(cmd *cobra.Command, _ []string) error {
 	outputDir, _ := cmd.Flags().GetString("output")
 	embedDiagram, _ := cmd.Flags().GetBool("embed-diagram")
 	scale, _ := cmd.Flags().GetFloat64("scale")
+	drawioPathFlag, _ := cmd.Flags().GetString("drawio-path")
 
 	if outputDir != "" {
 		if err := validatePathContainment(outputDir); err != nil {
@@ -90,8 +92,9 @@ func runExport(cmd *cobra.Command, _ []string) error {
 		return exitWithCode(fmt.Errorf("loading draw.io file: %w", err), 2)
 	}
 
-	// Detect draw.io CLI binary.
-	binary, err := export.DetectDrawioBinary()
+	// Resolve draw.io CLI binary: --drawio-path flag, then
+	// BAUSTEINSICHT_DRAWIO_PATH env var, then auto-detection.
+	binary, err := export.ResolveDrawioBinary(drawioPathFlag)
 	if err != nil {
 		return exitWithCode(err, 2)
 	}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -25,6 +25,42 @@ type ExportOptions struct {
 // platformPaths is a function variable so tests can override it.
 var platformPaths = platformDrawioPaths
 
+// DrawioPathEnvVar is the environment variable that overrides draw.io binary
+// auto-detection. The --drawio-path flag takes precedence over it.
+const DrawioPathEnvVar = "BAUSTEINSICHT_DRAWIO_PATH"
+
+// ResolveDrawioBinary determines which draw.io CLI binary to use.
+// Precedence (highest first):
+//  1. flagPath — the explicit --drawio-path flag value (if non-empty)
+//  2. BAUSTEINSICHT_DRAWIO_PATH environment variable (if set)
+//  3. auto-detection via DetectDrawioBinary
+//
+// When an explicit path (flag or env) is given, it must point at an existing
+// file; otherwise an error is returned rather than silently falling back to
+// auto-detection, so misconfiguration is surfaced loudly.
+func ResolveDrawioBinary(flagPath string) (string, error) {
+	if flagPath != "" {
+		return verifyExplicitBinary(flagPath, "--drawio-path")
+	}
+	if envPath := os.Getenv(DrawioPathEnvVar); envPath != "" {
+		return verifyExplicitBinary(envPath, DrawioPathEnvVar)
+	}
+	return DetectDrawioBinary()
+}
+
+// verifyExplicitBinary checks that an explicitly configured draw.io path exists
+// and is not a directory, returning a clear error referencing its source.
+func verifyExplicitBinary(path, source string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("draw.io binary from %s not found: %s", source, path)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("draw.io binary from %s is a directory, not an executable: %s", source, path)
+	}
+	return path, nil
+}
+
 // DetectDrawioBinary finds the draw.io CLI binary.
 // Search order:
 //  1. "drawio-export" — devcontainer wrapper (Linux, adds xvfb + --no-sandbox)

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -136,6 +137,20 @@ func TestResolveDrawioBinary_FlagPathNotFound(t *testing.T) {
 	_, err := ResolveDrawioBinary(missing)
 	if err == nil {
 		t.Error("expected error when --drawio-path points at a missing file")
+	}
+}
+
+// TestResolveDrawioBinary_PathIsDirectory verifies that an explicit --drawio-path
+// pointing at a directory (a common misconfiguration) returns a clear error
+// rather than treating the directory as an executable. (#420)
+func TestResolveDrawioBinary_PathIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := ResolveDrawioBinary(dir)
+	if err == nil {
+		t.Fatal("expected error when --drawio-path points at a directory")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Errorf("error should mention it is a directory, got: %v", err)
 	}
 }
 

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -64,6 +64,81 @@ func TestDetectDrawioBinary_ErrorWhenNotFound(t *testing.T) {
 	}
 }
 
+// TestResolveDrawioBinary_FlagWins verifies that an explicit --drawio-path value
+// takes precedence over the BAUSTEINSICHT_DRAWIO_PATH env var and auto-detection.
+// (#420)
+func TestResolveDrawioBinary_FlagWins(t *testing.T) {
+	dir := t.TempDir()
+	flagBin := fakeBinary(t, dir, "flag-drawio")
+	envBin := fakeBinary(t, dir, "env-drawio")
+
+	t.Setenv("BAUSTEINSICHT_DRAWIO_PATH", envBin)
+	// Ensure auto-detection cannot interfere.
+	t.Setenv("PATH", t.TempDir())
+	old := platformPaths
+	platformPaths = func() []string { return nil }
+	t.Cleanup(func() { platformPaths = old })
+
+	bin, err := ResolveDrawioBinary(flagBin)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != flagBin {
+		t.Errorf("flag should win: expected %q, got %q", flagBin, bin)
+	}
+}
+
+// TestResolveDrawioBinary_EnvWhenNoFlag verifies that BAUSTEINSICHT_DRAWIO_PATH
+// is honored when the --drawio-path flag is absent. (#420)
+func TestResolveDrawioBinary_EnvWhenNoFlag(t *testing.T) {
+	dir := t.TempDir()
+	envBin := fakeBinary(t, dir, "env-drawio")
+
+	t.Setenv("BAUSTEINSICHT_DRAWIO_PATH", envBin)
+	// Ensure auto-detection cannot interfere.
+	t.Setenv("PATH", t.TempDir())
+	old := platformPaths
+	platformPaths = func() []string { return nil }
+	t.Cleanup(func() { platformPaths = old })
+
+	bin, err := ResolveDrawioBinary("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != envBin {
+		t.Errorf("env should be used: expected %q, got %q", envBin, bin)
+	}
+}
+
+// TestResolveDrawioBinary_AutoDetectWhenNeither verifies that auto-detection runs
+// when neither the flag nor the env var are set. (#420)
+func TestResolveDrawioBinary_AutoDetectWhenNeither(t *testing.T) {
+	dir := t.TempDir()
+	autoBin := fakeBinary(t, dir, "drawio")
+
+	t.Setenv("BAUSTEINSICHT_DRAWIO_PATH", "")
+	t.Setenv("PATH", dir)
+
+	bin, err := ResolveDrawioBinary("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != autoBin {
+		t.Errorf("auto-detect should be used: expected %q, got %q", autoBin, bin)
+	}
+}
+
+// TestResolveDrawioBinary_FlagPathNotFound verifies that an explicit --drawio-path
+// pointing at a non-existent file returns an error rather than silently falling
+// back to auto-detection. (#420)
+func TestResolveDrawioBinary_FlagPathNotFound(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := ResolveDrawioBinary(missing)
+	if err == nil {
+		t.Error("expected error when --drawio-path points at a missing file")
+	}
+}
+
 func TestBuildExportArgs(t *testing.T) {
 	args := BuildExportArgs(ExportOptions{
 		Format:       "png",


### PR DESCRIPTION
## What was broken

Fixes #420. When the draw.io binary is not found, `bausteinsicht export` printed an error advertising a `--drawio-path` flag and a `BAUSTEINSICHT_DRAWIO_PATH` environment variable (`internal/export/export.go` lines 100-101, formerly 70-71). Neither actually existed:

- The `--drawio-path` flag was never registered on the export command.
- `BAUSTEINSICHT_DRAWIO_PATH` was read nowhere in the codebase.

So the troubleshooting advice told users to use features that did not exist — useless in exactly the containers/CI scenarios where auto-detection fails.

## The fix

Implement both, as recommended in the issue:

- New `export.ResolveDrawioBinary(flagPath string)` resolves the draw.io binary with precedence **flag > env > auto-detection**:
  1. `--drawio-path` flag value (if non-empty)
  2. `BAUSTEINSICHT_DRAWIO_PATH` env var (if set)
  3. `DetectDrawioBinary()` auto-detection
- An explicit path (flag or env) must point at an existing, non-directory file; otherwise a clear error is returned (referencing the source) instead of silently falling back to auto-detection, so misconfiguration is surfaced loudly.
- The export command registers the `--drawio-path` flag and routes binary resolution through `ResolveDrawioBinary`.

Minimal change: the existing `DetectDrawioBinary` auto-detection and the already-correct error text are untouched.

## How it was verified

New table of tests in `internal/export/export_test.go`:
- `TestResolveDrawioBinary_FlagWins` — flag value wins over env var and auto-detection.
- `TestResolveDrawioBinary_EnvWhenNoFlag` — env var honored when the flag is absent.
- `TestResolveDrawioBinary_AutoDetectWhenNeither` — auto-detection runs when neither is set.
- `TestResolveDrawioBinary_FlagPathNotFound` — explicit missing path errors rather than falling back.

**Mutation check:** with the fix logic reverted (so `ResolveDrawioBinary` always called `DetectDrawioBinary`), the new tests FAILED. Restoring the fix made them pass — confirming the tests actually guard the behavior.

**Test/format results:**
- `go build ./...` — clean.
- `go test ./...` — all green.
- `gofmt -l` on the three touched files — clean.

Manual check: `bausteinsicht export --help` now lists `--drawio-path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)