### PR TITLE
docs(site): rename the ADR menu label to "ADRs"

### DIFF
--- a/docToolchainConfig.groovy
+++ b/docToolchainConfig.groovy
@@ -143,7 +143,7 @@ microsite.with {
     // set a title to '-' in order to remove this menu entry.
     // 'Development' holds internal dev artifacts (E2E reports, test plan, security review,
     // announcement) — built and link-reachable, but hidden from the top nav ('-').
-    menu = ['tutorial':'Tutorial', 'manual':'User Manual', 'PRD':'PRD', 'Specification':'Specification', 'arc42':'Architecture', 'ADR':'ADR', 'Development':'-']
+    menu = ['tutorial':'Tutorial', 'manual':'User Manual', 'PRD':'PRD', 'Specification':'Specification', 'arc42':'Architecture', 'ADR':'ADRs', 'Development':'-']
 
 //tag::additionalConverters[]
 /**


### PR DESCRIPTION
## What

Renames the **ADR** top-nav menu label to **ADRs** — the section groups all nine ADRs, so the plural reads naturally as a collection and matches the `arc42/ADRs/` folder name.

Title-only change in the menu map (`'ADR':'ADR'` → `'ADR':'ADRs'`). The internal `jbake-menu` code stays `ADR`, so none of the ADR files need re-tagging.

## Verification

Built locally with `./dtcw generateSite` and inspected `build/microsite/output/index.html` — top nav now reads: **Tutorial · User Manual · PRD · Specification · Architecture · ADRs** (Development hidden). Confirmed before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
