### PR TITLE
fix(ci): normalize line endings to LF and make test failures block CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Force LF on checkout for all text files on every platform.
+#
+# Windows CI runners default to core.autocrlf=true, which would inject CRLF
+# at checkout and break byte-exact comparisons such as
+# internal/schema.TestCommittedSchemaInSync (it compares the committed
+# schemas/bausteinsicht.schema.json verbatim against the LF output of the
+# generator). Pinning eol=lf keeps the working copy identical to the LF blobs
+# the generator produces, so the test holds on Windows too.
+* text=auto eol=lf
+
+# Binary assets — never normalize.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.pdf  binary

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,6 +27,9 @@ jobs:
           go-version-file: go.mod
       - run: go build ./...
       - name: Run tests with coverage
+        id: test
+        # continue-on-error so the report still generates and uploads below;
+        # the job is failed explicitly in the final step if tests did not pass.
         continue-on-error: true
         shell: bash
         run: go test ./... -json -covermode=atomic -coverprofile=coverage.out > test-results.json
@@ -90,6 +93,16 @@ jobs:
             test-results.json
             coverage.out
           retention-days: 30
+      - name: Fail job if tests failed
+        if: always()
+        shell: bash
+        env:
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          if [ "$TEST_OUTCOME" != "success" ]; then
+            echo "::error::Go tests failed — see the 'Run tests with coverage' step and the uploaded test report."
+            exit 1
+          fi
 
   merge-reports:
     needs: build-and-test
@@ -127,7 +140,9 @@ jobs:
           retention-days: 90
 
   report-pr-comment:
-    if: github.event_name == 'pull_request'
+    # always() so the report still posts even when build-and-test fails the
+    # job on a test failure (the artifacts are uploaded before that happens).
+    if: always() && github.event_name == 'pull_request'
     needs: [build-and-test, merge-reports]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The multi-OS test report showed **one Windows-only test failure** while CI stayed green:

| Metric | 🐧 Linux | 🪟 Windows | 🍎 macOS |
|--------|----------|-----------|--------|
| ❌ Failed | 0 | **1** | 0 |

### Root cause (two independent issues)

**1. CRLF on Windows checkout.** `internal/schema.TestCommittedSchemaInSync` compares the committed `schemas/bausteinsicht.schema.json` **byte-for-byte** against the LF output of the schema generator (`sync_test.go:57`). Verified:
- committed blob: **0 CRLF** (pure LF)
- generator output: **0 CRLF** (pure LF)
- under LF the two are **byte-identical**

Windows runners default to `core.autocrlf=true`, so the file is checked out with CRLF → `\r\n` ≠ `\n` → fail on Windows only. There was **no `.gitattributes`** to pin line endings.

**2. Test failures did not block CI.** The `Run tests with coverage` step was `continue-on-error: true`, so a red test never failed the job (the failure only surfaced in the PR comment). Combined with golangci-lint running `|| true` elsewhere, the pipeline was effectively advisory-only on tests.

## Fix

1. **`.gitattributes`** with `* text=auto eol=lf` — all text files check out as LF on every platform, so byte-exact tests hold on Windows. Binary assets (`*.png`, `*.pdf`, …) are marked `binary`. The repo blobs are already LF, so this only affects checkout (no renormalization diff).
2. **`go.yml`** — the test step keeps `continue-on-error` so the multi-OS report still generates and uploads, but a final step now **fails the job when tests did not pass** (`steps.test.outcome`). `report-pr-comment` is moved to `if: always()` so the report still posts on a red job.

## Verification

- Confirmed locally: committed schema blob == generator output under LF (byte-identical).
- `go.yml` validated as well-formed YAML.

## Notes

- This PR deliberately does **not** add a gofmt gate — the tree has pre-existing gofmt drift (39 files, alignment-only) tracked separately, to be fixed together with the gate in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)