### PR TITLE
fix(model): place comma before trailing // comment in InsertObjectEntry

### DIFF
--- a/internal/model/patch.go
+++ b/internal/model/patch.go
@@ -328,7 +328,6 @@ func InsertObjectEntry(data []byte, objectPath []string, key, valueJSON string) 
 	}
 
 	// Build the insertion text.
-	var insertion string
 	if hasEntries {
 		// Find the last non-whitespace/comment byte before closeBrace to
 		// append a comma after the previous entry (not before the new one).
@@ -336,27 +335,59 @@ func InsertObjectEntry(data []byte, objectPath []string, key, valueJSON string) 
 		for lastContent > start && (data[lastContent] == ' ' || data[lastContent] == '\t' || data[lastContent] == '\n' || data[lastContent] == '\r') {
 			lastContent--
 		}
-		// Insert comma after last entry, then newline + new entry.
+
+		// If the last entry's line has a trailing // comment, the comma must go
+		// before the comment — not after it — to avoid corrupting the JSONC file.
+		commaAfter := lastContent
+		lineStart := lastContent
+		for lineStart > start && data[lineStart-1] != '\n' {
+			lineStart--
+		}
+		if cp := findLineComment(data, lineStart, lastContent+1); cp >= 0 {
+			commaAfter = cp - 1
+			for commaAfter > lineStart && (data[commaAfter] == ' ' || data[commaAfter] == '\t') {
+				commaAfter--
+			}
+		}
+
 		comma := ""
-		if lastContent > start && data[lastContent] != ',' {
+		if commaAfter > start && data[commaAfter] != ',' {
 			comma = ","
 		}
-		insertion = fmt.Sprintf("%s\n%s  %q: %s\n%s", comma, indent, key, valueJSON, indent)
-		// Replace from after last content to closing brace (inclusive) with:
-		// comma + \n + indent + new entry + \n + indent + }
-		result := make([]byte, 0, len(data)+len(insertion))
-		result = append(result, data[:lastContent+1]...)
-		result = append(result, []byte(insertion)...)
+		newEntry := fmt.Sprintf("\n%s  %q: %s\n%s", indent, key, valueJSON, indent)
+		result := make([]byte, 0, len(data)+len(comma)+len(newEntry))
+		result = append(result, data[:commaAfter+1]...)
+		result = append(result, []byte(comma)...)
+		// Preserve any trailing comment text between commaAfter and lastContent.
+		result = append(result, data[commaAfter+1:lastContent+1]...)
+		result = append(result, []byte(newEntry)...)
 		result = append(result, data[closeBrace:]...)
 		return result, nil
 	}
 
-	insertion = fmt.Sprintf("\n%s  %q: %s\n%s", indent, key, valueJSON, indent)
+	insertion := fmt.Sprintf("\n%s  %q: %s\n%s", indent, key, valueJSON, indent)
 	result := make([]byte, 0, len(data)+len(insertion))
 	result = append(result, data[:closeBrace]...)
 	result = append(result, []byte(insertion)...)
 	result = append(result, data[closeBrace:]...)
 	return result, nil
+}
+
+// findLineComment returns the byte offset of the first // comment in data[from:to]
+// that is not inside a JSON string. Returns -1 if none found.
+func findLineComment(data []byte, from, to int) int {
+	i := from
+	for i < to {
+		if data[i] == '"' {
+			i = skipString(data, i, len(data))
+			continue
+		}
+		if i+1 < to && data[i] == '/' && data[i+1] == '/' {
+			return i
+		}
+		i++
+	}
+	return -1
 }
 
 // AppendArrayEntry appends a new value to the array at the given path.
@@ -387,7 +418,6 @@ func AppendArrayEntry(data []byte, arrayPath []string, valueJSON string) ([]byte
 		hasEntries = true
 	}
 
-	var insertion string
 	if hasEntries {
 		// Find the last non-whitespace byte before closeBracket to
 		// append comma after the previous entry.
@@ -395,19 +425,35 @@ func AppendArrayEntry(data []byte, arrayPath []string, valueJSON string) ([]byte
 		for lastContent > start && (data[lastContent] == ' ' || data[lastContent] == '\t' || data[lastContent] == '\n' || data[lastContent] == '\r') {
 			lastContent--
 		}
+
+		// Same trailing-comment guard as InsertObjectEntry.
+		commaAfter := lastContent
+		lineStart := lastContent
+		for lineStart > start && data[lineStart-1] != '\n' {
+			lineStart--
+		}
+		if cp := findLineComment(data, lineStart, lastContent+1); cp >= 0 {
+			commaAfter = cp - 1
+			for commaAfter > lineStart && (data[commaAfter] == ' ' || data[commaAfter] == '\t') {
+				commaAfter--
+			}
+		}
+
 		comma := ""
-		if lastContent > start && data[lastContent] != ',' {
+		if commaAfter > start && data[commaAfter] != ',' {
 			comma = ","
 		}
-		insertion = fmt.Sprintf("%s\n%s  %s\n%s", comma, indent, valueJSON, indent)
-		result := make([]byte, 0, len(data)+len(insertion))
-		result = append(result, data[:lastContent+1]...)
-		result = append(result, []byte(insertion)...)
+		newEntry := fmt.Sprintf("\n%s  %s\n%s", indent, valueJSON, indent)
+		result := make([]byte, 0, len(data)+len(comma)+len(newEntry))
+		result = append(result, data[:commaAfter+1]...)
+		result = append(result, []byte(comma)...)
+		result = append(result, data[commaAfter+1:lastContent+1]...)
+		result = append(result, []byte(newEntry)...)
 		result = append(result, data[closeBracket:]...)
 		return result, nil
 	}
 
-	insertion = fmt.Sprintf("\n%s  %s\n%s", indent, valueJSON, indent)
+	insertion := fmt.Sprintf("\n%s  %s\n%s", indent, valueJSON, indent)
 	result := make([]byte, 0, len(data)+len(insertion))
 	result = append(result, data[:closeBracket]...)
 	result = append(result, []byte(insertion)...)

--- a/internal/model/patch.go
+++ b/internal/model/patch.go
@@ -336,19 +336,11 @@ func InsertObjectEntry(data []byte, objectPath []string, key, valueJSON string) 
 			lastContent--
 		}
 
-		// If the last entry's line has a trailing // comment, the comma must go
-		// before the comment — not after it — to avoid corrupting the JSONC file.
-		commaAfter := lastContent
 		lineStart := lastContent
 		for lineStart > start && data[lineStart-1] != '\n' {
 			lineStart--
 		}
-		if cp := findLineComment(data, lineStart, lastContent+1); cp >= 0 {
-			commaAfter = cp - 1
-			for commaAfter > lineStart && (data[commaAfter] == ' ' || data[commaAfter] == '\t') {
-				commaAfter--
-			}
-		}
+		commaAfter := commaInsertPoint(data, lastContent, lineStart)
 
 		comma := ""
 		if commaAfter > start && data[commaAfter] != ',' {
@@ -358,7 +350,6 @@ func InsertObjectEntry(data []byte, objectPath []string, key, valueJSON string) 
 		result := make([]byte, 0, len(data)+len(comma)+len(newEntry))
 		result = append(result, data[:commaAfter+1]...)
 		result = append(result, []byte(comma)...)
-		// Preserve any trailing comment text between commaAfter and lastContent.
 		result = append(result, data[commaAfter+1:lastContent+1]...)
 		result = append(result, []byte(newEntry)...)
 		result = append(result, data[closeBrace:]...)
@@ -379,7 +370,7 @@ func findLineComment(data []byte, from, to int) int {
 	i := from
 	for i < to {
 		if data[i] == '"' {
-			i = skipString(data, i, len(data))
+			i = skipString(data, i, to)
 			continue
 		}
 		if i+1 < to && data[i] == '/' && data[i+1] == '/' {
@@ -388,6 +379,23 @@ func findLineComment(data []byte, from, to int) int {
 		i++
 	}
 	return -1
+}
+
+// commaInsertPoint returns the position after which a trailing comma should be
+// inserted for the last entry ending at lastContent. When the entry's line ends
+// with a // comment, the returned position is the last non-whitespace byte
+// before the comment so the comma lands before it; otherwise lastContent is
+// returned unchanged.
+func commaInsertPoint(data []byte, lastContent, lineStart int) int {
+	cp := findLineComment(data, lineStart, lastContent+1)
+	if cp < 0 {
+		return lastContent
+	}
+	pos := cp - 1
+	for pos > lineStart && (data[pos] == ' ' || data[pos] == '\t') {
+		pos--
+	}
+	return pos
 }
 
 // AppendArrayEntry appends a new value to the array at the given path.
@@ -426,18 +434,11 @@ func AppendArrayEntry(data []byte, arrayPath []string, valueJSON string) ([]byte
 			lastContent--
 		}
 
-		// Same trailing-comment guard as InsertObjectEntry.
-		commaAfter := lastContent
 		lineStart := lastContent
 		for lineStart > start && data[lineStart-1] != '\n' {
 			lineStart--
 		}
-		if cp := findLineComment(data, lineStart, lastContent+1); cp >= 0 {
-			commaAfter = cp - 1
-			for commaAfter > lineStart && (data[commaAfter] == ' ' || data[commaAfter] == '\t') {
-				commaAfter--
-			}
-		}
+		commaAfter := commaInsertPoint(data, lastContent, lineStart)
 
 		comma := ""
 		if commaAfter > start && data[commaAfter] != ',' {

--- a/internal/model/patch_test.go
+++ b/internal/model/patch_test.go
@@ -241,6 +241,62 @@ func TestAppendArrayEntry_PreservesComments(t *testing.T) {
 	}
 }
 
+func TestInsertObjectEntry_TrailingLineComment(t *testing.T) {
+	// Regression test for #399: comma must be placed before a trailing // comment,
+	// not appended after it (which would produce invalid JSONC).
+	input := `{
+  "model": {
+    "webshop": { "kind": "system", "title": "Webshop" } // main system
+  }
+}`
+	got, err := InsertObjectEntry([]byte(input), []string{"model"}, "api", `{ "kind": "system" }`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := string(got)
+
+	// Comment must still be present and unchanged.
+	if !strings.Contains(result, "// main system") {
+		t.Errorf("trailing comment was removed:\n%s", result)
+	}
+	// The comma must appear before the comment, not after it.
+	if strings.Contains(result, "// main system,") {
+		t.Errorf("comma placed after trailing comment (file corruption):\n%s", result)
+	}
+	// New entry must be present.
+	if !strings.Contains(result, `"api"`) {
+		t.Errorf("new entry missing:\n%s", result)
+	}
+}
+
+func TestAppendArrayEntry_TrailingLineComment(t *testing.T) {
+	// Regression test for #399: same trailing-comment corruption in arrays.
+	input := `{
+  "specification": { "elements": { "system": { "notation": "System" } } },
+  "model": {},
+  "relationships": [
+    { "from": "a", "to": "b", "label": "calls" } // initial rel
+  ],
+  "views": {}
+}`
+	got, err := AppendArrayEntry([]byte(input), []string{"relationships"}, `{ "from": "c", "to": "d", "label": "uses" }`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	result := string(got)
+
+	if !strings.Contains(result, "// initial rel") {
+		t.Errorf("trailing comment was removed:\n%s", result)
+	}
+	if strings.Contains(result, "// initial rel,") {
+		t.Errorf("comma placed after trailing comment (file corruption):\n%s", result)
+	}
+	if !strings.Contains(result, `"from": "c"`) {
+		t.Errorf("new entry missing:\n%s", result)
+	}
+}
+
+
 func TestPatchValue_WithBlockComments(t *testing.T) {
 	input := `{
   /* block comment */

--- a/internal/model/patch_test.go
+++ b/internal/model/patch_test.go
@@ -242,11 +242,56 @@ func TestAppendArrayEntry_PreservesComments(t *testing.T) {
 }
 
 func TestInsertObjectEntry_TrailingLineComment(t *testing.T) {
-	// Regression test for #399: comma must be placed before a trailing // comment,
-	// not appended after it (which would produce invalid JSONC).
+	// Regression for #399: comma must go before the trailing // comment.
 	input := `{
   "model": {
     "webshop": { "kind": "system", "title": "Webshop" } // main system
+  }
+}`
+	want := `{
+  "model": {
+    "webshop": { "kind": "system", "title": "Webshop" }, // main system
+    "api": { "kind": "system" }
+  }
+}`
+	got, err := InsertObjectEntry([]byte(input), []string{"model"}, "api", `{ "kind": "system" }`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestInsertObjectEntry_TrailingCommentWithURLInValue(t *testing.T) {
+	// Regression for review finding H1: findLineComment must not mistake // inside
+	// a string value (URL) for a comment, and must still find the real // comment.
+	input := `{
+  "model": {
+    "webshop": { "url": "https://example.com" } // main system
+  }
+}`
+	want := `{
+  "model": {
+    "webshop": { "url": "https://example.com" }, // main system
+    "api": { "kind": "system" }
+  }
+}`
+	got, err := InsertObjectEntry([]byte(input), []string{"model"}, "api", `{ "kind": "system" }`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestInsertObjectEntry_TrailingCommentAlreadyHasComma(t *testing.T) {
+	// Existing comma before a trailing comment must not produce a double comma.
+	input := `{
+  "model": {
+    "webshop": { "kind": "system" }, // main system
+    "db": { "kind": "database" }
   }
 }`
 	got, err := InsertObjectEntry([]byte(input), []string{"model"}, "api", `{ "kind": "system" }`)
@@ -254,23 +299,16 @@ func TestInsertObjectEntry_TrailingLineComment(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	result := string(got)
-
-	// Comment must still be present and unchanged.
-	if !strings.Contains(result, "// main system") {
-		t.Errorf("trailing comment was removed:\n%s", result)
+	if strings.Contains(result, ",,") {
+		t.Errorf("double comma produced:\n%s", result)
 	}
-	// The comma must appear before the comment, not after it.
-	if strings.Contains(result, "// main system,") {
-		t.Errorf("comma placed after trailing comment (file corruption):\n%s", result)
-	}
-	// New entry must be present.
 	if !strings.Contains(result, `"api"`) {
 		t.Errorf("new entry missing:\n%s", result)
 	}
 }
 
 func TestAppendArrayEntry_TrailingLineComment(t *testing.T) {
-	// Regression test for #399: same trailing-comment corruption in arrays.
+	// Regression for #399: same trailing-comment corruption in arrays.
 	input := `{
   "specification": { "elements": { "system": { "notation": "System" } } },
   "model": {},
@@ -285,9 +323,6 @@ func TestAppendArrayEntry_TrailingLineComment(t *testing.T) {
 	}
 	result := string(got)
 
-	if !strings.Contains(result, "// initial rel") {
-		t.Errorf("trailing comment was removed:\n%s", result)
-	}
 	if strings.Contains(result, "// initial rel,") {
 		t.Errorf("comma placed after trailing comment (file corruption):\n%s", result)
 	}


### PR DESCRIPTION
## Summary

- Fixes #399 — `InsertObjectEntry` (and `AppendArrayEntry`) corrupted JSONC files when the last entry of an object/array had a trailing inline comment like `"webshop": {...} // main system`
- Root cause: the backward scan found the last non-whitespace byte *inside* the comment text, then appended the comma after it → `// main system,` → invalid JSONC that `model.Load` rejects on next read
- Fix: added `findLineComment` helper; if a `//` comment is found on the last entry's line, the comma is inserted before the comment and the comment is preserved in-place
- `AppendArrayEntry` gets the same fix since it shares the identical pattern

## Test plan

- [x] `TestInsertObjectEntry_TrailingLineComment` — verifies comma placed before `//`, comment preserved, new entry present
- [x] `TestAppendArrayEntry_TrailingLineComment` — same for arrays
- [x] All existing `TestInsertObjectEntry_*` and `TestAppendArrayEntry_*` tests still pass
- [x] Full `./...` test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)