### PR TITLE
fix(cmd): generate-template produces working sync templates (#419)

### DIFF
--- a/cmd/bausteinsicht/generate_template_test.go
+++ b/cmd/bausteinsicht/generate_template_test.go
@@ -166,7 +166,9 @@ func TestGenerateTemplate_ContainsAllKinds(t *testing.T) {
 
 	kinds := []string{"person", "system", "database", "external_system"}
 	for _, kind := range kinds {
-		if !strings.Contains(content, "["+kind+"]") {
+		// Kinds are carried as bausteinsicht_template attributes — the anchor
+		// the sync engine reads, not a decorative "[kind]" label.
+		if !strings.Contains(content, `bausteinsicht_template="`+kind+`"`) {
 			t.Errorf("expected kind %q in template", kind)
 		}
 	}

--- a/cmd/bausteinsicht/init_test.go
+++ b/cmd/bausteinsicht/init_test.go
@@ -287,10 +287,11 @@ func TestInitGenerateTemplateContainsAllKinds(t *testing.T) {
 	}
 	content := string(data)
 
-	// The default model should have certain kinds
+	// The default model should have certain kinds, carried as
+	// bausteinsicht_template attributes (the sync anchor).
 	expectedKinds := []string{"actor", "system", "container"}
 	for _, kind := range expectedKinds {
-		if !strings.Contains(content, "["+kind+"]") {
+		if !strings.Contains(content, `bausteinsicht_template="`+kind+`"`) {
 			t.Errorf("generated template missing kind %q", kind)
 		}
 	}

--- a/internal/template/generator.go
+++ b/internal/template/generator.go
@@ -10,6 +10,11 @@ import (
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
 
+// templateVersion is the bausteinsicht_template_version written to generated
+// templates. It must match drawio.CurrentTemplateVersion so LoadTemplate accepts
+// the output.
+const templateVersion = "1"
+
 // Generator creates a draw.io template from an element specification.
 type Generator struct {
 	spec   model.Specification
@@ -30,6 +35,16 @@ func NewGenerator(spec model.Specification, style string) *Generator {
 }
 
 // Generate produces the draw.io template XML as a complete mxfile.
+//
+// The output matches the structure the sync engine's LoadTemplate expects:
+//   - <object bausteinsicht_template="<kind>"> wrappers carrying the element style
+//   - "-title"/"-tech"/"-desc" sub-cells for grouped text labels
+//   - "<kind>_boundary" templates for container kinds
+//   - a "relationship" connector template
+//   - a bausteinsicht_template_version attribute on the <mxfile> root
+//
+// This makes a generated template directly usable as --template without falling
+// back to default styles.
 func (g *Generator) Generate() string {
 	doc := etree.NewDocument()
 	doc.CreateProcInst("xml", `version="1.0" encoding="UTF-8"`)
@@ -40,10 +55,11 @@ func (g *Generator) Generate() string {
 	mxfile.CreateAttr("agent", "Bausteinsicht")
 	mxfile.CreateAttr("version", "1.0")
 	mxfile.CreateAttr("type", "device")
+	mxfile.CreateAttr("bausteinsicht_template_version", templateVersion)
 
 	diagram := mxfile.CreateElement("diagram")
-	diagram.CreateAttr("id", "1")
-	diagram.CreateAttr("name", "Template")
+	diagram.CreateAttr("id", "template")
+	diagram.CreateAttr("name", "Bausteinsicht Template")
 
 	root := diagram.CreateElement("mxGraphModel")
 	root.CreateAttr("dx", "0")
@@ -72,21 +88,24 @@ func (g *Generator) Generate() string {
 
 	g.nextID = 2
 
-	// Collect kinds in sorted order
+	// Collect kinds in sorted order for deterministic output.
 	var kinds []string
 	for kind := range g.spec.Elements {
 		kinds = append(kinds, kind)
 	}
-
-	// Sort for consistent output
 	sort.Strings(kinds)
 
-	// Layout elements in grid (4 columns)
+	// Layout element templates in a grid (4 columns).
 	layout := GridLayout(kinds, 4)
-
 	for _, elem := range layout {
-		g.addElement(rootElem, elem.Kind, elem.Position.X, elem.Position.Y)
+		g.addElementTemplate(rootElem, elem.Kind, elem.Position.X, elem.Position.Y)
 	}
+
+	// Boundary templates for container kinds, laid out below the element grid.
+	g.addBoundaryTemplates(rootElem, kinds, layout)
+
+	// Relationship connector template (bare mxCell carrying the connector style).
+	g.addConnectorTemplate(rootElem)
 
 	doc.Indent(2)
 	var buf bytes.Buffer
@@ -96,49 +115,153 @@ func (g *Generator) Generate() string {
 	return buf.String()
 }
 
-func (g *Generator) addElement(parent *etree.Element, kind string, x, y int) {
+// addElementTemplate writes one <object bausteinsicht_template="kind"> wrapper
+// plus its title/tech/desc sub-cells.
+func (g *Generator) addElementTemplate(parent *etree.Element, kind string, x, y int) {
 	cfg := DefaultShapeConfig(kind)
 	colors := ColorForKind(g.style, kind)
-	elementSpec := g.spec.Elements[kind]
+	style := g.buildStyle(cfg, colors)
 
-	// Create label with kind name and type
-	kindTitle := strings.ToUpper(kind[:1]) + kind[1:]
-	label := fmt.Sprintf("<b>%s</b><br/>[%s]", kindTitle, kind)
+	objID := "template-" + kind
 
-	// Build style string
-	style := g.buildStyle(cfg, colors, elementSpec)
+	obj := parent.CreateElement("object")
+	obj.CreateAttr("label", "")
+	obj.CreateAttr("bausteinsicht_template", kind)
+	obj.CreateAttr("id", objID)
 
-	cell := parent.CreateElement("mxCell")
-	cell.CreateAttr("id", fmt.Sprintf("%d", g.nextID))
-	g.nextID++
-	cell.CreateAttr("value", label)           // Don't escape: draw.io uses html=1 and requires raw HTML markup for rich text
-	cell.CreateAttr("style", style+";html=1") // Enable HTML rendering in draw.io
-	cell.CreateAttr("vertex", "1")
+	cell := obj.CreateElement("mxCell")
 	cell.CreateAttr("parent", "1")
+	cell.CreateAttr("style", style)
+	cell.CreateAttr("vertex", "1")
 
-	geometry := cell.CreateElement("mxGeometry")
-	geometry.CreateAttr("x", fmt.Sprintf("%d", x))
-	geometry.CreateAttr("y", fmt.Sprintf("%d", y))
-	geometry.CreateAttr("width", fmt.Sprintf("%d", cfg.Width))
-	geometry.CreateAttr("height", fmt.Sprintf("%d", cfg.Height))
-	geometry.CreateAttr("as", "geometry")
+	geo := cell.CreateElement("mxGeometry")
+	geo.CreateAttr("x", fmt.Sprintf("%d", x))
+	geo.CreateAttr("y", fmt.Sprintf("%d", y))
+	geo.CreateAttr("width", fmt.Sprintf("%d", cfg.Width))
+	geo.CreateAttr("height", fmt.Sprintf("%d", cfg.Height))
+	geo.CreateAttr("as", "geometry")
+
+	// Sub-cells: title, technology, description. Positions are relative to the
+	// parent object's geometry, stacked vertically.
+	titleH, techH := 24, 18
+	descH := cfg.Height - titleH - techH
+	if descH < 18 {
+		descH = 18
+	}
+
+	kindTitle := strings.ToUpper(kind[:1]) + kind[1:]
+	g.addSubCell(parent, objID, "title", kindTitle,
+		fmt.Sprintf("text;html=1;fontSize=13;fontStyle=1;fontColor=%s;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;", colors.Stroke),
+		0, 0, cfg.Width, titleH)
+	g.addSubCell(parent, objID, "tech", "[Technology]",
+		"text;html=1;fontSize=10;fontStyle=2;fontColor=#666666;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;",
+		0, titleH, cfg.Width, techH)
+	g.addSubCell(parent, objID, "desc", "Description",
+		"text;html=1;whiteSpace=wrap;fontSize=10;fontColor=#555555;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;",
+		0, titleH+techH, cfg.Width, descH)
 }
 
-func (g *Generator) buildStyle(cfg ShapeConfig, colors ColorStyle, _ model.ElementKind) string {
+// addSubCell writes a "-title"/"-tech"/"-desc" text sub-cell parented to objID.
+func (g *Generator) addSubCell(parent *etree.Element, objID, role, value, style string, x, y, w, h int) {
+	cell := parent.CreateElement("mxCell")
+	cell.CreateAttr("id", objID+"-"+role)
+	cell.CreateAttr("parent", objID)
+	cell.CreateAttr("style", style)
+	cell.CreateAttr("value", value)
+	cell.CreateAttr("vertex", "1")
+
+	geo := cell.CreateElement("mxGeometry")
+	geo.CreateAttr("x", fmt.Sprintf("%d", x))
+	geo.CreateAttr("y", fmt.Sprintf("%d", y))
+	geo.CreateAttr("width", fmt.Sprintf("%d", w))
+	geo.CreateAttr("height", fmt.Sprintf("%d", h))
+	geo.CreateAttr("as", "geometry")
+}
+
+// addBoundaryTemplates writes a "<kind>_boundary" template for every container
+// kind in the spec, placed in a row beneath the element grid.
+func (g *Generator) addBoundaryTemplates(parent *etree.Element, kinds []string, layout []Element) {
+	// Find the lowest point of the element grid so boundaries sit below it.
+	y := 40
+	for _, elem := range layout {
+		cfg := DefaultShapeConfig(elem.Kind)
+		bottom := elem.Position.Y + cfg.Height
+		if bottom > y {
+			y = bottom
+		}
+	}
+	y += 60
+
+	x := 40
+	for _, kind := range kinds {
+		if !g.spec.Elements[kind].Container {
+			continue
+		}
+		boundaryKind := kind + "_boundary"
+		colors := ColorForKind(g.style, kind)
+		style := fmt.Sprintf(
+			"swimlane;startSize=30;fillColor=none;strokeColor=%s;fontColor=%s;fontStyle=1;rounded=1;arcSize=5;whiteSpace=wrap;html=1;container=1;collapsible=0;dashed=1;dashPattern=8 4;fontSize=13;",
+			colors.Stroke, colors.Stroke)
+
+		obj := parent.CreateElement("object")
+		obj.CreateAttr("label", strings.ToUpper(kind[:1])+kind[1:]+" Boundary")
+		obj.CreateAttr("bausteinsicht_template", boundaryKind)
+		obj.CreateAttr("id", "template-"+boundaryKind)
+
+		cell := obj.CreateElement("mxCell")
+		cell.CreateAttr("parent", "1")
+		cell.CreateAttr("style", style)
+		cell.CreateAttr("vertex", "1")
+
+		geo := cell.CreateElement("mxGeometry")
+		geo.CreateAttr("x", fmt.Sprintf("%d", x))
+		geo.CreateAttr("y", fmt.Sprintf("%d", y))
+		geo.CreateAttr("width", "300")
+		geo.CreateAttr("height", "200")
+		geo.CreateAttr("as", "geometry")
+
+		x += 340
+	}
+}
+
+// addConnectorTemplate writes the relationship connector template: a bare mxCell
+// carrying bausteinsicht_template="relationship".
+func (g *Generator) addConnectorTemplate(parent *etree.Element) {
+	cell := parent.CreateElement("mxCell")
+	cell.CreateAttr("id", "template-relationship")
+	cell.CreateAttr("bausteinsicht_template", "relationship")
+	cell.CreateAttr("parent", "1")
+	cell.CreateAttr("edge", "1")
+	cell.CreateAttr("value", "<b>label</b>")
+	cell.CreateAttr("style", "edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;endFill=1;strokeColor=#707070;fontColor=#707070;fontSize=11;strokeWidth=1.5;")
+
+	geo := cell.CreateElement("mxGeometry")
+	geo.CreateAttr("relative", "1")
+	geo.CreateAttr("as", "geometry")
+}
+
+// buildStyle composes the mxCell style string for an element template.
+func (g *Generator) buildStyle(cfg ShapeConfig, colors ColorStyle) string {
 	parts := []string{
 		fmt.Sprintf("fillColor=%s", colors.Fill),
 		fmt.Sprintf("strokeColor=%s", colors.Stroke),
 		"fontColor=#000000",
 		"fontSize=12",
+		"whiteSpace=wrap",
+		"html=1",
+		"align=center",
+		"verticalAlign=middle",
+		"container=0",
 	}
 
-	// Add shape if specified
+	// Add shape if specified.
 	if cfg.Shape != "" {
-		if strings.HasPrefix(cfg.Shape, "shape=") {
+		switch {
+		case strings.HasPrefix(cfg.Shape, "shape="):
 			parts = append(parts, cfg.Shape)
-		} else if !strings.Contains(cfg.Shape, "=") {
+		case !strings.Contains(cfg.Shape, "="):
 			parts = append(parts, fmt.Sprintf("shape=%s", cfg.Shape))
-		} else {
+		default:
 			parts = append(parts, cfg.Shape)
 		}
 	}

--- a/internal/template/generator_test.go
+++ b/internal/template/generator_test.go
@@ -46,7 +46,9 @@ func TestGenerateTemplateHasAllKinds(t *testing.T) {
 
 	kinds := []string{"person", "system", "database", "external_system"}
 	for _, kind := range kinds {
-		if !strings.Contains(result, "["+kind+"]") {
+		// Each kind is carried as a bausteinsicht_template attribute on an
+		// <object> wrapper — the synchronization anchor the sync engine reads.
+		if !strings.Contains(result, `bausteinsicht_template="`+kind+`"`) {
 			t.Errorf("expected kind %q in output", kind)
 		}
 	}

--- a/internal/template/roundtrip_test.go
+++ b/internal/template/roundtrip_test.go
@@ -1,0 +1,109 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bausteinsicht/internal/drawio"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// roundtripSpec covers element kinds, container kinds (which require boundary
+// templates), and a non-container leaf kind.
+func roundtripSpec() model.Specification {
+	return model.Specification{
+		Elements: map[string]model.ElementKind{
+			"person":          {Notation: "Person"},
+			"system":          {Notation: "System", Container: true},
+			"container":       {Notation: "Container", Container: true},
+			"component":       {Notation: "Component"},
+			"database":        {Notation: "Database"},
+			"external_system": {Notation: "External System"},
+		},
+	}
+}
+
+// TestGenerateTemplateRoundtrip verifies that a generated template parses back
+// through drawio.LoadTemplate with a style for every specification kind — i.e. it
+// is a working template, not just a visual palette. Regression test for #419.
+func TestGenerateTemplateRoundtrip(t *testing.T) {
+	for _, style := range []string{"default", "c4", "minimal", "dark"} {
+		t.Run(style, func(t *testing.T) {
+			spec := roundtripSpec()
+			gen := NewGenerator(spec, style)
+			xml := gen.Generate()
+
+			ts, err := drawio.LoadTemplateFromBytes([]byte(xml))
+			if err != nil {
+				t.Fatalf("LoadTemplateFromBytes: %v", err)
+			}
+
+			// Every element kind must resolve to a style (no "no template style" fallback).
+			for kind := range spec.Elements {
+				if _, ok := ts.GetStyle(kind); !ok {
+					t.Errorf("no template style for kind: %s", kind)
+				}
+			}
+
+			// Container kinds must produce a usable boundary template.
+			for kind, def := range spec.Elements {
+				if !def.Container {
+					continue
+				}
+				if _, ok := ts.GetBoundaryStyle(kind + "_boundary"); !ok {
+					t.Errorf("no boundary template for container kind: %s", kind)
+				}
+			}
+
+			// A relationship connector style must be present.
+			if ts.GetConnectorStyle() == "" {
+				t.Error("no relationship connector style")
+			}
+		})
+	}
+}
+
+// TestGenerateTemplateHasSubCells verifies the generated element templates carry
+// the title/tech/desc sub-cells the sync engine reads for grouped text labels.
+func TestGenerateTemplateHasSubCells(t *testing.T) {
+	gen := NewGenerator(roundtripSpec(), "default")
+	xml := gen.Generate()
+
+	ts, err := drawio.LoadTemplateFromBytes([]byte(xml))
+	if err != nil {
+		t.Fatalf("LoadTemplateFromBytes: %v", err)
+	}
+
+	style, ok := ts.GetStyle("system")
+	if !ok {
+		t.Fatal("no style for system")
+	}
+	if style.TitleStyle == nil {
+		t.Error("expected title sub-cell for system")
+	}
+	if style.TechStyle == nil {
+		t.Error("expected tech sub-cell for system")
+	}
+	if style.DescStyle == nil {
+		t.Error("expected desc sub-cell for system")
+	}
+}
+
+// TestGenerateTemplateHasVersion verifies the version attribute is emitted so
+// LoadTemplate treats the output as a current-format template.
+func TestGenerateTemplateHasVersion(t *testing.T) {
+	gen := NewGenerator(roundtripSpec(), "default")
+	xml := gen.Generate()
+
+	if !strings.Contains(xml, `bausteinsicht_template_version="1"`) {
+		t.Error("expected bausteinsicht_template_version attribute on output")
+	}
+
+	ts, err := drawio.LoadTemplateFromBytes([]byte(xml))
+	if err != nil {
+		t.Fatalf("LoadTemplateFromBytes: %v", err)
+	}
+	if ts.Version != drawio.CurrentTemplateVersion {
+		t.Errorf("expected version %d, got %d", drawio.CurrentTemplateVersion, ts.Version)
+	}
+}


### PR DESCRIPTION
Fixes #419.

## What was broken

`bausteinsicht generate-template` emitted a **visual palette**, not a working template. The output (`cmd/bausteinsicht/generate_template.go` → `internal/template/generator.go`) did not match the structure the sync engine's `drawio.LoadTemplate` (`internal/drawio/template.go`) requires:

- plain `mxCell` vertices with **no `bausteinsicht_template` attributes**
- **no `<object>` wrappers**
- **no `-title`/`-tech`/`-desc` sub-cells**
- **no `_boundary` / connector templates**
- **no `bausteinsicht_template_version`**

Using the result as `--template` produced `WARNING: no template style for kind: container` and fell back to default styles — the generated file was unusable as a real template.

## The fix

The generator now emits the same structure `init`'s embedded template (`templates/default.drawio`) uses, parametrised by the style preset (`default`/`c4`/`minimal`/`dark`):

- `<object bausteinsicht_template="<kind>">` wrappers carrying the element style + geometry
- `-title` / `-tech` / `-desc` text sub-cells per element
- `<kind>_boundary` swimlane templates for every container kind in the spec
- a `relationship` connector template (bare `mxCell` with the edge style)
- `bausteinsicht_template_version="1"` on the `<mxfile>` root

No public API changed; only the generated XML structure.

## How it was verified

- **New roundtrip test** (`internal/template/roundtrip_test.go`): `generate-template --style X` → `drawio.LoadTemplateFromBytes` asserts a style exists for every spec kind, a boundary for every container kind, and a non-empty connector style — across all four presets. Plus sub-cell and version assertions.
- **Mutation check**: reverting `generator.go` to `HEAD` makes the new tests FAIL (`no template style for kind: ...`, `no boundary template`, `no relationship connector style`, missing version); restoring the fix makes them PASS.
- **End-to-end**: built the binary, ran `init` → `generate-template --style c4` → `sync --template gen.drawio` — **no "no template style" warnings**.
- Updated the three pre-existing tests that asserted the old decorative `[kind]` label to check the `bausteinsicht_template` anchor instead.
- `go build ./...` and `go test ./...` all green. `gofmt -l` clean on all five touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)