### PR TITLE
style: gofmt the tree and add a CI gofmt gate

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -279,3 +279,23 @@ jobs:
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v6
         with:
           version: latest
+
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - name: Check gofmt
+        shell: bash
+        run: |
+          unformatted=$(gofmt -l . | grep -v '^vendor/' || true)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files are not gofmt-formatted. Run: gofmt -w ."
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "All Go files are gofmt-clean."

--- a/cmd/bausteinsicht/add_from_pattern.go
+++ b/cmd/bausteinsicht/add_from_pattern.go
@@ -152,18 +152,18 @@ func runListPatterns(cmd *cobra.Command) error {
 	if format == "json" {
 		// Output as JSON
 		type patternInfo struct {
-			ID            string `json:"id"`
-			Description   string `json:"description"`
-			ElementCount  int    `json:"elementCount"`
-			RelationshipCount int `json:"relationshipCount"`
+			ID                string `json:"id"`
+			Description       string `json:"description"`
+			ElementCount      int    `json:"elementCount"`
+			RelationshipCount int    `json:"relationshipCount"`
 		}
 		var patterns []patternInfo
 		for _, id := range patternIDs {
 			p := m.Specification.Patterns[id]
 			patterns = append(patterns, patternInfo{
-				ID:            id,
-				Description:   p.Description,
-				ElementCount:  len(p.Elements),
+				ID:                id,
+				Description:       p.Description,
+				ElementCount:      len(p.Elements),
 				RelationshipCount: len(p.Relationships),
 			})
 		}

--- a/cmd/bausteinsicht/add_specification_test.go
+++ b/cmd/bausteinsicht/add_specification_test.go
@@ -17,11 +17,11 @@ func TestIsValidSpecKey(t *testing.T) {
 		{"my_component", true},
 		{"my-component", true},
 		{"custom123", true},
-		{"_invalid", false},    // starts with underscore
-		{"123invalid", false},  // starts with digit
-		{"Component", false},   // uppercase
+		{"_invalid", false},     // starts with underscore
+		{"123invalid", false},   // starts with digit
+		{"Component", false},    // uppercase
 		{"my component", false}, // space
-		{"", false},            // empty
+		{"", false},             // empty
 	}
 
 	for _, tt := range tests {

--- a/cmd/bausteinsicht/generate_template.go
+++ b/cmd/bausteinsicht/generate_template.go
@@ -52,10 +52,10 @@ func runGenerateTemplate(cmd *cobra.Command, _ []string) error {
 
 	// Validate style
 	validStyles := map[string]bool{
-		"default":  true,
-		"c4":       true,
-		"minimal":  true,
-		"dark":     true,
+		"default": true,
+		"c4":      true,
+		"minimal": true,
+		"dark":    true,
 	}
 	if !validStyles[style] {
 		return exitWithCode(fmt.Errorf("unknown style %q: valid values are default, c4, minimal, dark", style), 2)

--- a/cmd/bausteinsicht/lint.go
+++ b/cmd/bausteinsicht/lint.go
@@ -54,8 +54,8 @@ func runLint(cmd *cobra.Command, _ []string) error {
 
 func lintOutputJSON(cmd *cobra.Command, r constraints.Result) error {
 	type jsonResult struct {
-		Passed     bool                 `json:"passed"`
-		Total      int                  `json:"total"`
+		Passed     bool                    `json:"passed"`
+		Total      int                     `json:"total"`
 		Violations []constraints.Violation `json:"violations"`
 	}
 

--- a/cmd/bausteinsicht/overlay.go
+++ b/cmd/bausteinsicht/overlay.go
@@ -70,10 +70,10 @@ func newOverlayApplyCmd() *cobra.Command {
 			format, _ := cmd.Flags().GetString("format")
 			if format == "json" {
 				out, _ := json.Marshal(map[string]interface{}{
-					"status":  "applied",
-					"metric":  metricKey,
-					"file":    drawioPath,
-					"model":   m.Specification,
+					"status": "applied",
+					"metric": metricKey,
+					"file":   drawioPath,
+					"model":  m.Specification,
 				})
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(out))
 			} else {

--- a/internal/benchmarks/benchmarks_test.go
+++ b/internal/benchmarks/benchmarks_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/docToolchain/Bausteinsicht/internal/diagram"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/docToolchain/Bausteinsicht/internal/table"
 )
 

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -198,11 +198,11 @@ func TestElementChanges_FilterByKind(t *testing.T) {
 	ec := ElementChanges{
 		Added: []diff.ElementChange{
 			{
-				ID: "api",
+				ID:   "api",
 				ToBe: &model.Element{Kind: "container", Title: "API"},
 			},
 			{
-				ID: "db",
+				ID:   "db",
 				ToBe: &model.Element{Kind: "storage", Title: "Database"},
 			},
 		},

--- a/internal/diagram/markdown_test.go
+++ b/internal/diagram/markdown_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestWrapDiagramsInMarkdown(t *testing.T) {
 	diagrams := map[string]string{
-		"context": "C4Context\n    title Context View\n    Person(user, \"User\")",
+		"context":   "C4Context\n    title Context View\n    Person(user, \"User\")",
 		"container": "C4Container\n    title Container View\n    Container(api, \"API\")",
 	}
 	viewTitles := map[string]string{
-		"context": "System Context",
+		"context":   "System Context",
 		"container": "Container Architecture",
 	}
 	viewKeys := []string{"context", "container"}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -80,10 +80,10 @@ func compareRelationships(asIsRels, toBeRels []model.Relationship, result *DiffR
 		if !exists {
 			// Relationship removed
 			result.Relationships = append(result.Relationships, RelationshipChange{
-				From:   asIsRel.From,
-				To:     asIsRel.To,
-				Type:   ChangeRemoved,
-				AsIs:   &asIsRel,
+				From: asIsRel.From,
+				To:   asIsRel.To,
+				Type: ChangeRemoved,
+				AsIs: &asIsRel,
 			})
 			continue
 		}
@@ -91,11 +91,11 @@ func compareRelationships(asIsRels, toBeRels []model.Relationship, result *DiffR
 		// Check if changed (e.g., label changed)
 		if asIsRel.Label != toBeRel.Label {
 			result.Relationships = append(result.Relationships, RelationshipChange{
-				From:   asIsRel.From,
-				To:     asIsRel.To,
-				Type:   ChangeChanged,
-				AsIs:   &asIsRel,
-				ToBe:   &toBeRel,
+				From: asIsRel.From,
+				To:   asIsRel.To,
+				Type: ChangeChanged,
+				AsIs: &asIsRel,
+				ToBe: &toBeRel,
 			})
 		}
 	}
@@ -104,10 +104,10 @@ func compareRelationships(asIsRels, toBeRels []model.Relationship, result *DiffR
 	for key, toBeRel := range toBeMap {
 		if _, exists := asIsMap[key]; !exists {
 			result.Relationships = append(result.Relationships, RelationshipChange{
-				From:   toBeRel.From,
-				To:     toBeRel.To,
-				Type:   ChangeAdded,
-				ToBe:   &toBeRel,
+				From: toBeRel.From,
+				To:   toBeRel.To,
+				Type: ChangeAdded,
+				ToBe: &toBeRel,
 			})
 		}
 	}

--- a/internal/diff/drawio.go
+++ b/internal/diff/drawio.go
@@ -2,14 +2,14 @@ package diff
 
 // DrawIO color definitions for diff visualization
 const (
-	ColorAdded   = "#d5e8d4"    // green
-	ColorRemoved = "#f8cecc"    // red
-	ColorChanged = "#ffe6cc"    // orange
-	ColorUnchanged = "#ffffff"  // white (default)
+	ColorAdded     = "#d5e8d4" // green
+	ColorRemoved   = "#f8cecc" // red
+	ColorChanged   = "#ffe6cc" // orange
+	ColorUnchanged = "#ffffff" // white (default)
 
-	StrokeAdded   = "#82b366"   // dark green
-	StrokeRemoved = "#b85450"   // dark red
-	StrokeChanged = "#d6b656"   // dark orange
+	StrokeAdded   = "#82b366" // dark green
+	StrokeRemoved = "#b85450" // dark red
+	StrokeChanged = "#d6b656" // dark orange
 )
 
 // AppliedChangeStyle returns the fill and stroke colors for a changed element

--- a/internal/diff/types.go
+++ b/internal/diff/types.go
@@ -13,35 +13,35 @@ const (
 
 // ElementChange represents a single element change
 type ElementChange struct {
-	ID       string                 `json:"id"`
-	Type     ChangeType             `json:"type"`
-	AsIs     *model.Element         `json:"asIs,omitempty"`
-	ToBe     *model.Element         `json:"toBe,omitempty"`
-	Reason   string                 `json:"reason,omitempty"`
+	ID     string         `json:"id"`
+	Type   ChangeType     `json:"type"`
+	AsIs   *model.Element `json:"asIs,omitempty"`
+	ToBe   *model.Element `json:"toBe,omitempty"`
+	Reason string         `json:"reason,omitempty"`
 }
 
 // RelationshipChange represents a single relationship change
 type RelationshipChange struct {
-	From     string         `json:"from"`
-	To       string         `json:"to"`
-	Type     ChangeType     `json:"type"`
-	AsIs     *model.Relationship `json:"asIs,omitempty"`
-	ToBe     *model.Relationship `json:"toBe,omitempty"`
+	From string              `json:"from"`
+	To   string              `json:"to"`
+	Type ChangeType          `json:"type"`
+	AsIs *model.Relationship `json:"asIs,omitempty"`
+	ToBe *model.Relationship `json:"toBe,omitempty"`
 }
 
 // DiffResult contains all changes between two architecture snapshots
 type DiffResult struct {
-	Elements      []ElementChange       `json:"elements"`
-	Relationships []RelationshipChange  `json:"relationships"`
+	Elements      []ElementChange      `json:"elements"`
+	Relationships []RelationshipChange `json:"relationships"`
 	Summary       Summary              `json:"summary"`
 }
 
 // Summary counts changes by type
 type Summary struct {
-	AddedElements      int `json:"addedElements"`
-	RemovedElements    int `json:"removedElements"`
-	ChangedElements    int `json:"changedElements"`
-	AddedRelationships int `json:"addedRelationships"`
+	AddedElements        int `json:"addedElements"`
+	RemovedElements      int `json:"removedElements"`
+	ChangedElements      int `json:"changedElements"`
+	AddedRelationships   int `json:"addedRelationships"`
 	RemovedRelationships int `json:"removedRelationships"`
 	TotalAddedElements   int `json:"totalAddedElements"`
 	TotalRemovedElements int `json:"totalRemovedElements"`

--- a/internal/drawio/document_chaos_test.go
+++ b/internal/drawio/document_chaos_test.go
@@ -11,10 +11,10 @@ func TestLoadCorruptXML(t *testing.T) {
 	tc := chaos.NewTestChaos(t)
 
 	testCases := map[string]string{
-		"not-xml": "this is not xml at all",
-		"incomplete-tag": "<mxfile><diagram",
+		"not-xml":         "this is not xml at all",
+		"incomplete-tag":  "<mxfile><diagram",
 		"invalid-nesting": "<mxfile></diagram></mxfile>",
-		"empty-file": "",
+		"empty-file":      "",
 	}
 
 	for name, content := range testCases {

--- a/internal/graph/analyzer.go
+++ b/internal/graph/analyzer.go
@@ -8,8 +8,8 @@ import (
 
 // Analyzer performs graph analysis on model relationships.
 type Analyzer struct {
-	model *model.BausteinsichtModel
-	graph map[string][]string // element ID → list of outgoing relationship targets
+	model   *model.BausteinsichtModel
+	graph   map[string][]string // element ID → list of outgoing relationship targets
 	reverse map[string][]string // reverse graph: target → list of incoming sources
 }
 

--- a/internal/graph/analyzer_test.go
+++ b/internal/graph/analyzer_test.go
@@ -87,9 +87,9 @@ func TestAnalyzerCentrality(t *testing.T) {
 			},
 		},
 		Model: map[string]model.Element{
-			"hub":    {Kind: "component", Title: "Hub"},
-			"dep1":   {Kind: "component", Title: "Dep1"},
-			"dep2":   {Kind: "component", Title: "Dep2"},
+			"hub":  {Kind: "component", Title: "Hub"},
+			"dep1": {Kind: "component", Title: "Dep1"},
+			"dep2": {Kind: "component", Title: "Dep2"},
 		},
 		Relationships: []model.Relationship{
 			{From: "hub", To: "dep1"},

--- a/internal/graph/types.go
+++ b/internal/graph/types.go
@@ -8,11 +8,11 @@ type Cycle struct {
 
 // Centrality metrics for an element.
 type Centrality struct {
-	ID        string  `json:"id"`
-	InDegree  int     `json:"inDegree"`  // number of incoming relationships
-	OutDegree int     `json:"outDegree"` // number of outgoing relationships
+	ID          string  `json:"id"`
+	InDegree    int     `json:"inDegree"`    // number of incoming relationships
+	OutDegree   int     `json:"outDegree"`   // number of outgoing relationships
 	Betweenness float64 `json:"betweenness"` // how many shortest paths pass through this node
-	Closeness float64 `json:"closeness"` // average distance to all other nodes
+	Closeness   float64 `json:"closeness"`   // average distance to all other nodes
 }
 
 // Component represents a strongly connected component in the graph.
@@ -24,13 +24,13 @@ type Component struct {
 
 // GraphAnalysis contains results from relationship graph analysis.
 type GraphAnalysis struct {
-	ElementCount    int           `json:"elementCount"`
-	RelationshipCount int         `json:"relationshipCount"`
-	Cycles          []Cycle       `json:"cycles"`
-	Centrality      []Centrality  `json:"centrality"`
-	Components      []Component   `json:"components"`
-	IDAGValid       bool          `json:"idagValid"` // true if graph is acyclic
-	MaxDepth        int           `json:"maxDepth"`  // longest dependency path
+	ElementCount      int          `json:"elementCount"`
+	RelationshipCount int          `json:"relationshipCount"`
+	Cycles            []Cycle      `json:"cycles"`
+	Centrality        []Centrality `json:"centrality"`
+	Components        []Component  `json:"components"`
+	IDAGValid         bool         `json:"idagValid"` // true if graph is acyclic
+	MaxDepth          int          `json:"maxDepth"`  // longest dependency path
 }
 
 // NodeInfo holds temporary computation data for graph algorithms.

--- a/internal/health/types.go
+++ b/internal/health/types.go
@@ -4,10 +4,10 @@ package health
 type ScoreCategory string
 
 const (
-	CategoryCompleteness   ScoreCategory = "completeness"
-	CategoryConformance    ScoreCategory = "conformance"
-	CategoryComplexity     ScoreCategory = "complexity"
-	CategoryDeprecation    ScoreCategory = "deprecation"
+	CategoryCompleteness  ScoreCategory = "completeness"
+	CategoryConformance   ScoreCategory = "conformance"
+	CategoryComplexity    ScoreCategory = "complexity"
+	CategoryDeprecation   ScoreCategory = "deprecation"
 	CategoryDocumentation ScoreCategory = "documentation"
 )
 
@@ -22,23 +22,23 @@ type Finding struct {
 
 // CategoryScore represents the score for a single dimension.
 type CategoryScore struct {
-	Category  ScoreCategory `json:"category"`
-	Score     float64       `json:"score"`      // 0-100
-	Weight    float64       `json:"weight"`     // 0-1
-	Findings  []Finding     `json:"findings"`
-	Details   string        `json:"details,omitempty"`
+	Category ScoreCategory `json:"category"`
+	Score    float64       `json:"score"`  // 0-100
+	Weight   float64       `json:"weight"` // 0-1
+	Findings []Finding     `json:"findings"`
+	Details  string        `json:"details,omitempty"`
 }
 
 // HealthScore is the overall architecture health assessment.
 type HealthScore struct {
-	Overall     float64          `json:"overall"`     // 0-100 weighted average
-	Categories  []CategoryScore  `json:"categories"`
-	Grade       string           `json:"grade"`       // A+, A, B+, B, C+, C, D, F
-	Summary     string           `json:"summary"`
-	Timestamp   string           `json:"timestamp"`   // ISO8601
-	ElementCnt  int              `json:"elementCnt"`
-	RelCnt      int              `json:"relCnt"`
-	ViewCnt     int              `json:"viewCnt"`
+	Overall    float64         `json:"overall"` // 0-100 weighted average
+	Categories []CategoryScore `json:"categories"`
+	Grade      string          `json:"grade"` // A+, A, B+, B, C+, C, D, F
+	Summary    string          `json:"summary"`
+	Timestamp  string          `json:"timestamp"` // ISO8601
+	ElementCnt int             `json:"elementCnt"`
+	RelCnt     int             `json:"relCnt"`
+	ViewCnt    int             `json:"viewCnt"`
 }
 
 // calculateGrade converts a numeric score to a letter grade.

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -389,15 +389,15 @@ func (p *dslParser) collectArgs() []string {
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 
 type lc4State struct {
-	kinds           map[string]bool // known element kind names from specification
-	kindsContainer  map[string]bool // kinds that have children in the model
-	spec            map[string]model.ElementKind
-	elements        map[string]model.Element
-	varToPath       map[string]string
-	pendingRels     []pendingRel
-	views           map[string]model.View
-	viewKeys        map[string]int
-	warnings        []string
+	kinds          map[string]bool // known element kind names from specification
+	kindsContainer map[string]bool // kinds that have children in the model
+	spec           map[string]model.ElementKind
+	elements       map[string]model.Element
+	varToPath      map[string]string
+	pendingRels    []pendingRel
+	views          map[string]model.View
+	viewKeys       map[string]int
+	warnings       []string
 }
 
 type pendingRel struct {

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -18,8 +18,8 @@ import (
 type tokKind int
 
 const (
-	tokEOF tokKind = iota
-	tokNewline // statement separator — emitted for each (group of) newline(s)
+	tokEOF     tokKind = iota
+	tokNewline         // statement separator — emitted for each (group of) newline(s)
 	tokString
 	tokIdent
 	tokLBrace

--- a/internal/layout/hierarchical.go
+++ b/internal/layout/hierarchical.go
@@ -7,10 +7,10 @@ import (
 // HierarchicalLayout computes layer assignments via longest-path algorithm,
 // then positions elements in layers with horizontal alignment.
 type HierarchicalLayout struct {
-	model     *model.BausteinsichtModel
-	rankDir   string // TB or LR
-	spacing   float64
-	layerGap  float64
+	model    *model.BausteinsichtModel
+	rankDir  string // TB or LR
+	spacing  float64
+	layerGap float64
 }
 
 // NewHierarchicalLayout creates a hierarchical layout engine.

--- a/internal/layout/types.go
+++ b/internal/layout/types.go
@@ -11,10 +11,10 @@ const (
 
 // Config holds layout computation parameters.
 type Config struct {
-	Algorithm     Algorithm
-	View          string // if empty, layout all views
+	Algorithm      Algorithm
+	View           string // if empty, layout all views
 	PreservePinned bool
-	RankDir       string // TB (top-to-bottom) or LR (left-to-right)
+	RankDir        string // TB (top-to-bottom) or LR (left-to-right)
 }
 
 // ElementPosition represents a positioned element.

--- a/internal/model/coverage_improvement_test.go
+++ b/internal/model/coverage_improvement_test.go
@@ -35,7 +35,7 @@ func TestValidateConstraints(t *testing.T) {
 	m := &BausteinsichtModel{
 		Specification: Specification{
 			Elements: map[string]ElementKind{
-				"system": {Notation: "box"},
+				"system":  {Notation: "box"},
 				"service": {Notation: "component"},
 			},
 		},
@@ -110,8 +110,8 @@ func TestDynamicViewStepTypes(t *testing.T) {
 
 func TestElementKindConfig(t *testing.T) {
 	tests := []struct {
-		name      string
-		kind      ElementKind
+		name            string
+		kind            ElementKind
 		canHaveChildren bool
 	}{
 		{"container", ElementKind{Notation: "box", Container: true}, true},
@@ -153,7 +153,7 @@ func TestRelationshipKindConfig(t *testing.T) {
 				"system": {Notation: "box"},
 			},
 			Relationships: map[string]RelationshipKind{
-				"sync": {Notation: "arrow", Dashed: false},
+				"sync":  {Notation: "arrow", Dashed: false},
 				"async": {Notation: "arrow", Dashed: true},
 			},
 		},
@@ -177,9 +177,9 @@ func TestComplexHierarchy(t *testing.T) {
 	m := &BausteinsichtModel{
 		Specification: Specification{
 			Elements: map[string]ElementKind{
-				"system": {Notation: "box", Container: true},
+				"system":  {Notation: "box", Container: true},
 				"service": {Notation: "component", Container: true},
-				"module": {Notation: "box", Container: false},
+				"module":  {Notation: "box", Container: false},
 			},
 		},
 		Model: map[string]Element{
@@ -192,7 +192,7 @@ func TestComplexHierarchy(t *testing.T) {
 						Title: "Backend",
 						Children: map[string]Element{
 							"auth": {Kind: "module", Title: "Auth"},
-							"api": {Kind: "module", Title: "API"},
+							"api":  {Kind: "module", Title: "API"},
 						},
 					},
 					"frontend": {

--- a/internal/model/model_chaos_test.go
+++ b/internal/model/model_chaos_test.go
@@ -12,10 +12,10 @@ func TestLoadCorruptJSONC(t *testing.T) {
 
 	testCases := []string{
 		"{invalid json}",
-		"{\"model\": }",  // incomplete
+		"{\"model\": }", // incomplete
 		"[not an object]",
-		"",               // empty
-		"{\"spec\": ",    // truncated
+		"",            // empty
+		"{\"spec\": ", // truncated
 	}
 
 	for _, invalid := range testCases {

--- a/internal/model/patch_test.go
+++ b/internal/model/patch_test.go
@@ -331,7 +331,6 @@ func TestAppendArrayEntry_TrailingLineComment(t *testing.T) {
 	}
 }
 
-
 func TestPatchValue_WithBlockComments(t *testing.T) {
 	input := `{
   /* block comment */

--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -579,4 +579,3 @@ func validateSupersededDecisions(m *BausteinsichtModel) []ValidationWarning {
 
 	return warnings
 }
-

--- a/internal/overlay/normalize.go
+++ b/internal/overlay/normalize.go
@@ -7,22 +7,22 @@ import (
 
 func IsMetricBetter(metricName string) bool {
 	goodMetrics := map[string]bool{
-		"coverage":       true,
-		"uptime":         true,
-		"deploy_freq":    true,
-		"success_rate":   true,
-		"availability":   true,
+		"coverage":     true,
+		"uptime":       true,
+		"deploy_freq":  true,
+		"success_rate": true,
+		"availability": true,
 	}
 	badMetrics := map[string]bool{
-		"error_rate":     true,
-		"latency":        true,
-		"p99":            true,
-		"p99_ms":         true,
-		"response_time":  true,
-		"cpu_usage":      true,
-		"memory_usage":   true,
-		"error_count":    true,
-		"failures":       true,
+		"error_rate":    true,
+		"latency":       true,
+		"p99":           true,
+		"p99_ms":        true,
+		"response_time": true,
+		"cpu_usage":     true,
+		"memory_usage":  true,
+		"error_count":   true,
+		"failures":      true,
 	}
 
 	if goodMetrics[metricName] {

--- a/internal/overlay/normalize_test.go
+++ b/internal/overlay/normalize_test.go
@@ -63,10 +63,10 @@ func TestColorForValue(t *testing.T) {
 		normalized float64
 		expected   string
 	}{
-		{0.1, "#d5e8d4"},  // Green
-		{0.3, "#fff2cc"},  // Yellow
-		{0.6, "#ffe6cc"},  // Orange
-		{0.9, "#f8cecc"},  // Red
+		{0.1, "#d5e8d4"}, // Green
+		{0.3, "#fff2cc"}, // Yellow
+		{0.6, "#ffe6cc"}, // Orange
+		{0.9, "#f8cecc"}, // Red
 	}
 
 	for _, tc := range tests {

--- a/internal/overlay/types.go
+++ b/internal/overlay/types.go
@@ -5,18 +5,18 @@ import (
 )
 
 type MetricsFile struct {
-	Meta    MetaInfo       `json:"meta"`
+	Meta    MetaInfo        `json:"meta"`
 	Metrics []ElementMetric `json:"metrics"`
 }
 
 type MetaInfo struct {
-	Generated           string            `json:"generated"`
-	Source              string            `json:"source"`
-	MetricDescriptions  map[string]string `json:"metric_descriptions"`
+	Generated          string            `json:"generated"`
+	Source             string            `json:"source"`
+	MetricDescriptions map[string]string `json:"metric_descriptions"`
 }
 
 type ElementMetric struct {
-	ElementID string             `json:"elementId"`
+	ElementID string `json:"elementId"`
 	Values    map[string]float64
 }
 

--- a/internal/snapshot/storage.go
+++ b/internal/snapshot/storage.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	snapshotDir   = ".bausteinsicht-snapshots"
-	indexFile     = "index.json"
+	snapshotDir     = ".bausteinsicht-snapshots"
+	indexFile       = "index.json"
 	snapshotDir0755 = 0o755
-	fileMode0644  = 0o644
+	fileMode0644    = 0o644
 )
 
 // Manager handles snapshot storage and retrieval

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -9,9 +9,9 @@ import (
 
 // Snapshot represents a point-in-time capture of the architecture model
 type Snapshot struct {
-	ID        string                 `json:"id"`
-	Timestamp time.Time              `json:"timestamp"`
-	Message   string                 `json:"message,omitempty"`
+	ID        string                    `json:"id"`
+	Timestamp time.Time                 `json:"timestamp"`
+	Message   string                    `json:"message,omitempty"`
 	Model     *model.BausteinsichtModel `json:"model"`
 }
 
@@ -26,9 +26,9 @@ type SnapshotMetadata struct {
 
 // SnapshotIndex holds the list of all snapshots
 type SnapshotIndex struct {
-	Version   int                  `json:"version"`
-	Snapshots []SnapshotMetadata   `json:"snapshots"`
-	UpdatedAt time.Time            `json:"updatedAt"`
+	Version   int                `json:"version"`
+	Snapshots []SnapshotMetadata `json:"snapshots"`
+	UpdatedAt time.Time          `json:"updatedAt"`
 }
 
 // NewSnapshot creates a snapshot from a model

--- a/internal/sync/badge_test.go
+++ b/internal/sync/badge_test.go
@@ -28,7 +28,7 @@ func TestAddStatusBadge_CreatesChildCell(t *testing.T) {
 
 func TestAddStatusBadge_CorrectColor(t *testing.T) {
 	tests := []struct {
-		status       string
+		status        string
 		expectedColor string
 	}{
 		{model.StatusProposed, "#fff2cc"},

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -18,11 +18,11 @@ const (
 	defaultHeight    = 60.0
 
 	// Child element placement within a scope boundary (#330).
-	childGridCols  = 3
-	childStartX    = 20.0
-	childStartY    = 80.0
-	childSpacingX  = 160.0
-	childSpacingY  = 100.0
+	childGridCols = 3
+	childStartX   = 20.0
+	childStartY   = 80.0
+	childSpacingX = 160.0
+	childSpacingY = 100.0
 )
 
 // applyTagStyles applies styles defined in tag definitions to an element's style.

--- a/internal/sync/forward_views_test.go
+++ b/internal/sync/forward_views_test.go
@@ -795,7 +795,6 @@ func TestApplyForward_ScopeBoundaryExpandsHeightForManyChildren(t *testing.T) {
 	}
 }
 
-
 // TestApplyForward_DeletedElementRemovedFromViewPages verifies that when an
 // element is deleted from the model, it is removed from all view pages where
 // it previously appeared. Regression test for #85.

--- a/internal/sync/sync_chaos_test.go
+++ b/internal/sync/sync_chaos_test.go
@@ -129,7 +129,7 @@ func TestSyncStatePartialWrite(t *testing.T) {
 	if tc.FileExists(stateFile) {
 		tc.CorruptFilePartial(stateFile, `{
 			"model_hash": "abc123",
-			"diagram_hash"`)  // Incomplete JSON
+			"diagram_hash"`) // Incomplete JSON
 	}
 
 	// Try to load the partially written state

--- a/internal/workspace/merge_test.go
+++ b/internal/workspace/merge_test.go
@@ -50,13 +50,13 @@ func TestMergeModels(t *testing.T) {
 	model1 := &model.BausteinsichtModel{
 		Specification: model.Specification{
 			Elements: map[string]model.ElementKind{
-				"system": {Notation: "box", Container: true},
+				"system":  {Notation: "box", Container: true},
 				"service": {Notation: "component"},
 			},
 		},
 		Model: map[string]model.Element{
 			"backend": {Kind: "system", Title: "Backend System"},
-			"cache": {Kind: "service", Title: "Cache Service"},
+			"cache":   {Kind: "service", Title: "Cache Service"},
 		},
 		Relationships: []model.Relationship{
 			{From: "backend", To: "cache", Label: "uses"},

--- a/internal/workspace/types.go
+++ b/internal/workspace/types.go
@@ -4,10 +4,10 @@ import "github.com/docToolchain/Bausteinsicht/internal/model"
 
 // Config defines a multi-model workspace configuration
 type Config struct {
-	Workspace WorkspaceMetadata          `json:"workspace"`
-	Models    []ModelRef                 `json:"models"`
-	Views     map[string]WorkspaceView   `json:"views,omitempty"`
-	CrossRels []CrossModelRelationship   `json:"crossModelRelationships,omitempty"`
+	Workspace WorkspaceMetadata        `json:"workspace"`
+	Models    []ModelRef               `json:"models"`
+	Views     map[string]WorkspaceView `json:"views,omitempty"`
+	CrossRels []CrossModelRelationship `json:"crossModelRelationships,omitempty"`
 }
 
 // WorkspaceMetadata contains workspace identification and metadata
@@ -35,12 +35,12 @@ type CrossModelRelationship struct {
 
 // WorkspaceView filters and displays elements from multiple models
 type WorkspaceView struct {
-	Title              string   `json:"title"`
-	IncludeFrom        []string `json:"include-from,omitempty"`
-	IncludeKinds       []string `json:"include-kinds,omitempty"`
-	ExcludeKinds       []string `json:"exclude-kinds,omitempty"`
-	Description        string   `json:"description,omitempty"`
-	Layout             string   `json:"layout,omitempty"`
+	Title        string   `json:"title"`
+	IncludeFrom  []string `json:"include-from,omitempty"`
+	IncludeKinds []string `json:"include-kinds,omitempty"`
+	ExcludeKinds []string `json:"exclude-kinds,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Layout       string   `json:"layout,omitempty"`
 }
 
 // LoadedModel holds a loaded model with its reference metadata

--- a/scripts/test-report-generator/coverage.go
+++ b/scripts/test-report-generator/coverage.go
@@ -80,8 +80,9 @@ func parseCoverageFile(path string) (map[string]*CoverageInfo, error) {
 
 // extractPackage extracts the Go package name from a file path
 // Examples:
-//   github.com/docToolchain/Bausteinsicht/internal/sync/forward.go -> github.com/docToolchain/Bausteinsicht/internal/sync
-//   github.com/docToolchain/Bausteinsicht/cmd/bausteinsicht/root.go -> github.com/docToolchain/Bausteinsicht/cmd/bausteinsicht
+//
+//	github.com/docToolchain/Bausteinsicht/internal/sync/forward.go -> github.com/docToolchain/Bausteinsicht/internal/sync
+//	github.com/docToolchain/Bausteinsicht/cmd/bausteinsicht/root.go -> github.com/docToolchain/Bausteinsicht/cmd/bausteinsicht
 func extractPackage(filePath string) string {
 	if idx := strings.LastIndex(filePath, "/"); idx != -1 {
 		return filePath[:idx]
@@ -101,13 +102,13 @@ type CoverageBlock struct {
 
 // FileCoverage holds per-file coverage: block list + aggregated stats
 type FileCoverage struct {
-	ImportPath  string           `json:"import_path"`
-	LocalPath   string           `json:"local_path"`
-	StmtTotal   int              `json:"stmt_total"`
-	StmtCovered int              `json:"stmt_covered"`
-	Coverage    float64          `json:"coverage"`
-	Blocks      []CoverageBlock  `json:"blocks"`
-	SourceLines []string         `json:"source_lines,omitempty"`
+	ImportPath  string          `json:"import_path"`
+	LocalPath   string          `json:"local_path"`
+	StmtTotal   int             `json:"stmt_total"`
+	StmtCovered int             `json:"stmt_covered"`
+	Coverage    float64         `json:"coverage"`
+	Blocks      []CoverageBlock `json:"blocks"`
+	SourceLines []string        `json:"source_lines,omitempty"`
 }
 
 // CoverageDetails holds file-level coverage information

--- a/scripts/test-report-generator/report.go
+++ b/scripts/test-report-generator/report.go
@@ -7,24 +7,24 @@ import (
 
 // Report represents a comprehensive test and coverage report
 type Report struct {
-	Timestamp       string                     `json:"timestamp"`
-	Tests           TestStats                  `json:"tests"`
-	Coverage        map[string]*CoverageInfo   `json:"coverage"`
-	Delta           *ReportDelta               `json:"delta,omitempty"`
-	LowCoverageList []string                   `json:"low_coverage_packages,omitempty"`
-	SlowestTests    []SlowTest                 `json:"slowest_tests,omitempty"`
-	RegressionTests *RegressionTestStats       `json:"regression_tests,omitempty"`
-	Details         *CoverageDetails           `json:"coverage_details,omitempty"`
+	Timestamp       string                   `json:"timestamp"`
+	Tests           TestStats                `json:"tests"`
+	Coverage        map[string]*CoverageInfo `json:"coverage"`
+	Delta           *ReportDelta             `json:"delta,omitempty"`
+	LowCoverageList []string                 `json:"low_coverage_packages,omitempty"`
+	SlowestTests    []SlowTest               `json:"slowest_tests,omitempty"`
+	RegressionTests *RegressionTestStats     `json:"regression_tests,omitempty"`
+	Details         *CoverageDetails         `json:"coverage_details,omitempty"`
 }
 
 // TestStats aggregates test results
 type TestStats struct {
-	Total     int                    `json:"total"`
-	Passed    int                    `json:"passed"`
-	Failed    int                    `json:"failed"`
-	Skipped   int                    `json:"skipped"`
-	PassRate  float64                `json:"pass_rate"`
-	TotalTime float64                `json:"total_time_seconds"`
+	Total     int                      `json:"total"`
+	Passed    int                      `json:"passed"`
+	Failed    int                      `json:"failed"`
+	Skipped   int                      `json:"skipped"`
+	PassRate  float64                  `json:"pass_rate"`
+	TotalTime float64                  `json:"total_time_seconds"`
 	ByPackage map[string]*PackageStats `json:"by_package"`
 	ByType    map[string]*TypeStats    `json:"by_type"`
 }
@@ -59,20 +59,20 @@ type SlowTest struct {
 
 // RegressionTestStats tracks regression tests
 type RegressionTestStats struct {
-	Total  int     `json:"total"`
-	Passed int     `json:"passed"`
-	Failed int     `json:"failed"`
-	Skipped int    `json:"skipped"`
+	Total    int     `json:"total"`
+	Passed   int     `json:"passed"`
+	Failed   int     `json:"failed"`
+	Skipped  int     `json:"skipped"`
 	PassRate float64 `json:"pass_rate"`
 }
 
 // ReportDelta represents changes from previous report
 type ReportDelta struct {
-	PassRateChange   float64 `json:"pass_rate_change"` // e.g., +2.5 or -1.0
-	CoverageChange   float64 `json:"coverage_change"`
+	PassRateChange    float64 `json:"pass_rate_change"` // e.g., +2.5 or -1.0
+	CoverageChange    float64 `json:"coverage_change"`
 	PerformanceChange float64 `json:"performance_change"` // % faster/slower
-	NewFailures      int     `json:"new_failures"`
-	ResolvedFailures int     `json:"resolved_failures"`
+	NewFailures       int     `json:"new_failures"`
+	ResolvedFailures  int     `json:"resolved_failures"`
 }
 
 // computeDerivedFields computes fields like low coverage list and slowest tests

--- a/scripts/test-report-generator/templates.go
+++ b/scripts/test-report-generator/templates.go
@@ -508,7 +508,7 @@ func (r *Report) renderLineLevelCoverage() string {
 						<summary class="file-header">
 							<span class="file-name">` + importPath + `</span>
 							<span class="file-coverage-badge ` + badgeClass + `">` +
-				fmt.Sprintf("%.1f%%", fc.Coverage) + `</span>
+			fmt.Sprintf("%.1f%%", fc.Coverage) + `</span>
 						</summary>
 						<div class="code-viewer">
 							<table class="code-table">

--- a/scripts/test-report-generator/trending.go
+++ b/scripts/test-report-generator/trending.go
@@ -28,13 +28,13 @@ func (r *Report) DetectPerformanceRegression(slowThreshold float64) []SlowTest {
 
 // TrendData holds historical trend information across multiple reports
 type TrendData struct {
-	Timestamp     string    `json:"timestamp"`
-	PassRate      float64   `json:"pass_rate"`
-	Coverage      float64   `json:"coverage"`
-	AvgTestTime   float64   `json:"avg_test_time"`
-	FailureCount  int       `json:"failure_count"`
-	TotalTests    int       `json:"total_tests"`
-	RegressionPct float64   `json:"regression_pct"`
+	Timestamp     string  `json:"timestamp"`
+	PassRate      float64 `json:"pass_rate"`
+	Coverage      float64 `json:"coverage"`
+	AvgTestTime   float64 `json:"avg_test_time"`
+	FailureCount  int     `json:"failure_count"`
+	TotalTests    int     `json:"total_tests"`
+	RegressionPct float64 `json:"regression_pct"`
 }
 
 // ExtractTrend extracts trend data from a report
@@ -104,8 +104,8 @@ func GenerateTrendMarkdown(trends []TrendData) string {
 
 // AnalyzeTrendBreakpoints identifies significant changes in trend data
 type TrendBreakpoint struct {
-	Type      string  // "regression" or "improvement"
-	Metric    string  // "pass_rate", "coverage", "performance"
+	Type      string // "regression" or "improvement"
+	Metric    string // "pass_rate", "coverage", "performance"
 	Change    float64
 	Timestamp string
 }


### PR DESCRIPTION
Closes #460.

## What

1. **`gofmt -w .`** over the whole tree — 39 files, **alignment-only, zero behavior change** (struct fields / composite-literal keys re-aligned to gofmt's columns).
2. **New `format` job in `go.yml`** that fails when `gofmt -l .` reports anything, so formatting cannot drift again.

## Why

The 39 files had been committed unformatted across ~25 merged feature/fix commits (2026-05-06 → 2026-06-18). Nothing in CI gated formatting — only the local `scripts/pre-commit` hook, which PR merges bypass. Both gofmt 1.22 and the toolchain gofmt 1.25.8 agreed on the same 39 files, so this is genuine drift, not a version effect.

## Verification

- `gofmt -l .` → empty after the change.
- `go build ./...` passes; pre-commit hook (gofmt + go vet) green.
- The new `format` job passes on the now-clean tree.

## Notes

- Formatting-only commit — no logic touched, the test suite is unaffected.
- The gate is added **together with** the cleanup so it passes immediately (adding it on the dirty tree would have failed at once).
- Companion to #459 (CRLF/Windows test + blocking tests); both edit `go.yml` in non-overlapping regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)