### PR TITLE
docs: fix broken inter-page links repo-wide (.adoc -> .html)

### DIFF
--- a/src/docs/arc42/2026-03-06-architecture-review.adoc
+++ b/src/docs/arc42/2026-03-06-architecture-review.adoc
@@ -25,14 +25,14 @@ Maintainers, contributors, and adopters evaluating Bausteinsicht for use in thei
 
 === Input Artifacts
 
-* link:chapters/10_quality_requirements.adoc[Chapter 10 — Quality Requirements] (QS-1 through QS-6)
-* link:ADRs/ADR-001-DSL-Format.adoc[ADR-001 — DSL Format (JSONC)]
-* link:ADRs/ADR-002-Implementation-Language.adoc[ADR-002 — Implementation Language (Go)]
-* link:ADRs/ADR-003-Risk-Classification.adoc[ADR-003 — Risk Classification]
-* link:ADRs/ADR-004-Sequence-Diagram-Export.adoc[ADR-004 — Sequence Diagram Export (Rejected)]
-* link:../spec/05_sync_specification.adoc[Sync Specification]
-* link:../security/2026-03-01-security-review.adoc[Security Review 2026-03-01]
-* link:../e2e-test-report-2026-03-05.adoc[E2E Test Report 2026-03-05]
+* link:chapters/10_quality_requirements.html[Chapter 10 — Quality Requirements] (QS-1 through QS-6)
+* link:ADRs/ADR-001-DSL-Format.html[ADR-001 — DSL Format (JSONC)]
+* link:ADRs/ADR-002-Implementation-Language.html[ADR-002 — Implementation Language (Go)]
+* link:ADRs/ADR-003-Risk-Classification.html[ADR-003 — Risk Classification]
+* link:ADRs/ADR-004-Sequence-Diagram-Export.html[ADR-004 — Sequence Diagram Export (Rejected)]
+* link:../spec/05_sync_specification.html[Sync Specification]
+* link:../security/2026-03-01-security-review.html[Security Review 2026-03-01]
+* link:../e2e-test-report-2026-03-05.html[E2E Test Report 2026-03-05]
 
 
 == Business and Architecture Drivers
@@ -125,7 +125,7 @@ Seven architectural approaches were identified and analyzed.
 
 === AP-1: JSONC with JSON Schema
 
-_Reference: link:ADRs/ADR-001-DSL-Format.adoc[ADR-001]_
+_Reference: link:ADRs/ADR-001-DSL-Format.html[ADR-001]_
 
 The architecture model is defined in JSONC (JSON with Comments) and validated against a JSON Schema.
 JSONC provides universal IDE support via SchemaStore, is natively readable by LLMs, and requires no custom parser.
@@ -135,7 +135,7 @@ The schema serves as living documentation and enables autocompletion without plu
 
 === AP-2: Go Single Binary
 
-_Reference: link:ADRs/ADR-002-Implementation-Language.adoc[ADR-002]_
+_Reference: link:ADRs/ADR-002-Implementation-Language.html[ADR-002]_
 
 The tool is implemented in Go, producing a statically linked binary with no runtime dependencies.
 Go provides compile-time type safety, fast startup (<10 ms), cross-compilation from a single build machine, and a minimal supply chain (no post-install script execution).
@@ -368,7 +368,7 @@ Tradeoff points are architectural decisions where improving one quality attribut
 [[TP-2]]
 === TP-2: JSONC vs. Custom DSL
 
-_Reference: link:ADRs/ADR-001-DSL-Format.adoc[ADR-001]_
+_Reference: link:ADRs/ADR-001-DSL-Format.html[ADR-001]_
 
 *Decision:* JSONC with JSON Schema, not a custom DSL (like Structurizr DSL or LikeC4).
 
@@ -472,7 +472,7 @@ Risks are architectural decisions or conditions that may cause problems.
 
 *Likelihood:* Medium — the tool accepts `--model` and `--template` paths without validation. +
 *Impact:* Medium — an attacker who controls CLI arguments could read or write files outside the intended directory. +
-*Reference:* SEC-001 in the link:../security/2026-03-01-security-review.adoc[security review]. +
+*Reference:* SEC-001 in the link:../security/2026-03-01-security-review.html[security review]. +
 *Mitigation:* The tool is a local CLI invoked by the user; the user already has filesystem access. Risk is relevant only when CLI is invoked by automated agents with untrusted input. +
 *Recommendation:* *[A]* Document the trust model. Consider optional `--restrict-to-dir` flag for agent use cases.
 

--- a/src/docs/arc42/2026-03-06-lasr-review.adoc
+++ b/src/docs/arc42/2026-03-06-lasr-review.adoc
@@ -24,7 +24,7 @@ The method produces a visual gap profile (spider chart) that highlights potentia
 
 === Companion Document
 
-This review complements the link:2026-03-06-architecture-review.adoc[ATAM Architecture Review] conducted on the same date.
+This review complements the link:2026-03-06-architecture-review.html[ATAM Architecture Review] conducted on the same date.
 Where ATAM provides comprehensive analysis of sensitivity points and tradeoffs, LASR provides a quick visual gap profile.
 
 
@@ -39,7 +39,7 @@ The tool ships as a single Go binary with zero runtime dependencies.
 
 == Step 2: Evaluation Scale — Quality Goals
 
-The top 5 quality goals are derived from the link:chapters/10_quality_requirements.adoc[quality requirements] and the project's business goals.
+The top 5 quality goals are derived from the link:chapters/10_quality_requirements.html[quality requirements] and the project's business goals.
 Each goal is assigned a **target value** (where we want to be for v1) on a 0–100 scale.
 
 [cols="1,3,1"]

--- a/src/docs/arc42/2026-03-30-architecture-review-update.adoc
+++ b/src/docs/arc42/2026-03-30-architecture-review-update.adoc
@@ -7,7 +7,7 @@
 
 == Review Context
 
-This is a follow-up Mini-ATAM review assessing the Bausteinsicht architecture 24 days after the initial link:2026-03-06-architecture-review.adoc[full ATAM review (2026-03-06)].
+This is a follow-up Mini-ATAM review assessing the Bausteinsicht architecture 24 days after the initial link:2026-03-06-architecture-review.html[full ATAM review (2026-03-06)].
 It focuses on three questions:
 
 1. Which recommendations from the initial review have been implemented?

--- a/src/docs/arc42/ADRs/ADR-004-Sequence-Diagram-Export.adoc
+++ b/src/docs/arc42/ADRs/ADR-004-Sequence-Diagram-Export.adoc
@@ -8,9 +8,9 @@
 
 == Status
 
-Superseded by link:ADR-008-Sequence-Diagram-Export-Revisited.adoc[ADR-008]
+Superseded by link:ADR-008-Sequence-Diagram-Export-Revisited.html[ADR-008]
 
-NOTE: This ADR rejected dynamic views / sequence export for v1. The decision was *reversed* in 2026-05 (link:https://github.com/docToolchain/Bausteinsicht/issues/282[#282], link:https://github.com/docToolchain/Bausteinsicht/issues/321[#321]) when the `dynamicViews` model section and the `export-sequence` command were implemented — i.e. Option B below, which this ADR scored lowest. See link:ADR-008-Sequence-Diagram-Export-Revisited.adoc[ADR-008] for the superseding decision and its corrected weighting. The analysis below is retained unchanged as historical record.
+NOTE: This ADR rejected dynamic views / sequence export for v1. The decision was *reversed* in 2026-05 (link:https://github.com/docToolchain/Bausteinsicht/issues/282[#282], link:https://github.com/docToolchain/Bausteinsicht/issues/321[#321]) when the `dynamicViews` model section and the `export-sequence` command were implemented — i.e. Option B below, which this ADR scored lowest. See link:ADR-008-Sequence-Diagram-Export-Revisited.html[ADR-008] for the superseding decision and its corrected weighting. The analysis below is retained unchanged as historical record.
 
 == Context
 

--- a/src/docs/arc42/ADRs/ADR-007-Testing-Strategy.adoc
+++ b/src/docs/arc42/ADRs/ADR-007-Testing-Strategy.adoc
@@ -203,8 +203,8 @@ Overall target: **≥85% package coverage** for critical paths, **≥70% for CLI
 
 == Related Decision Records
 
-- link:ADR-002-Implementation-Language.adoc[ADR-002] — Go as implementation language (influences test frameworks)
-- link:ADR-003-Risk-Classification.adoc[ADR-003] — Risk tier (influences coverage targets)
+- link:ADR-002-Implementation-Language.html[ADR-002] — Go as implementation language (influences test frameworks)
+- link:ADR-003-Risk-Classification.html[ADR-003] — Risk tier (influences coverage targets)
 
 == References
 

--- a/src/docs/arc42/ADRs/ADR-008-Sequence-Diagram-Export-Revisited.adoc
+++ b/src/docs/arc42/ADRs/ADR-008-Sequence-Diagram-Export-Revisited.adoc
@@ -10,11 +10,11 @@
 
 Accepted
 
-Supersedes link:ADR-004-Sequence-Diagram-Export.adoc[ADR-004], which rejected this feature for v1.
+Supersedes link:ADR-004-Sequence-Diagram-Export.html[ADR-004], which rejected this feature for v1.
 
 == Context
 
-link:ADR-004-Sequence-Diagram-Export.adoc[ADR-004] evaluated four approaches to sequence-diagram support and *rejected* the feature for Bausteinsicht's core, recommending an out-of-scope LLM Skill instead. Its Pugh matrix scored "Dynamic Views" (Option B) lowest (-9), driven by heavy penalties on model complexity, implementation effort, and alignment with a structural-only focus.
+link:ADR-004-Sequence-Diagram-Export.html[ADR-004] evaluated four approaches to sequence-diagram support and *rejected* the feature for Bausteinsicht's core, recommending an out-of-scope LLM Skill instead. Its Pugh matrix scored "Dynamic Views" (Option B) lowest (-9), driven by heavy penalties on model complexity, implementation effort, and alignment with a structural-only focus.
 
 Experience after ADR-004 changed three of those assumptions:
 

--- a/src/docs/arc42/chapters/01_introduction_and_goals.adoc
+++ b/src/docs/arc42/chapters/01_introduction_and_goals.adoc
@@ -41,7 +41,7 @@ Bausteinsicht addresses the gap between structured architecture models and widel
 | Templates are draw.io files containing styled example elements. Users create and customize templates entirely within draw.io.
 |===
 
-See link:../../PRD/PRD-001-Bausteinsicht.adoc[PRD-001] for the full product requirements.
+See link:../../PRD/PRD-001-Bausteinsicht.html[PRD-001] for the full product requirements.
 
 === Quality Goals
 
@@ -111,4 +111,4 @@ The following projects solve similar or overlapping problems:
 |===
 
 Bausteinsicht's differentiator is **bidirectional synchronization** between a text model (JSONC) and draw.io diagrams — edits in either direction are merged.
-See link:../../arc42/ADRs/ADR-001-DSL-Format.adoc[ADR-001] for a detailed comparison of DSL formats.
+See link:../../arc42/ADRs/ADR-001-DSL-Format.html[ADR-001] for a detailed comparison of DSL formats.

--- a/src/docs/arc42/chapters/02_architecture_constraints.adoc
+++ b/src/docs/arc42/chapters/02_architecture_constraints.adoc
@@ -18,10 +18,10 @@ ifndef::imagesdir[:imagesdir: ../../images]
 | Constraint | Description
 
 | Go as implementation language
-| The tool is implemented in Go to enable single-binary distribution without runtime dependencies. See link:../ADRs/ADR-002-Implementation-Language.adoc[ADR-002].
+| The tool is implemented in Go to enable single-binary distribution without runtime dependencies. See link:../ADRs/ADR-002-Implementation-Language.html[ADR-002].
 
 | JSON as model format
-| The architecture model uses JSON (JSONC) with JSON Schema for validation. See link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001].
+| The architecture model uses JSON (JSONC) with JSON Schema for validation. See link:../ADRs/ADR-001-DSL-Format.html[ADR-001].
 
 | draw.io XML as output format
 | The visual representation uses draw.io's mxGraph XML format. This constrains layout capabilities to what draw.io supports.

--- a/src/docs/arc42/chapters/09_architecture_decisions.adoc
+++ b/src/docs/arc42/chapters/09_architecture_decisions.adoc
@@ -19,42 +19,42 @@ All ADRs are located in `src/docs/arc42/ADRs/`.
 |===
 | ADR | Title | Status | Summary
 
-| link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001]
+| link:../ADRs/ADR-001-DSL-Format.html[ADR-001]
 | Choice of DSL Format
 | Accepted
 | JSON with JSON Schema (JSONC) chosen over TypeScript DSL and Custom DSL (Langium). Scored highest on learnability, IDE support, LLM friendliness, and bidirectional sync suitability.
 
-| link:../ADRs/ADR-002-Implementation-Language.adoc[ADR-002]
+| link:../ADRs/ADR-002-Implementation-Language.html[ADR-002]
 | Choice of Implementation Language
 | Accepted
 | Go chosen over Python and Kotlin/JVM. Single-binary distribution, LLM-friendly code generation, compile-time type safety, and dedicated mxGraph library support.
 
-| link:../ADRs/ADR-003-Risk-Classification.adoc[ADR-003]
+| link:../ADRs/ADR-003-Risk-Classification.html[ADR-003]
 | Risk Classification
 | Accepted
 | Tier 2 (Extended Assurance) — determined by Code Type = 2 (Business Logic). Existing toolchain covers most mitigations. Guides AI-assisted development quality requirements.
 
-| link:../ADRs/ADR-004-Sequence-Diagram-Export.adoc[ADR-004]
+| link:../ADRs/ADR-004-Sequence-Diagram-Export.html[ADR-004]
 | Sequence Diagram Export
 | Superseded by ADR-008
 | Originally rejected `dynamicViews` / sequence export for v1. Reversed in 2026-05; see ADR-008.
 
-| link:../ADRs/ADR-005-Auto-Layout-Engine.adoc[ADR-005]
+| link:../ADRs/ADR-005-Auto-Layout-Engine.html[ADR-005]
 | Auto-Layout Engine for New Diagram Pages
 | Accepted
 | Layered/grid/none placement modes for fresh diagram pages. Relationship-aware BFS ordering within scopes; manual positions preserved on incremental sync.
 
-| link:../ADRs/ADR-006-CLI-Add-Command-Strategy.adoc[ADR-006]
+| link:../ADRs/ADR-006-CLI-Add-Command-Strategy.html[ADR-006]
 | CLI Add Command Strategy
 | Accepted
 | `add` subcommands merge into existing items rather than replacing them, for safe LLM- and script-driven editing.
 
-| link:../ADRs/ADR-007-Testing-Strategy.adoc[ADR-007]
+| link:../ADRs/ADR-007-Testing-Strategy.html[ADR-007]
 | Testing Strategy
 | Accepted
 | Unit / integration / E2E classification, plus property-based tests (pgregory.net/rapid). Tests trace to issues and use cases.
 
-| link:../ADRs/ADR-008-Sequence-Diagram-Export-Revisited.adoc[ADR-008]
+| link:../ADRs/ADR-008-Sequence-Diagram-Export-Revisited.html[ADR-008]
 | Sequence Diagram Export (Revisited)
 | Accepted
 | Reverses ADR-004: implements `dynamicViews` + `export-sequence` (PlantUML/Mermaid). Behavioral views kept in one model with structure; sync engine ignores the section.

--- a/src/docs/arc42/chapters/10_quality_requirements.adoc
+++ b/src/docs/arc42/chapters/10_quality_requirements.adoc
@@ -52,7 +52,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 | Within 30 minutes, the developer has created a valid architecture model with at least 3 elements, 2 relationships, and 1 draw.io view — using only the documentation and IDE autocompletion.
 |===
 
-Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON chosen for universal familiarity and IDE support).
+Driven by: link:../ADRs/ADR-001-DSL-Format.html[ADR-001] (JSON chosen for universal familiarity and IDE support).
 
 ==== QS-2: IDE Support
 
@@ -68,7 +68,7 @@ Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON chosen for univer
 | The editor provides autocompletion for property names, validates values against allowed types, and shows hover documentation for each field — without any Bausteinsicht-specific plugin installed. Only the JSON Schema association is required.
 |===
 
-Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON Schema provides free IDE support via SchemaStore).
+Driven by: link:../ADRs/ADR-001-DSL-Format.html[ADR-001] (JSON Schema provides free IDE support via SchemaStore).
 
 ==== QS-3: LLM Friendliness
 
@@ -84,7 +84,7 @@ Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON Schema provides f
 | The agent successfully adds the element with title, description, technology, and relationships, then runs `bausteinsicht sync` — all without human intervention and without producing invalid JSON.
 |===
 
-Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON is the native output format of LLMs).
+Driven by: link:../ADRs/ADR-001-DSL-Format.html[ADR-001] (JSON is the native output format of LLMs).
 
 ==== QS-4: Sync Reliability
 
@@ -114,7 +114,7 @@ Driven by: link:../ADRs/ADR-001-DSL-Format.adoc[ADR-001] (JSON is the native out
 | The tool runs immediately without installing Go, Python, Node.js, Java, or any other runtime. Total time from download to first successful command is under 1 minute.
 |===
 
-Driven by: link:../ADRs/ADR-002-Implementation-Language.adoc[ADR-002] (Go chosen for single-binary distribution).
+Driven by: link:../ADRs/ADR-002-Implementation-Language.html[ADR-002] (Go chosen for single-binary distribution).
 
 ==== QS-6: Flexible Hierarchy
 

--- a/src/docs/arc42/chapters/11_technical_risks.adoc
+++ b/src/docs/arc42/chapters/11_technical_risks.adoc
@@ -14,7 +14,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 == Risks and Technical Debts
 
 
-The canonical risk analysis for Bausteinsicht is the link:../2026-03-06-architecture-review.adoc[ATAM Architecture Review (2026-03-06)], which identifies 8 risks, 5 sensitivity points, and 6 tradeoff points.
+The canonical risk analysis for Bausteinsicht is the link:../2026-03-06-architecture-review.html[ATAM Architecture Review (2026-03-06)], which identifies 8 risks, 5 sensitivity points, and 6 tradeoff points.
 This section summarizes the top risks.
 For the complete risk register, sensitivity point analysis, and tradeoff analysis, refer to the full ATAM review.
 

--- a/src/docs/manual/user-manual.adoc
+++ b/src/docs/manual/user-manual.adoc
@@ -55,7 +55,7 @@ bausteinsicht sync
 This creates a sample Online Shop architecture with three views.
 Open `architecture.drawio` in draw.io to see the generated diagrams.
 
-For a detailed walkthrough, see the link:../spec/06_tutorial.adoc[Getting Started Tutorial].
+For a detailed walkthrough, see the link:../spec/06_tutorial.html[Getting Started Tutorial].
 
 === Daily Workflow
 
@@ -520,7 +520,7 @@ See <<troubleshooting>> for common export issues.
 [[troubleshooting]]
 === Command Reference
 
-See the link:../spec/02_cli_specification.adoc[CLI Specification] for full command details.
+See the link:../spec/02_cli_specification.html[CLI Specification] for full command details.
 
 [cols="2,3"]
 |===
@@ -581,6 +581,6 @@ See the link:../spec/02_cli_specification.adoc[CLI Specification] for full comma
 
 === Further Reading
 
-* link:../spec/03_data_models.adoc[Data Models] — JSONC structure, draw.io XML format, Go structs
-* link:../spec/05_sync_specification.adoc[Sync Specification] — three-way sync algorithm details
-* link:../spec/06_tutorial.adoc[Getting Started Tutorial] — step-by-step walkthrough
+* link:../spec/03_data_models.html[Data Models] — JSONC structure, draw.io XML format, Go structs
+* link:../spec/05_sync_specification.html[Sync Specification] — three-way sync algorithm details
+* link:../spec/06_tutorial.html[Getting Started Tutorial] — step-by-step walkthrough

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -10,7 +10,7 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 == CLI Specification
 
-See link:01_use_cases.adoc[Use Cases] for the functional overview of all CLI commands.
+See link:01_use_cases.html[Use Cases] for the functional overview of all CLI commands.
 
 === Command Overview
 

--- a/src/docs/spec/07_trust_model.adoc
+++ b/src/docs/spec/07_trust_model.adoc
@@ -51,5 +51,5 @@ The trust model assumes the user (or their agent framework) controls filesystem 
 
 == Related Documents
 
-* link:../security/2026-03-01-security-review.adoc[Security Review]
+* link:../security/2026-03-01-security-review.html[Security Review]
 * link:../../../CLAUDE.md[Project Conventions — Security Report]

--- a/src/docs/tutorial/01_getting_started.adoc
+++ b/src/docs/tutorial/01_getting_started.adoc
@@ -89,7 +89,7 @@ Four files appear, each with a clear job:
 | **The generated diagrams.** One draw.io page per view. You arrange and fine-tune here; structural truth stays in the model.
 
 | `template.drawio`
-| **The visual style library.** One styled shape per element kind. Copy it, restyle it, pass it with `--template` (see link:03_drawio_roundtrip.adoc[chapter 3]).
+| **The visual style library.** One styled shape per element kind. Copy it, restyle it, pass it with `--template` (see link:03_drawio_roundtrip.html[chapter 3]).
 
 | `.bausteinsicht-sync`
 | **Sync memory.** A checksummed snapshot of the last synced state, so the next sync knows what changed on which side. Commit it together with the other files.
@@ -176,4 +176,4 @@ Rel(onlineshop, email_service, "sends emails")
 
 You have a valid model, generated diagrams, and the tools to inspect both. Next, you will change the model and watch the diagrams follow.
 
-Continue with link:02_modeling.adoc[2. Modeling Your Architecture].
+Continue with link:02_modeling.html[2. Modeling Your Architecture].

--- a/src/docs/tutorial/02_modeling.adoc
+++ b/src/docs/tutorial/02_modeling.adoc
@@ -167,4 +167,4 @@ bausteinsicht validate --format json
 }
 ----
 
-Continue with link:03_drawio_roundtrip.adoc[3. The draw.io Round-Trip].
+Continue with link:03_drawio_roundtrip.html[3. The draw.io Round-Trip].

--- a/src/docs/tutorial/03_drawio_roundtrip.adoc
+++ b/src/docs/tutorial/03_drawio_roundtrip.adoc
@@ -158,4 +158,4 @@ This re-places all elements of the synced views — deliberately destructive to 
 
 Views form a hierarchy through their `scope`: a view scoped to `onlineshop` shows its children inside the system boundary. Sync generates page links between the levels — click a system in the context view to jump to its container view, and use the generated back-button to return. The result reads like an interactive C4 model inside plain draw.io.
 
-Continue with link:04_exports.adoc[4. Sharing: Exports].
+Continue with link:04_exports.html[4. Sharing: Exports].

--- a/src/docs/tutorial/04_exports.adoc
+++ b/src/docs/tutorial/04_exports.adoc
@@ -156,4 +156,4 @@ bausteinsicht export --view context --image-format png
 
 This drives the draw.io desktop app headlessly, so it requires draw.io installed on the machine. `--image-format svg`, `--scale 2` for high-DPI (scale factors above 1 need a hardware GPU), `--output <dir>` to choose the destination. In containers, see the devcontainer notes in the repository — headless draw.io needs xvfb and a dbus daemon.
 
-Continue with link:05_analysis_evolution.adoc[5. Analysis and Evolution].
+Continue with link:05_analysis_evolution.html[5. Analysis and Evolution].

--- a/src/docs/tutorial/05_analysis_evolution.adoc
+++ b/src/docs/tutorial/05_analysis_evolution.adoc
@@ -152,4 +152,4 @@ The diff speaks architecture — added elements, removed relationships, changed 
 
 For planned architectures, the model can carry `asIs` and `toBe` sections; `bausteinsicht diff` then reports the gap between today and the target as a structured change list — the same idea as snapshots, but for states you model deliberately side by side.
 
-Continue with link:06_ai_workflows.adoc[6. AI and Automation Workflows].
+Continue with link:06_ai_workflows.html[6. AI and Automation Workflows].

--- a/src/docs/tutorial/06_ai_workflows.adoc
+++ b/src/docs/tutorial/06_ai_workflows.adoc
@@ -133,8 +133,8 @@ A pull request that introduces a dependency cycle, breaks a constraint, or lets 
 
 == Where to go from here
 
-* The link:../spec/02_cli_specification.adoc[CLI specification] documents commands in depth.
-* The link:../spec/05_sync_specification.adoc[sync specification] explains the synchronization algorithm precisely.
-* The link:../arc42/arc42.adoc[architecture documentation] shows Bausteinsicht documented with Bausteinsicht.
+* The link:../spec/02_cli_specification.html[CLI specification] documents commands in depth.
+* The link:../spec/05_sync_specification.html[sync specification] explains the synchronization algorithm precisely.
+* The link:../arc42/arc42.html[architecture documentation] shows Bausteinsicht documented with Bausteinsicht.
 
 You now have the full loop: model in text, diagrams in draw.io, analysis in CI, and agents as co-architects. Replace the sample shop with your own system — `bausteinsicht init` in a fresh directory is all it takes.


### PR DESCRIPTION
## Problem

`link:<doc>.adoc[…]` renders as a **literal** link (unlike `xref:`), so on the published docToolchain site these point at `.adoc` source files that don't exist there — they 404. The rendered pages are `.html`. This affects the whole docs tree, not just the tutorial.

Verified live: `…/tutorial/02_modeling.html` → 200, but `…/tutorial/02_modeling.adoc` (as linked) → 404.

## Fix

Two commits:
1. **Tutorial** — the 6 "Continue with …" links + chapter-1/6 cross-references.
2. **Repo-wide** — every other internal `link:…adoc[…]` under `src/docs/`: arc42 chapters (01, 02, 09, 10, 11), all cross-linking ADRs, the ATAM/LASR review docs, the spec, and the user manual.

All converted to the `.html` target (matching the convention already used in `spec/06_tutorial.adoc`).

**Left untouched:** the `link:../../../CLAUDE.md[…]` reference (not a rendered site page) and all `https://` links. `xref:` is not used anywhere.

## Verification
- 0 internal `link:…adoc[` remain under `src/docs/`.
- Every distinct `.html` target confirmed to resolve **200** on the live site (ADRs, PRD, spec, security review, review docs, E2E report, quality requirements).
- Link-target changes only — no content edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
