### PR TITLE
docs(tutorial): warm up the intro (the why) and deepen the draw.io how-to

### DIFF
--- a/src/docs/tutorial/01_getting_started.adoc
+++ b/src/docs/tutorial/01_getting_started.adoc
@@ -12,9 +12,19 @@ ifndef::imagesdir[:imagesdir: ../../images]
 
 This tutorial takes you from an empty directory to a living architecture model: you will model a system, sync it with draw.io, analyze it, version it, and drive it from an AI agent. Every command and every output shown here was executed against the current build — what you see is what you get.
 
-== What Bausteinsicht is
+== What Bausteinsicht is — and why
 
-Bausteinsicht keeps your software architecture in a structured JSONC model and renders it as draw.io diagrams — with bidirectional synchronization. Change the model, and the diagrams follow. Rename an element in draw.io, and the model follows. The single source of truth is a text file that lives in git, diffs cleanly, and is readable by humans, IDEs, and LLMs alike.
+Architecture documentation rots. The diagram in the wiki drifts from the system, and nobody trusts it after a few months. Bausteinsicht attacks that from a specific angle: it splits *what the architecture is* from *how it looks*.
+
+Humans and LLMs want different things from architecture. **You** want a picture — boxes and lines you can take in at a glance and point at in a review. An **LLM** wants structured text — something it can read precisely, reason about, and edit without misunderstanding a diagram's pixels. Bausteinsicht gives each side what it's good with and keeps them in lockstep:
+
+* The **source of truth is a JSONC model** — a structured text file that lives in git, diffs cleanly, validates against a schema, and is trivially readable and writable by an LLM.
+* From that one model, Bausteinsicht **generates draw.io diagrams** — the visual, human-facing view, in a tool you already know.
+* Synchronization runs **both ways**: change the model and the diagrams follow; rename or redraw in draw.io and the model follows.
+
+That bridge is the point. An LLM can confidently restructure the model — add a service, rewire a dependency, validate the result — because it works in text, not pixels. You review and arrange the *diagram*, where humans are fast. Neither side has to work in the other's awkward medium, and because the model is the single source of truth, the picture can't quietly drift from reality. The model stays LLM-readable; the diagrams stay human-readable; the two never disagree.
+
+The rest of this tutorial walks that loop end to end — model it, see it in draw.io, arrange it once, then let model and diagram evolve together.
 
 == Installation
 

--- a/src/docs/tutorial/03_drawio_roundtrip.adoc
+++ b/src/docs/tutorial/03_drawio_roundtrip.adoc
@@ -57,9 +57,35 @@ Rel(onlineshop_api, onlineshop_export_storage, "writes reports")
 @enduml
 ....
 
+== Working in draw.io
+
+The generated `architecture.drawio` is a normal draw.io file — but a few things are specific to how Bausteinsicht builds it. This is where you spend your "human" time, so it's worth knowing the moves.
+
+=== Navigating
+
+Each **view is its own page** — use the page tabs along the bottom of the draw.io window to switch between System Context, Container View, and so on. You also navigate by **drilling down**: click a system in the context view and draw.io follows the generated link to that system's container page; a generated *back* button returns you to the parent. Browsing the architecture is mostly clicking, like an interactive C4 model.
+
+=== Selecting and moving an element
+
+Here's the one thing that trips people up. Each element is a draw.io **container**: the shape plus its **title and description as child cells**. It is *not* a locked group, so a single click does not always grab "the whole box":
+
+* Click the **shape body** (the colored area, away from the text) → selects the whole element. Drag it and the title/description move with it.
+* Click directly on the **title or description text** → selects just that text cell. Good for editing, not for moving the element.
+* The reliable way to grab a complete element — especially a small one whose text covers most of the body — is a **rubber-band selection**: press on empty canvas and drag a box around the element. To reposition a whole row at once, rubber-band around all of them and drag together.
+
+TIP: if you grabbed only the label, press `Escape` and try again on the shape body, or just rubber-band around the element.
+
+=== Editing text (this flows back to the model)
+
+Double-click an element's **title** and type to rename it; double-click the **description** to edit it. On the next `sync` these travel back into the model (see Reverse, below). Editing an element's **position or size changes nothing in the model** — layout is yours to keep.
+
+=== Lay it out once
+
+New elements arrive stacked by the auto-layout and marked (a red dashed border) so you can spot them. You arrange them by hand the first time — and **only** the first time. After that, sync **never moves what you have placed**; it only positions the *next* new element. So manual layout is a one-time cost per element, not a tax you pay on every sync. (If you ever want to start the arrangement over, `sync --relayout` re-runs the auto-layout — see Layout control below.)
+
 == Reverse: draw.io → model
 
-Open `architecture.drawio`, double-click the "Search Service" shape, and rename it to "Product Search". Save, then:
+Open `architecture.drawio`, double-click the "Search Service" title, and rename it to "Product Search". Save, then:
 
 [source,bash]
 ----


### PR DESCRIPTION
## What

Addresses feedback that the tutorial read too dry and under-served a few core aspects.

### ch1 — lead with the *why*
New "What Bausteinsicht is — and why" section frames the whole tool as an **LLM↔human collaboration bridge**: humans want a visual diagram they can grasp at a glance; an LLM wants structured text it can read and edit precisely. Bausteinsicht keeps an **LLM-readable JSONC model** as the single source of truth and generates **human-readable, maintainable draw.io diagrams** from it, syncing both ways — so neither side works in the other's awkward medium and the picture can't drift from reality.

### ch3 — a real draw.io how-to
New "Working in draw.io" section covering the practical moves that were missing:
- **Navigating** — pages = views; drill down by clicking linked elements; generated back button.
- **Selecting & moving** — the gotcha: each element is a draw.io **container** (shape + title/description as child cells), *not* a locked group. Click the shape body to move the whole thing, or **rubber-band select** to reliably grab it (and to move a whole row at once). Verified against the generated XML (`container=1`, child cells with relative geometry).
- **Editing text** — double-click the title/description to rename (reverse-syncs); position/size changes never touch the model.
- **Lay it out once** — the key principle the feedback asked for: manual layout is a **one-time** cost per element; sync never moves what you placed, it only positions newly added elements. `--relayout` for a fresh start.

## Verification
Built locally with `./dtcw generateSite`; both chapters render (why-narrative and the full draw.io section present in the output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
