### PR TITLE
docs(spec): document layout modes, badges, tag styling, info boxes (#423 slice C)

### DIFF
--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -610,13 +610,13 @@ NOTE: Unlike element templates which use `<object>` wrappers, the connector temp
 
 === Layout Modes
 
-Each view chooses how new elements are placed via its `layout` field (BR-014). `computeLayout` (`internal/sync/layout.go`) dispatches on it:
+Each view chooses how new elements are placed via its `layout` field; an out-of-set value is rejected by validation (BR-014). `computeLayout` (`internal/sync/layout.go`) dispatches on it:
 
 * `layered` (the default, also used when `layout` is empty) — elements are arranged in horizontal rows grouped by kind, following the specification's element order, with related elements placed near each other.
 * `grid` — all elements are placed in a simple grid; useful for overview pages.
 * `none` — the legacy horizontal-row placement; sync does not arrange beyond a single row, leaving layout to the user.
 
-Sync only *places* elements that are new to a page; it never moves elements already positioned (see <<Placement Strategy for New Elements>>). The `sync --relayout` flag (`ForwardOptions.Relayout`) overrides this: it clears and re-lays-out **all** view pages from scratch — deliberately destructive to manual arrangement.
+Sync only *places* elements that are new to a page; it never moves elements already positioned (see <<Placement Strategy for New Elements>>). The `sync --relayout` flag (`ForwardOptions.Relayout`) overrides this: it clears and re-lays-out **all** view pages from scratch, deliberately discarding the hand-tuned positions of managed elements. `clearPageElements` removes only Bausteinsicht-managed cells (`bausteinsicht_id` objects and `rel-…` connectors), so any shape you drew yourself is left untouched.
 
 === Status and Decision Badges
 
@@ -635,7 +635,7 @@ Forward sync can add two informational boxes to each view page:
 * a **metadata box** (`createMetadata`) showing the view's title and description, the model path, the sync timestamp, and the `config.author` / `config.repo` values;
 * a **legend** (`createLegend`) showing the element kinds used in the view.
 
-Both are enabled by default and switched off per model via `config.metadata: false` and `config.legend: false` — the gate is `Config.Metadata == nil || *Config.Metadata`, so an unset value means on. The boxes are keyed by `metadata-<viewID>` / `legend-<viewID>` cell IDs and are updated in place on subsequent syncs rather than duplicated.
+Both are enabled by default and switched off per model via `config.metadata: false` and `config.legend: false` — the gate is `Config.Metadata == nil || *Config.Metadata`, so an unset value means on. The metadata box additionally needs the sync to supply the model path and timestamp, which the normal `sync` / `watch` path always does. The boxes are keyed by `metadata-<viewID>` / `legend-<viewID>` cell IDs and are updated in place on subsequent syncs rather than duplicated.
 
 === Edge Cases
 

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -620,7 +620,7 @@ Sync only *places* elements that are new to a page; it never moves elements alre
 
 === Status and Decision Badges
 
-When an element carries `decisions` (linked ADR IDs), forward sync renders one **decision badge** per decision as a child cell in the element's top-right corner (`AddDecisionBadges`, `internal/sync/badge.go`). Each badge is coloured by the referenced ADR's status (`DecisionBadgeColor`: blue = active, yellow = proposed, grey = superseded/deprecated) and carries a `bausteinsicht_decision_id` attribute.
+When an element carries `decisions` (linked ADR IDs), forward sync renders one **decision badge** per decision as a child cell in the element's top-right corner. The entry point is `synchronizeDecisionBadges`, which clears stale badges and then calls `AddDecisionBadges` (`internal/sync/`). Each badge is coloured by the referenced ADR's status (`DecisionBadgeColor`: blue = active, yellow = proposed, grey = superseded/deprecated) and carries a `bausteinsicht_decision_id` attribute.
 
 NOTE: A **status badge** renderer (`AddStatusBadge`, coloured by the element's lifecycle `status` via `StatusColor`) is implemented and unit-tested but is **not currently wired into forward sync** — no production code calls it. Whether to wire it up (render a lifecycle badge alongside decision badges) or remove it is an open decision; until then, element `status` is validated (BR-029–BR-031) but not visualised.
 
@@ -632,7 +632,7 @@ An element's `tags` can drive its visual style. For each tag, `applyTagStyles` (
 
 Forward sync can add two informational boxes to each view page:
 
-* a **metadata box** (`createMetadata`) showing the model path, the sync timestamp, and the `config.author` / `config.repo` values;
+* a **metadata box** (`createMetadata`) showing the view's title and description, the model path, the sync timestamp, and the `config.author` / `config.repo` values;
 * a **legend** (`createLegend`) showing the element kinds used in the view.
 
 Both are enabled by default and switched off per model via `config.metadata: false` and `config.legend: false` — the gate is `Config.Metadata == nil || *Config.Metadata`, so an unset value means on. The boxes are keyed by `metadata-<viewID>` / `legend-<viewID>` cell IDs and are updated in place on subsequent syncs rather than duplicated.

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -610,9 +610,9 @@ NOTE: Unlike element templates which use `<object>` wrappers, the connector temp
 
 === Layout Modes
 
-Each view chooses how new elements are placed via its `layout` field; an out-of-set value is rejected by validation (BR-014). `computeLayout` (`internal/sync/layout.go`) dispatches on it:
+Each view chooses how its **fresh-page** layout is computed via its `layout` field; an out-of-set value is rejected by validation (BR-014). `computeLayout` (`internal/sync/layout.go`) runs only when a page is first populated or rebuilt with `--relayout`; incremental additions to an existing page use cursor-based placement (`computePlacement`) regardless of `layout`. `computeLayout` dispatches on the field:
 
-* `layered` (the default, also used when `layout` is empty) — elements are arranged in horizontal rows grouped by kind, following the specification's element order, with related elements placed near each other.
+* `layered` (the default, also used when `layout` is empty) — elements are arranged in horizontal rows grouped by kind, in the specification's element order. Within a tier, a view's scoped children are ordered by relationship adjacency (BFS) so related ones sit near each other; all other elements are ordered alphabetically.
 * `grid` — all elements are placed in a simple grid; useful for overview pages.
 * `none` — the legacy horizontal-row placement; sync does not arrange beyond a single row, leaving layout to the user.
 
@@ -620,7 +620,7 @@ Sync only *places* elements that are new to a page; it never moves elements alre
 
 === Status and Decision Badges
 
-When an element carries `decisions` (linked ADR IDs), forward sync renders one **decision badge** per decision as a child cell in the element's top-right corner. The entry point is `synchronizeDecisionBadges`, which clears stale badges and then calls `AddDecisionBadges` (`internal/sync/`). Each badge is coloured by the referenced ADR's status (`DecisionBadgeColor`: blue = active, yellow = proposed, grey = superseded/deprecated) and carries a `bausteinsicht_decision_id` attribute.
+When an element carries `decisions` (linked ADR IDs), forward sync renders one **decision badge** per decision as a child cell near the element's top-right corner (the X offset is derived from the element's `width` attribute, which defaults to 100 when absent — as it is on generated cells whose size lives in the child `<mxGeometry>` — so the placement approximates the top-right rather than tracking the exact width). The entry point is `synchronizeDecisionBadges`, which clears stale badges and then calls `AddDecisionBadges` (`internal/sync/`). Each badge is coloured by the referenced ADR's status (`DecisionBadgeColor`: blue = active, yellow = proposed, grey = superseded/deprecated) and carries a `bausteinsicht_decision_id` attribute.
 
 NOTE: A **status badge** renderer (`AddStatusBadge`, coloured by the element's lifecycle `status` via `StatusColor`) is implemented and unit-tested but is **not currently wired into forward sync** — no production code calls it. Whether to wire it up (render a lifecycle badge alongside decision badges) or remove it is an open decision; until then, element `status` is validated (BR-029–BR-031) but not visualised.
 

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -608,6 +608,35 @@ Relationship connectors also use template styles. The connector template is iden
 
 NOTE: Unlike element templates which use `<object>` wrappers, the connector template is a bare `<mxCell>` since connectors do not need custom metadata attributes.
 
+=== Layout Modes
+
+Each view chooses how new elements are placed via its `layout` field (BR-014). `computeLayout` (`internal/sync/layout.go`) dispatches on it:
+
+* `layered` (the default, also used when `layout` is empty) — elements are arranged in horizontal rows grouped by kind, following the specification's element order, with related elements placed near each other.
+* `grid` — all elements are placed in a simple grid; useful for overview pages.
+* `none` — the legacy horizontal-row placement; sync does not arrange beyond a single row, leaving layout to the user.
+
+Sync only *places* elements that are new to a page; it never moves elements already positioned (see <<Placement Strategy for New Elements>>). The `sync --relayout` flag (`ForwardOptions.Relayout`) overrides this: it clears and re-lays-out **all** view pages from scratch — deliberately destructive to manual arrangement.
+
+=== Status and Decision Badges
+
+When an element carries `decisions` (linked ADR IDs), forward sync renders one **decision badge** per decision as a child cell in the element's top-right corner (`AddDecisionBadges`, `internal/sync/badge.go`). Each badge is coloured by the referenced ADR's status (`DecisionBadgeColor`: blue = active, yellow = proposed, grey = superseded/deprecated) and carries a `bausteinsicht_decision_id` attribute.
+
+NOTE: A **status badge** renderer (`AddStatusBadge`, coloured by the element's lifecycle `status` via `StatusColor`) is implemented and unit-tested but is **not currently wired into forward sync** — no production code calls it. Whether to wire it up (render a lifecycle badge alongside decision badges) or remove it is an open decision; until then, element `status` is validated (BR-029–BR-031) but not visualised.
+
+=== Tag-Based Styling
+
+An element's `tags` can drive its visual style. For each tag, `applyTagStyles` (`internal/sync/forward.go`) looks up the matching `TagDefinition` in `specification.tags` and merges its `style` properties into the element's draw.io style string. Tag styles layer on top of the template style, so a tag can override fill colour, stroke, or font without changing the template. Tags that resolve to no `TagDefinition`, or definitions without a `style`, leave the base style unchanged.
+
+=== Metadata and Legend Boxes
+
+Forward sync can add two informational boxes to each view page:
+
+* a **metadata box** (`createMetadata`) showing the model path, the sync timestamp, and the `config.author` / `config.repo` values;
+* a **legend** (`createLegend`) showing the element kinds used in the view.
+
+Both are enabled by default and switched off per model via `config.metadata: false` and `config.legend: false` — the gate is `Config.Metadata == nil || *Config.Metadata`, so an unset value means on. The boxes are keyed by `metadata-<viewID>` / `legend-<viewID>` cell IDs and are updated in place on subsequent syncs rather than duplicated.
+
 === Edge Cases
 
 ==== Element appears in multiple views


### PR DESCRIPTION
Slice C of #423 (spec audit, section 3 — unspecified sync behaviors).

## What
Adds four code-verified sections to `05_sync_specification.adoc`:
1. **Layout Modes** — `layered` (default) / `grid` / `none`, and the `--relayout` flag (`layout.go` `computeLayout`, `ForwardOptions.Relayout`).
2. **Status and Decision Badges** — `AddDecisionBadges` renders one ADR-status-coloured badge per `decisions` entry. `AddStatusBadge` is implemented + unit-tested but **not wired into forward sync** — documented as an open decision (wire up or remove).
3. **Tag-Based Styling** — `applyTagStyles` merges `specification.tags` styles onto an element's draw.io style.
4. **Metadata and Legend Boxes** — `createMetadata` / `createLegend`, default-on, gated by `config.metadata` / `config.legend` (unset = on).

## Why
The audit found ~15 implemented behaviors unspecified. This covers the visual/layout group; each statement was re-derived from the implementation (not from the prior doc).

## Verification
- Layout dispatch: `internal/sync/layout.go:43-58`. `--relayout`: `forward.go` `ForwardOptions.Relayout`.
- Decision badge call site: `forward.go:1357`; colours `badge.go` `DecisionBadgeColor`. `AddStatusBadge` has **no** production call site (only tests) — confirmed.
- Tag styling: `forward.go` `applyTagStyles`. Metadata/legend gating: `forward.go:242-251`.
- asciidoctor renders clean; the `<<Placement Strategy for New Elements>>` xref resolves.

## Not covered (no silent cap)
Two audit items remain for a follow-up: rendered-elements deletion guard (#240) and cross-view repair (#236).

## Remaining #423 slices
D (E2E test plan), E (tutorial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)