### PR TITLE
docs(spec): fix P1 spec/code contradictions (UC-7 page-based, trust model, auto-detect, export family)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Architecture-as-code tool with draw.io as visual frontend and bidirectional sync
 - Flexible element hierarchy (not limited to 4 C4 levels)
 - Unique variable names as element IDs for synchronization
 - Template-based styling (templates are draw.io files)
-- Zoom-based drill-down navigation on single draw.io page
+- Page-based drill-down navigation (one draw.io page per view, cross-page links + back button; see ADR-009)
 - CLI + watch mode; CLI commands for LLM-driven workflows
 
 ## Development Environment

--- a/src/docs/arc42/ADRs/ADR-009-Drill-Down-Navigation.adoc
+++ b/src/docs/arc42/ADRs/ADR-009-Drill-Down-Navigation.adoc
@@ -1,0 +1,111 @@
+:jbake-title: ADR-009: Drill-Down Navigation
+:jbake-type: page_toc
+:jbake-status: published
+:jbake-menu: Development
+:jbake-order: 9
+
+= ADR-009: Page-Based Drill-Down Navigation
+
+== Status
+
+Accepted
+
+== Context
+
+Bausteinsicht renders views as draw.io diagrams and lets architects navigate between abstraction levels (context → container → component). Early specification text (UC-7, AC-7.1) and a Key Design Decision in `CLAUDE.md` described this as *single-page semantic zoom*: all views on one draw.io canvas, where zooming in reveals the next level of detail and the parent view stays visible (smaller) above for orientation.
+
+The implementation went a different way: *one draw.io page per view*, with sync-generated cross-page links on elements that have a deeper view, and a generated "back" button to return to the parent. This ADR records that the page-based approach is the accepted design and explains why, resolving the contradiction the documentation audit (#422) surfaced.
+
+== Evaluated Approaches
+
+==== Approach A: Single-page semantic zoom (the original vision)
+
+All views laid out on one canvas; drilling down is zooming; the parent stays on screen.
+
+* Keeps the parent visible for orientation
+* draw.io has **no native semantic zoom / level-of-detail** — this would require simulating it by scaling and positioning nested content, a fragile hack
+* Fights bidirectional sync: a single canvas mixing all levels is hard to diff and reconcile against the model
+
+==== Approach B: One page per view + cross-page links (implemented)
+
+Each view is its own draw.io page; sync adds page links to drill-down elements and a back-navigation button.
+
+* draw.io pages and page links are **native** features
+* Each page maps cleanly to one view, which the sync engine already resolves — diff/reconcile stays simple
+* Leaving the page loses the "parent visible" orientation (mitigated by the generated back button)
+
+== Weighted Pugh Matrix
+
+Rating scale: -1 = worse than reference, 0 = same, +1 = better. Reference option: *A (single-page zoom)*.
+
+[cols="4,1,1,1"]
+|===
+| Criterion | Weight | A: Single-page zoom (Ref) | B: Page-based
+
+| *Native draw.io support*
+| 5
+| 0
+| +1
+
+| *Bidirectional-sync robustness*
+| 4
+| 0
+| +1
+
+| *Implementation effort*
+| 4
+| 0
+| +1
+
+| *Orientation (parent visible while drilling)*
+| 3
+| 0
+| -1
+
+| *Per-level export/print*
+| 2
+| 0
+| +1
+
+|===
+
+=== Weighted Results
+
+[cols="3,1,1"]
+|===
+| Criterion | A: Single-page zoom (Ref) | B: Page-based
+
+| Native draw.io support (×5)            | 0 | +5
+| Bidirectional-sync robustness (×4)     | 0 | +4
+| Implementation effort (×4)             | 0 | +4
+| Orientation (×3)                       | 0 | -3
+| Per-level export/print (×2)            | 0 | +2
+| *Total*                                | *0* | *+12*
+|===
+
+== Decision
+
+**Accepted — page-based drill-down (Approach B).**
+
+Each view is rendered as its own draw.io page. Sync generates a cross-page link on every element that has a deeper view, and a "back" navigation button on child pages. This works with draw.io's native page model instead of against it, and keeps the bidirectional sync simple (one page ↔ one view).
+
+== Consequences
+
+=== Positive
+
+* Uses native draw.io pages and links — no fragile semantic-zoom emulation
+* Clean page ↔ view mapping keeps forward/reverse sync tractable
+* Each level exports and prints as a self-contained page
+
+=== Negative
+
+* The parent view is not visible while viewing a child level; orientation relies on the generated back button and the page list
+
+=== Risk
+
+The lost "parent visible" orientation is a usability trade-off, not a correctness or security concern; it creates no new Chapter 11 risk and is *explicitly accepted without a tracked risk*.
+
+=== Implementation
+
+* Page per view and cross-page links: `internal/sync/forward.go` (`pageID := "view-" + viewID`, `data:page/id,` links)
+* Back-navigation button: `internal/sync/forward.go` (generated `nav-back-` cell)

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -182,8 +182,8 @@ This prevents corrupted files if the process is interrupted during write.
 
 Bausteinsicht uses convention over configuration:
 
-1. Look for `*.jsonc` in the current directory (first match = model file)
-2. Look for `*.drawio` in the current directory (first match = diagram file)
+1. Look for `*.jsonc` in the current directory. Exactly one match is used as the model file; if several exist, the command aborts and requires `--model` (it never silently picks one, since the tool mutates and synchronizes files).
+2. Look for `*.drawio` in the current directory (the diagram file)
 3. Look for `.bausteinsicht-sync` in the current directory
 4. Template: `template.drawio` in the current directory, or fall back to the embedded default
 

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -58,4 +58,9 @@ All ADRs are located in `src/docs/arc42/ADRs/`.
 | Sequence Diagram Export (Revisited)
 | Accepted
 | Reverses ADR-004: implements `dynamicViews` + `export-sequence` (PlantUML/Mermaid). Behavioral views kept in one model with structure; sync engine ignores the section.
+
+| link:../ADRs/ADR-009-Drill-Down-Navigation.adoc[ADR-009]
+| Drill-Down Navigation
+| Accepted
+| Page-based drill-down (one draw.io page per view + cross-page links + back button) over single-page semantic zoom. Uses native draw.io pages; keeps bidirectional sync simple.
 |===

--- a/src/docs/spec/01_use_cases.adoc
+++ b/src/docs/spec/01_use_cases.adoc
@@ -343,11 +343,11 @@ stop
 === UC-7: Drill-Down Navigation
 
 ==== Description
-An architect navigates between different abstraction levels within a single draw.io diagram using zoom-based drill-down.
+An architect navigates between abstraction levels by following links between draw.io pages — one page per view — drilling from a context view into a container view into a component view, and back via a generated navigation button. See link:../arc42/ADRs/ADR-009-Drill-Down-Navigation.adoc[ADR-009] for why this is page-based rather than single-page zoom.
 
 ==== Preconditions
-* Multiple views exist at different hierarchy levels
-* Views are placed on a single draw.io page with appropriate spacing
+* Multiple views exist at different hierarchy levels (e.g. a context view scoped to a system, a container view scoped to that system's children)
+* Sync has run, so each view is rendered as its own draw.io page
 
 ==== Flow
 
@@ -355,25 +355,24 @@ An architect navigates between different abstraction levels within a single draw
 ....
 @startuml
 start
-:Architect views context diagram
-(high zoom level);
-:Architect clicks on a system element;
-:draw.io follows link to
-container view area;
-:Zoom adjusts to show
-container-level detail;
+:Architect opens the context view page;
+:Architect clicks a system element;
+:draw.io follows the page link
+to that system's container view page;
 note right
-  Context diagram remains
-  visible (small) above
-  for orientation
+  Each view is a separate
+  draw.io page; sync generates
+  cross-page links on elements
+  that have a deeper view
 end note
-:Architect clicks on a container;
-:draw.io navigates to
-component view area;
+:Architect clicks a container element;
+:draw.io follows the link
+to the component view page;
 if (Wants to go back?) then (yes)
-  :Click on parent view
-  (visible above);
-  :Zoom back to parent level;
+  :Click the generated
+  "back" navigation button;
+  :draw.io returns to the
+  parent view page;
 else (no)
   :Continue exploring;
 endif
@@ -382,11 +381,11 @@ stop
 ....
 
 ==== Postconditions
-* User can navigate between abstraction levels via click
-* Parent views remain visible for orientation
+* User can navigate between abstraction levels by clicking linked elements
+* Each level is a dedicated page; a generated back-navigation button returns to the parent view
 
 ==== Error Scenarios
-* Target view does not exist → element is not clickable (no link generated)
+* Target view does not exist → element carries no page link (not clickable for drill-down)
 
 === UC-8: Export Diagram Views
 

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -84,7 +84,7 @@ These flags are available on all subcommands via persistent flags on the root co
 | `text`
 
 | `--model <path>`
-| Path to the model file (`.jsonc`). When omitted, auto-detection scans the current directory for `*.jsonc` files and uses the first match.
+| Path to the model file (`.jsonc`). When omitted, auto-detection scans the current directory for a single `*.jsonc` file; if more than one is present, the command aborts and asks for `--model` (see Auto-Detection Behavior).
 | auto-detect
 
 | `--template <path>`
@@ -103,8 +103,9 @@ NOTE: `--version` is a root-level flag only, not a global flag. It is used as `b
 When `--model` is not specified, all commands that require a model file invoke auto-detection:
 
 1. The current working directory is scanned for files matching `*.jsonc`.
-2. If one or more `.jsonc` files are found, the first match (alphabetically) is used.
-3. If no `.jsonc` file is found, the command exits with code 2 and an error message.
+2. If exactly one `.jsonc` file is found, it is used.
+3. If more than one `.jsonc` file is found, the command **aborts** with exit code 2 and the message `multiple .jsonc files in <dir> — use --model to select one`. It does **not** silently pick one, because the tool mutates files and synchronizes — operating on the wrong model must never happen by accident.
+4. If no `.jsonc` file is found, the command exits with code 2 and an error message.
 
 === Exit Codes
 
@@ -128,7 +129,9 @@ When `--model` is not specified, all commands that require a model file invoke a
 
 Initializes a new Bausteinsicht project in the current directory by creating a sample model, a default template, an initial draw.io diagram, and the sync state file.
 
-**Flags:** No command-specific flags. Uses global flags only.
+**Flags:**
+
+* `--generate-template` -- Generate the template from the model's specification instead of writing the built-in default template.
 
 **Created files:**
 
@@ -219,6 +222,8 @@ Runs one bidirectional synchronization cycle between the architecture model and 
 **Flags:**
 
 * `--relayout` -- Re-apply auto-layout to all view pages, resetting element positions to the layout engine's computed positions. Without this flag, existing element positions are preserved.
+* `--mermaid` -- Also write Mermaid diagrams of the views to a Markdown file after syncing.
+* `--mermaid-output <path>` -- Output file for the Mermaid diagrams (default `architecture.md`). Implies `--mermaid`.
 
 **Behavior:**
 
@@ -283,7 +288,10 @@ $ bausteinsicht sync --format json
 
 Watches the model and draw.io files for changes and automatically runs a sync cycle on each detected change.
 
-**Flags:** No command-specific flags. Uses global flags only.
+**Flags:**
+
+* `--mermaid` -- Also write Mermaid diagrams of the views to a Markdown file after each sync.
+* `--mermaid-output <path>` -- Output file for the Mermaid diagrams (default `architecture.md`). Implies `--mermaid`.
 
 **Behavior:**
 
@@ -666,6 +674,11 @@ Exports draw.io diagram views to image files (PNG or SVG) using the draw.io CLI.
 | No
 | `.` (current directory)
 
+| `--scale`
+| Export scale factor (e.g. `2.0` for retina, `3.0` for print). Values greater than 1 require a hardware GPU.
+| No
+| `1`
+
 | `--embed-diagram`
 | Embed the draw.io XML source in the exported image file.
 | No
@@ -677,15 +690,14 @@ Exports draw.io diagram views to image files (PNG or SVG) using the draw.io CLI.
 * Loads the model and draw.io document to determine which pages to export.
 * Detects the draw.io CLI binary automatically. Exits with code 2 if not found.
 * Creates the output directory if it does not exist.
-* Output files are named `<view-key>.<format>` (e.g., `context.png`).
+* Output files are named `architecture-<view-key>.<format>` (e.g., `architecture-context.png`).
 * Each view page is exported individually; partial failures are reported.
 
-**JSON output structure:**
+**JSON output structure** (the `errors` array is present only on partial failure):
 [source,json]
 ----
 {
-  "files": ["./context.png", "./container.png"],
-  "errors": [],
+  "files": ["architecture-context.png", "architecture-container.png"],
   "success": true
 }
 ----
@@ -735,9 +747,9 @@ Exports element attributes as an AsciiDoc or Markdown table per view or as a com
 | `adoc`
 
 | `--output`
-| Output directory for exported files.
+| Output directory for exported files. When omitted, the table is written to **stdout**.
 | No
-| `.` (current directory)
+| (stdout)
 
 | `--combined`
 | Export a single combined table with elements from all views, deduplicated.
@@ -750,48 +762,49 @@ Exports element attributes as an AsciiDoc or Markdown table per view or as a com
 * Loads the model and resolves view elements.
 * For each view, generates a table with columns: ID, Kind, Title, Technology, Description.
 * Elements are sorted alphabetically by ID within each table.
-* Output files are named `<view-key>.adoc` or `<view-key>.md` (e.g., `context.adoc`).
-* With `--combined`, produces a single file `combined.adoc` (or `.md`) containing all elements across views, deduplicated by ID.
+* Without `--output`, the table(s) are written to stdout. With `--output <dir>`, files are written there and the output filenames depend on the selection:
+** A single view (`--view <key>`) → `<view-key>-elements.adoc` (or `.md`).
+** All views, no `--combined` → one file `all-views-elements.adoc` (or `.md`) covering every view.
+** `--combined` → one deduplicated file `elements.adoc` (or `.md`).
 * Creates the output directory if it does not exist.
 
-**JSON output structure:**
+**JSON output structure** — `--format json` emits an array of element rows (not a file list):
 [source,json]
 ----
-{
-  "files": ["./context.adoc", "./container.adoc"],
-  "success": true
-}
+[
+  { "id": "customer", "title": "Customer", "kind": "actor", "description": "..." },
+  { "id": "webshop.api", "title": "REST API", "kind": "container", "technology": "Go", "description": "..." }
+]
 ----
 
 **Exit codes:**
 
-* `0` -- all tables exported successfully
+* `0` -- table(s) exported successfully
 * `1` -- one or more exports failed (partial failure)
 * `2` -- model file not found, invalid format, or no views to export
 
 **Example:**
 [source,bash]
 ----
-$ bausteinsicht export-table
-Exported: ./context.adoc
-Exported: ./container.adoc
+$ bausteinsicht export-table --view context        # writes to stdout
+=== System Context
+...
 
 $ bausteinsicht export-table --table-format md --output docs/tables --view context
-Exported: docs/tables/context.md
+Exported: docs/tables/context-elements.md
 
 $ bausteinsicht export-table --combined --output docs/tables
-Exported: docs/tables/combined.adoc
+Exported: docs/tables/elements.adoc
 
-$ bausteinsicht export-table --format json
-{
-  "files": ["./context.adoc"],
-  "success": true
-}
+$ bausteinsicht export-table --view context --format json
+[
+  { "id": "customer", "title": "Customer", "kind": "actor", "description": "..." }
+]
 ----
 
 ==== `bausteinsicht export-diagram`
 
-Exports views as PlantUML C4 or Mermaid C4 text diagrams.
+Exports views as text diagrams in one of several formats (C4-PlantUML, Mermaid, Graphviz DOT, D2, standalone HTML, or Structurizr DSL).
 
 **Flags:**
 
@@ -800,61 +813,63 @@ Exports views as PlantUML C4 or Mermaid C4 text diagrams.
 | Flag | Description | Required | Default
 
 | `--view`
-| Export only a specific view by its key. When omitted, all views are exported.
+| Export only a specific view by its key. When omitted, all views are exported. Not supported with `--diagram-format structurizr` (which always exports the whole workspace).
 | No
 | (all views)
 
 | `--diagram-format`
-| Diagram output format: `plantuml` or `mermaid`.
+| Diagram output format: `plantuml`, `mermaid`, `dot`, `d2`, `html`, or `structurizr`.
 | No
 | `plantuml`
 
 | `--output`
-| Output directory for exported files.
+| Output directory for exported files. When omitted, the diagram is written to **stdout**.
 | No
-| `.` (current directory)
+| (stdout)
 |===
 
 **Behavior:**
 
 * Loads the model and resolves view elements and relationships.
 * Auto-detects the C4 level (Context, Container, or Component) from the view content.
-* Generates C4 diagram source using the appropriate macros (`Person`, `System`, `System_Ext`, `Container`, `Component`, `System_Boundary`, `Container_Boundary`).
+* Generates diagram source in the requested format. C4-PlantUML uses the stdlib include syntax (`!include <C4/C4_Context>`, etc.).
 * Relationships are filtered to those visible in the view. Endpoints are lifted to visible ancestor elements when the original endpoints are not included in the view.
-* PlantUML output uses the local stdlib include syntax (`!include <C4/C4_Context>`, etc.).
-* Output files are named `<view-key>.puml` (PlantUML) or `<view-key>.mmd` (Mermaid).
+* Without `--output`, the diagram(s) are written to stdout. With `--output <dir>`, per-view files are named `<view-key>.<ext>`, where `<ext>` is `puml`, `mmd`, `dot`, `d2`, or `html`.
+* `--diagram-format structurizr` is special: it exports the entire workspace as a single `workspace.dsl` file and rejects `--view` (exit code 1).
 * Creates the output directory if it does not exist.
 
-**JSON output structure:**
+**JSON output structure** — `--format json` emits an array of one object per exported view (not a file list):
 [source,json]
 ----
-{
-  "files": ["./context.puml", "./container.puml"],
-  "success": true
-}
+[
+  { "view": "context", "format": "plantuml", "source": "@startuml\n!include <C4/C4_Context>\n..." }
+]
 ----
 
 **Exit codes:**
 
 * `0` -- all diagrams exported successfully
-* `1` -- one or more exports failed (partial failure)
+* `1` -- one or more exports failed, or `--view` used with `structurizr`
 * `2` -- model file not found, invalid format, or no views to export
 
 **Example:**
 [source,bash]
 ----
-$ bausteinsicht export-diagram
-Exported: ./context.puml
-Exported: ./container.puml
+$ bausteinsicht export-diagram --view context        # writes to stdout
+@startuml
+!include <C4/C4_Context>
+...
 
 $ bausteinsicht export-diagram --diagram-format mermaid --output docs/diagrams --view context
 Exported: docs/diagrams/context.mmd
 
-$ bausteinsicht export-diagram --format json
-{
-  "files": ["./context.puml"],
-  "success": true
-}
+$ bausteinsicht export-diagram --diagram-format structurizr --output docs
+Exported: docs/workspace.dsl
+
+$ bausteinsicht export-diagram --view context --format json
+[
+  { "view": "context", "format": "plantuml", "source": "@startuml\n..." }
+]
 ----
 
 ==== `bausteinsicht export-sequence`

--- a/src/docs/spec/04_acceptance_criteria.adoc
+++ b/src/docs/spec/04_acceptance_criteria.adoc
@@ -284,7 +284,7 @@ Feature: LLM-driven model manipulation
 
 === Navigation and Drill-Down (UC-7)
 
-==== AC-7.1: Zoom-based navigation
+==== AC-7.1: Page-based drill-down navigation
 
 [source,gherkin]
 ----
@@ -294,14 +294,14 @@ Feature: Drill-down navigation in draw.io
     Given a model with system "webshop" containing containers "api" and "db"
     And views exist for both context and container level
     When "bausteinsicht sync" generates the draw.io file
-    Then the "webshop" element in the context view contains a link
-    And clicking the link navigates to the container view area
+    Then each view is rendered as its own draw.io page
+    And the "webshop" element in the context view page carries a link
+    And clicking the link navigates to the container view page
 
-  Scenario: Parent view visible after drill-down
-    Given views at context and container level on a single draw.io page
-    When the user navigates from context to container level
-    Then the context view remains visible (smaller) above the container view
-    And clicking the context view navigates back
+  Scenario: Navigate back to the parent view
+    Given the user has drilled down from the context page to the container page
+    When the user clicks the generated back-navigation button
+    Then draw.io returns to the context view page
 ----
 
 === Export Command (UC-8)

--- a/src/docs/spec/07_trust_model.adoc
+++ b/src/docs/spec/07_trust_model.adoc
@@ -2,7 +2,7 @@
 :jbake-type: page_toc
 :jbake-status: published
 :jbake-menu: Specification
-:jbake-order: 7
+:jbake-order: 8
 
 = Trust Model
 
@@ -13,11 +13,17 @@ It operates entirely on the local filesystem with the permissions of the invokin
 
 == Trust Boundaries
 
-=== Fully Trusted: CLI Flags
+=== Path-Validated: CLI Flags
 
-CLI flags (`--model`, `--template`, `--output`) are provided directly by the user.
-Like other file-processing CLIs (`cat`, `jq`, `sed`), Bausteinsicht accepts arbitrary file paths by design.
-There is no path restriction — the user has full filesystem access.
+CLI flags (`--model`, `--template`, `--output`) are provided by the user, but their paths are **validated** before use: `validatePathContainment` (`cmd/bausteinsicht/root.go`) rejects paths containing `..` or otherwise escaping the working directory, returning exit code 2 (SEC-001 / SEC-016). This guards against an automated agent with untrusted input reading or writing outside the intended directory. Absolute paths and ordinary relative paths within the tree are accepted; directory-traversal sequences are not.
+
+=== Resource Limits
+
+To bound large or pathological input, regardless of source:
+
+* **Model size** — files larger than 10 MB are rejected (`internal/model/loader.go`).
+* **Hierarchy depth** — element nesting deeper than `MaxElementDepth` (50) is rejected (`internal/model/resolve.go`, SEC-007).
+* **Ambiguous auto-detection** — multiple `.jsonc` files in the working directory abort the command rather than silently selecting one.
 
 === Semi-Trusted: Model and Template Files
 
@@ -42,11 +48,22 @@ When Bausteinsicht runs inside an AI agent loop or CI pipeline, the caller shoul
 There is no built-in `--restrict-to-dir` flag.
 The trust model assumes the user (or their agent framework) controls filesystem boundaries.
 
+== External Processes
+
+Bausteinsicht is not a pure in-process transformer — some commands invoke external binaries, resolved from `PATH`:
+
+* **draw.io** — `export` (PNG/SVG) launches the draw.io CLI (`internal/export`).
+* **git** — `stale` and `changelog` shell out to `git log` to derive element history (`internal/stale`, `internal/changelog`).
+* **bausteinsicht (self)** — the LSP server re-executes the `bausteinsicht` binary for diagnostics (`internal/lsp/diagnostics.go`).
+
+These binaries are trusted and located via `PATH`; model and template *content* never determines which process runs or supplies its arguments. In a hardened environment, control `PATH` so only the intended binaries are resolved.
+
 == Non-Threats
 
 * **No network access** — Bausteinsicht makes no HTTP calls, DNS lookups, or socket connections.
-* **No code execution** — The model format (JSONC) and template format (draw.io XML) cannot trigger
-  arbitrary code execution.
+* **No code execution from input** — The model format (JSONC) and template format (draw.io XML) cannot trigger
+  arbitrary code execution; input content is parsed as data, never evaluated. (The tool does spawn the trusted
+  external binaries listed above, but never ones named or parameterized by model/template content.)
 * **No credential handling** — Bausteinsicht does not read, store, or transmit credentials.
 
 == Related Documents


### PR DESCRIPTION
## What

Fixes the **spec audit P1** findings (#422) — places where the spec actively contradicted the shipped code. Implements the maintainer decisions recorded on the issue.

### UC-7 / AC-7.1 — drill-down is page-based
Rewrote UC-7 (`spec/01`) and AC-7.1 (`spec/04`) from the original single-page-semantic-zoom description to the implemented **page-based drill-down** (one draw.io page per view + cross-page links + back button). New **ADR-009** records the decision with a weighted Pugh matrix (page-based wins +12 vs the single-page reference); `CLAUDE.md`'s Key Design Decision updated; ADR-009 added to the ch9 index.

### Trust model — corrected to the real guards
`07_trust_model.adoc` claimed "no path restriction — full filesystem access". Replaced with the actual `validatePathContainment` guard (rejects `..`, SEC-001/016), added a **Resource Limits** section (10 MB model cap, `MaxElementDepth` 50, multi-`.jsonc` abort) and an **External Processes** section (draw.io / git / LSP self-exec via PATH), and sharpened the "no code execution" non-threat to "no code execution *from input*".

### Auto-detection — spec'd backwards
`spec/02` and `arc42/08` said "first match alphabetically"; the code **aborts** on multiple `.jsonc` (exit 2, "use --model"). Docs now match the code (code stays — silently picking a file is unsafe for a tool that mutates and syncs).

### Export family — filenames, defaults, JSON shapes
All verified empirically against a built binary:
- `export` writes `architecture-<view>.<fmt>` (was `<view>.<fmt>`); added the `--scale` flag.
- `export-table` / `export-diagram` default to **stdout** (was `.`); real output filenames documented (`<view>-elements.adoc`, `elements.adoc`, `all-views-elements.adoc`; `workspace.dsl`).
- `--format json` emits **arrays** (table rows / `[{view,format,source}]`), not `{files,success}`.
- `export-diagram` lists all six formats (plantuml/mermaid/dot/d2/html/structurizr) incl. the structurizr whole-workspace special case that rejects `--view`.

### Missing flags + nav fix
Added `sync/watch --mermaid`/`--mermaid-output` and `init --generate-template` to the spec. Resolved the jbake nav collision: `07_trust_model` order 7 → 8 (filename kept to preserve inbound links).

## Verification
- `/doc-check review` → **PASS**: pure doc catch-up (0 impl/test changed, 7 docs), every newly-cited flag/symbol exists on main, no stale references remain.
- All export behavior, filenames, and JSON shapes confirmed by running the commands.
- AsciiDoc structure checked (tables balanced, PlantUML blocks balanced, no typographic quotes, ADR-009 links resolve).

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
