### PR TITLE
docs(spec): document the remaining CLI commands (#423 slice 2)

### DIFF
--- a/cmd/bausteinsicht/import.go
+++ b/cmd/bausteinsicht/import.go
@@ -25,8 +25,8 @@ Supported formats:
 
 Exit codes:
   0   import successful
-  1   parse error
-  2   output file already exists (use --force to overwrite)`,
+  1   import failed (unknown --from, unreadable input, parse/encoding error)
+  2   output file already exists (use --force to overwrite, or --dry-run to skip the check)`,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -1228,7 +1228,7 @@ Imports an architecture model from an external DSL and writes a Bausteinsicht `.
 | `--force` | Overwrite the output file if it already exists. | No | `false`
 |===
 
-**Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output exists without `--force`; exit `1` on any other import failure (unknown `--from`, unreadable input, parse/encoding error).
+**Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output file already exists and neither `--force` nor `--dry-run` is set — `--dry-run` prints to stdout and skips the existence check, so it never fails on an existing output. Exit `1` on any other import failure (unknown `--from`, unreadable input, parse/encoding error).
 
 ==== `bausteinsicht generate-template`
 
@@ -1272,12 +1272,12 @@ Loads external metrics (error rate, coverage, …) from a JSON file and overlays
 |===
 | Subcommand | Description
 
-| `apply <metrics-file>` | Apply a metric heatmap (`--metric <key>`, default: first available; `--output`, default `architecture.drawio`).
+| `apply <metrics-file>` | Apply a metric heatmap (`--metric <key>`, default: first available; `--output`, default `<model-dir>/architecture.drawio`, i.e. next to the model file).
 | `list <metrics-file>` | List the metrics available in the file.
-| `remove` | Remove the overlay and restore original colors (`--output`).
+| `remove` | Remove the overlay and restore original colors (`--output`, same default).
 |===
 
-`apply` and `remove` load the model directly and do **not** auto-detect — pass `--model` (there is no default).
+`apply` and `remove` load the model directly and do **not** auto-detect — pass `--model` (there is no default). When `--output` is omitted it resolves relative to the model file's directory, not the current directory. Any overlay failure (missing model/metrics file, unreadable diagram, unknown metric) exits with code `2`.
 
 ==== `bausteinsicht repl`
 
@@ -1285,7 +1285,7 @@ Starts an interactive shell for editing the model.
 
 **Flags:** none beyond the global flags.
 
-**Behavior:** keeps the model in memory; supports `add`/`remove`/`list`/`undo`/`save`. Validates before every save; pure additions are patched comment-preserving, modifications/deletions fall back to a full rewrite (with a warning). Warns on exit with unsaved changes; `Ctrl-D` (EOF) exits cleanly.
+**Behavior:** keeps the model in memory; supports `add`/`remove`/`list`/`show`/`validate`/`undo`/`save` (plus `help` and `exit`). Validates before every save; pure additions are patched comment-preserving, modifications/deletions fall back to a full rewrite (with a warning). `exit` with unsaved changes prompts for confirmation before quitting; `Ctrl-D` (EOF) warns about unsaved changes and exits cleanly.
 
 ==== `bausteinsicht adr`
 

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -106,6 +106,38 @@ See link:01_use_cases.html[Use Cases] for the functional overview of all CLI com
 | Generate an architecture changelog between two versions
 | Implemented
 
+| `bausteinsicht import`
+| Import a model from Structurizr DSL or LikeC4
+| Implemented
+
+| `bausteinsicht generate-template`
+| Generate a draw.io template from the specification
+| Implemented
+
+| `bausteinsicht layout`
+| Compute hierarchical layout and write positions back to draw.io
+| Implemented
+
+| `bausteinsicht overlay`
+| Apply/list/remove metric heatmap overlays on the diagram
+| Implemented
+
+| `bausteinsicht repl`
+| Interactive shell for editing the model
+| Implemented
+
+| `bausteinsicht adr`
+| List and show Architecture Decision Records linked to elements
+| Implemented
+
+| `bausteinsicht workspace`
+| List, merge, and validate multi-model workspaces
+| Implemented
+
+| `bausteinsicht schema`
+| Generate the JSON Schema from the Go model types
+| Implemented
+
 | `bausteinsicht --version`
 | Display version number
 | Implemented
@@ -1177,3 +1209,124 @@ Generates a human-readable changelog between two versions of the model.
 |===
 
 **Behavior:** loads the model at each git ref (via `git rev-parse` / `git show`) and reports the architecture changes between them. Only git refs are supported — snapshot IDs are not (yet) resolved, and an empty `--since` fails to resolve. (Note: changelog uses `--changelog-format`, not the global `--format`.)
+
+==== `bausteinsicht import`
+
+Imports an architecture model from an external DSL and writes a Bausteinsicht `.jsonc` file.
+
+**Arguments:** `<input-file>` (required) — the source DSL file.
+
+**Flags:**
+
+[cols="2,3,1,1"]
+|===
+| Flag | Description | Required | Default
+
+| `--from` | Source format: `structurizr` (`.dsl`) or `likec4` (`.c4`). | Yes | (none)
+| `--output` | Output model file path. | No | `architecture.jsonc`
+| `--dry-run` | Print the generated model to stdout instead of writing the file. | No | `false`
+| `--force` | Overwrite the output file if it already exists. | No | `false`
+|===
+
+**Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output exists without `--force`, `1` on a parse error.
+
+==== `bausteinsicht generate-template`
+
+Generates a draw.io template with a styled shape for each element kind in the specification.
+
+**Flags:**
+
+[cols="2,3,1,1"]
+|===
+| Flag | Description | Required | Default
+
+| `--style` | Visual preset: `default`, `c4`, `minimal`, or `dark`. | No | `default`
+| `--output` | Output template file. | No | `architecture-template.drawio`
+| `--model` | Model file (auto-detected if omitted). | No | (auto-detect)
+|===
+
+**Behavior:** the generated file carries the `bausteinsicht_template` attributes the sync engine needs, so it works directly as a `--template`.
+
+==== `bausteinsicht layout`
+
+Computes a hierarchical layout for the diagram and writes the element positions back to the draw.io file.
+
+**Flags:**
+
+[cols="2,3,1,1"]
+|===
+| Flag | Description | Required | Default
+
+| `--algorithm` | Layout algorithm (currently only `hierarchical`). | No | `hierarchical`
+| `--rank-dir` | Ranking direction: `TB` (top-to-bottom) or `LR` (left-to-right). | No | `TB`
+| `--preserve-pinned` | Do not move elements marked `bausteinsicht-pinned=true`. | No | `true`
+|===
+
+==== `bausteinsicht overlay`
+
+Loads external metrics (error rate, coverage, …) from a JSON file and overlays them as a heatmap on draw.io elements; original styles are preserved.
+
+**Subcommands:**
+
+[cols="1,3"]
+|===
+| Subcommand | Description
+
+| `apply <metrics-file>` | Apply a metric heatmap (`--metric <key>`, default: first available; `--output`, default `architecture.drawio`).
+| `list <metrics-file>` | List the metrics available in the file.
+| `remove` | Remove the overlay and restore original colors (`--output`).
+|===
+
+==== `bausteinsicht repl`
+
+Starts an interactive shell for editing the model.
+
+**Flags:** none beyond the global flags.
+
+**Behavior:** keeps the model in memory; supports `add`/`remove`/`list`/`undo`/`save`. Validates before every save; pure additions are patched comment-preserving, modifications/deletions fall back to a full rewrite (with a warning). Warns on exit with unsaved changes; `Ctrl-D` (EOF) exits cleanly.
+
+==== `bausteinsicht adr`
+
+Lists and shows Architecture Decision Records linked to model elements (the `decisions` field).
+
+**Subcommands:**
+
+[cols="1,3"]
+|===
+| Subcommand | Description
+
+| `list` | List all ADRs, or only those linked to one element (`--element <id>`).
+| `show <adr-id>` | Show details of a specific ADR.
+|===
+
+**Flags:** `--model`, `-m` (default `architecture.jsonc`) and the global `--format`.
+
+==== `bausteinsicht workspace`
+
+Works with multi-model workspaces that combine several architecture models.
+
+**Subcommands:**
+
+[cols="1,3"]
+|===
+| Subcommand | Description
+
+| `list <config-file>` | List the models in a workspace configuration.
+| `merge <config-file> <output-file>` | Merge the configured models into one unified model.
+| `validate <config-file>` | Validate a workspace configuration.
+|===
+
+==== `bausteinsicht schema`
+
+Manages the JSON Schema for Bausteinsicht models.
+
+**Subcommands:**
+
+[cols="1,3"]
+|===
+| Subcommand | Description
+
+| `generate` | Generate the JSON Schema from the Go model types.
+|===
+
+**Behavior:** the schema is generated from `internal/model` types, so it stays in sync with the model definitions.

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -1228,7 +1228,7 @@ Imports an architecture model from an external DSL and writes a Bausteinsicht `.
 | `--force` | Overwrite the output file if it already exists. | No | `false`
 |===
 
-**Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output exists without `--force`, `1` on a parse error.
+**Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output exists without `--force`; exit `1` on any other import failure (unknown `--from`, unreadable input, parse/encoding error).
 
 ==== `bausteinsicht generate-template`
 
@@ -1277,6 +1277,8 @@ Loads external metrics (error rate, coverage, …) from a JSON file and overlays
 | `remove` | Remove the overlay and restore original colors (`--output`).
 |===
 
+`apply` and `remove` load the model directly and do **not** auto-detect — pass `--model` (there is no default).
+
 ==== `bausteinsicht repl`
 
 Starts an interactive shell for editing the model.
@@ -1299,7 +1301,7 @@ Lists and shows Architecture Decision Records linked to model elements (the `dec
 | `show <adr-id>` | Show details of a specific ADR.
 |===
 
-**Flags:** `--model`, `-m` (default `architecture.jsonc`) and the global `--format`.
+**Flags:** `--model`, `-m` (default `architecture.jsonc`). `adr list` supports `--format text|json` and `--element <id>` to filter; `adr show` prints text only.
 
 ==== `bausteinsicht workspace`
 
@@ -1326,7 +1328,7 @@ Manages the JSON Schema for Bausteinsicht models.
 |===
 | Subcommand | Description
 
-| `generate` | Generate the JSON Schema from the Go model types.
+| `generate` | Generate the JSON Schema from the Go model types (`--output`, default `schemas/bausteinsicht.schema.json`).
 |===
 
 **Behavior:** the schema is generated from `internal/model` types, so it stays in sync with the model definitions.


### PR DESCRIPTION
## What

Completes the `spec/02` command reference with the last **8** commands: `import`, `generate-template`, `layout`, `overlay`, `repl`, `adr`, `workspace`, `schema` — added to both the Command Overview and the Detailed Command Specifications.

All flags, subcommands, and arguments **verified against the binary's `--help`** (lesson applied from #456 — no assumed behavior): e.g. `overlay apply/list/remove <metrics-file>`, `workspace list/merge/validate <config-file>`, `adr list/show <adr-id>`, `schema generate`, `layout --rank-dir/--preserve-pinned`, `import --from/--dry-run/--force`.

**`spec/02` now covers all 27 commands** (it documented 9 before this backlog).

## Scope

Slice 2 of the Spec P2 backlog (#423). The data-model + lifecycle part is in #457 (open). After both merge, #423's remaining items are the contract-form bits (BR-IDs / test traceability, Cockburn use cases) and the E2E-test-plan refresh.

## Verification

Built locally with `./dtcw generateSite` — renders; tables balanced; cross-checked that every command in `bausteinsicht --help` now has a section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)