### PR TITLE
docs(arc42): ch1-3 catch up with the grown product (#416 final slice)

### DIFF
--- a/src/docs/arc42/chapters/01_introduction_and_goals.adoc
+++ b/src/docs/arc42/chapters/01_introduction_and_goals.adoc
@@ -39,6 +39,18 @@ Bausteinsicht addresses the gap between structured architecture models and widel
 
 | Template System
 | Templates are draw.io files containing styled example elements. Users create and customize templates entirely within draw.io.
+
+| Architecture Analysis
+| Commands assess the model: constraint checking (`lint`), a health score (`health`), dependency-graph analysis (`graph`), stale-element detection (`stale`), lifecycle status (`status`), and full-text search (`find`).
+
+| Architecture Evolution
+| The architecture is versioned and comparable over time: snapshots with semantic diff (`snapshot`), as-is/to-be comparison (`diff`), and an architecture changelog (`changelog`).
+
+| Interoperability & Export
+| Models import from Structurizr DSL and LikeC4 (`import`) and export to C4-PlantUML, Mermaid, DOT, D2, HTML, Structurizr DSL, sequence diagrams, tables, and PNG/SVG.
+
+| IDE Integration
+| A Language Server (the separate `bausteinsicht-lsp` binary) and a VS Code extension provide in-editor diagnostics and code lenses for model files.
 |===
 
 See link:../../PRD/PRD-001-Bausteinsicht.html[PRD-001] for the full product requirements.

--- a/src/docs/arc42/chapters/02_architecture_constraints.adoc
+++ b/src/docs/arc42/chapters/02_architecture_constraints.adoc
@@ -26,11 +26,17 @@ ifndef::imagesdir[:imagesdir: ../../images]
 | draw.io XML as output format
 | The visual representation uses draw.io's mxGraph XML format. This constrains layout capabilities to what draw.io supports.
 
-| No JavaScript/Node.js
-| JavaScript and Node.js are excluded from the technology stack due to security concerns with npm package managers.
+| No JavaScript/Node.js in the product
+| The CLI and its libraries use no JavaScript/Node.js, avoiding npm supply-chain risk. Exception: the optional VS Code extension (`vscode-extension/`) is a separate TypeScript/npm artifact, not part of the released binary.
 
 | Cross-platform
 | The tool must run on Linux, macOS, and Windows.
+
+| Headless draw.io for image export
+| `export` (PNG/SVG) shells out to the draw.io desktop CLI; it must be installed (in containers: via xvfb + dbus). The text exports need no draw.io.
+
+| Git for history-based commands
+| `stale` and `changelog` invoke the `git` binary to derive element history; outside a git repository they degrade gracefully.
 |===
 
 === Organizational Constraints

--- a/src/docs/arc42/chapters/03_context_and_scope.adoc
+++ b/src/docs/arc42/chapters/03_context_and_scope.adoc
@@ -82,6 +82,8 @@ image::arc42/architecture-context.png[System Context,width=80%]
 
 include::context-elements.adoc[]
 
+NOTE: The generated diagram above is itself produced from a Bausteinsicht model and shows the principal technical partners (developer, draw.io, IDE). The table below is the authoritative, complete set of communication partners — including the human architect, LLM agents, and git, which act on the system rather than appearing inside its own context view.
+
 [cols="1,2,2"]
 |===
 | Communication Partner | Input | Output
@@ -140,4 +142,24 @@ include::context-elements.adoc[]
 | JSON Schema
 | Published schema file (local or SchemaStore.org)
 | Enables IDE support without Bausteinsicht-specific plugins.
+
+| draw.io CLI
+| External process (auto-detected on `PATH`)
+| `export` invokes the headless draw.io binary to render diagram pages to PNG/SVG.
+
+| Git
+| External process (`git log`)
+| `stale` and `changelog` read element history from the repository; optional (graceful degradation outside git).
+
+| Import / export formats
+| Files on filesystem
+| In: Structurizr DSL (`.dsl`), LikeC4 (`.c4`). Out: C4-PlantUML, Mermaid, DOT, D2, HTML, Structurizr DSL, sequence diagrams, AsciiDoc/Markdown tables.
+
+| Language Server (LSP)
+| JSON-RPC over stdio
+| The `bausteinsicht-lsp` binary serves diagnostics and code lenses to editors (e.g. the VS Code extension).
+
+| Snapshot store
+| Files on filesystem (`.bausteinsicht-snapshots/`)
+| Versioned model captures written and read by the `snapshot` commands.
 |===


### PR DESCRIPTION
## What

Final slice of the arc42 P2 refresh (#416) — brings **arc42 Chapters 1–3** up to date with the grown product.

- **ch1 (Introduction & Goals)** — the requirements overview covered only the v1 core. Extended it to the shipped surface: Architecture Analysis (`lint`/`health`/`graph`/`stale`/`status`/`find`), Architecture Evolution (`snapshot`/`diff`/`changelog`), Interoperability & Export (import + six diagram/table formats), and IDE Integration (the `bausteinsicht-lsp` binary + VS Code extension). Quality goals were already correct and are unchanged.
- **ch2 (Constraints)** — scoped the "No JavaScript/Node.js" constraint to the **product binary** (the VS Code extension is a separate TS/npm artifact, called out as the exception), and added the two **de-facto runtime constraints**: headless draw.io for PNG/SVG export, and git for the history-based commands.
- **ch3 (Context & Scope)** — added a note explaining why the generated context diagram shows fewer partners than the authoritative partner table, and added the missing **technical interfaces**: draw.io CLI exec, git exec, import/export file formats, LSP over stdio, and the snapshot store.

## Completes #416

The arc42 P2 refresh is now done across five slices: ch12 glossary ✅ · ch5 building blocks ✅ · ch6 runtime ✅ · ch11 risks ✅ · **ch1-3 ← this PR**. `Closes #416`.

## Verification

Built locally with `./dtcw generateSite` — all three chapters render (tables balanced; new rows/notes present in the output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
