### PR TITLE
docs(spec): modernize tutorial — grown sample model + full command reference (#423 slice E)

### DIFF
--- a/src/docs/spec/06_tutorial.adoc
+++ b/src/docs/spec/06_tutorial.adoc
@@ -64,7 +64,7 @@ The model contains:
 * **Actors**: Customer and Back-Office User
 * **System**: Online Shop, containing a Web Frontend, a Mobile App, a REST API (with Product Catalog, Order Processing, and Notification Service components), a Database, a Cache, a Message Queue, and Export Storage
 * **External systems**: Payment Provider and E-Mail Service
-* **Relationships**: e.g. the Customer uses the Web Frontend, the REST API reads/writes the Database, charges the Payment Provider, and sends mail via the E-Mail Service
+* **Relationships**: e.g. the Customer uses the Web Frontend, the REST API reads/writes the Database, the Order Processing component charges the Payment Provider, and the Notification Service sends email asynchronously via the E-Mail Service
 * **Views**: System Context, Container View, API Components
 * **Dynamic views** (sequence diagrams): Checkout Flow and Catalog Browse
 

--- a/src/docs/spec/06_tutorial.adoc
+++ b/src/docs/spec/06_tutorial.adoc
@@ -68,6 +68,8 @@ The model contains:
 * **Views**: System Context, Container View, API Components
 * **Dynamic views** (sequence diagrams): Checkout Flow and Catalog Browse
 
+NOTE: The **E-Mail Service** above is an *external* system the shop talks to. In Step 4 you will add a separate *internal* Email Service container — they are different elements that happen to have similar names.
+
 === Step 3: Open the Diagram
 
 Open `architecture.drawio` in draw.io. You'll see three tabs (pages):
@@ -246,7 +248,7 @@ This makes Bausteinsicht ideal for AI-assisted architecture work — an LLM can 
 | `bausteinsicht export`
 | Export diagram views as PNG or SVG images (flags: `--image-format` png/svg, `--view`, `--output`, `--embed-diagram`)
 
-| `bausteinsicht add view` / `add specification`
+| `bausteinsicht add view` / `bausteinsicht add specification`
 | Create a view or extend the specification (LLM-friendly)
 
 | `bausteinsicht export-diagram`
@@ -273,13 +275,13 @@ This makes Bausteinsicht ideal for AI-assisted architecture work — an LLM can 
 | `bausteinsicht graph`
 | Analyse the relationship graph: cycles, centrality, dependency depth
 
-| `bausteinsicht stale` / `status` / `find` / `show`
+| `bausteinsicht stale` / `bausteinsicht status` / `bausteinsicht find` / `bausteinsicht show`
 | Inspect the model: flag stale elements, list by lifecycle status, full-text search, show one element
 
-| `bausteinsicht snapshot` / `diff` / `changelog`
+| `bausteinsicht snapshot` / `bausteinsicht diff` / `bausteinsicht changelog`
 | Versioned snapshots, as-is/to-be comparison, and architecture changelog
 
-| `bausteinsicht generate-template` / `layout` / `schema` / `workspace` / `overlay` / `adr`
+| `bausteinsicht generate-template` / `bausteinsicht layout` / `bausteinsicht schema` / `bausteinsicht workspace` / `bausteinsicht overlay` / `bausteinsicht adr`
 | Generate a template from the spec, lay out a diagram, generate the JSON Schema, merge multi-model workspaces, overlay metric heatmaps, and list ADRs
 |===
 

--- a/src/docs/spec/06_tutorial.adoc
+++ b/src/docs/spec/06_tutorial.adoc
@@ -61,9 +61,12 @@ Output: `Model is valid.`
 
 The model contains:
 
-* **Elements**: Customer (actor), Online Shop (system) with Frontend, REST API, and Database containers
-* **Relationships**: Customer uses Frontend, Frontend calls API, API reads/writes Database
+* **Actors**: Customer and Back-Office User
+* **System**: Online Shop, containing a Web Frontend, a Mobile App, a REST API (with Product Catalog, Order Processing, and Notification Service components), a Database, a Cache, a Message Queue, and Export Storage
+* **External systems**: Payment Provider and E-Mail Service
+* **Relationships**: e.g. the Customer uses the Web Frontend, the REST API reads/writes the Database, charges the Payment Provider, and sends mail via the E-Mail Service
 * **Views**: System Context, Container View, API Components
+* **Dynamic views** (sequence diagrams): Checkout Flow and Catalog Browse
 
 === Step 3: Open the Diagram
 
@@ -242,7 +245,45 @@ This makes Bausteinsicht ideal for AI-assisted architecture work — an LLM can 
 
 | `bausteinsicht export`
 | Export diagram views as PNG or SVG images (flags: `--image-format` png/svg, `--view`, `--output`, `--embed-diagram`)
+
+| `bausteinsicht add view` / `add specification`
+| Create a view or extend the specification (LLM-friendly)
+
+| `bausteinsicht export-diagram`
+| Export views as C4 text diagrams: PlantUML, Mermaid, DOT, D2, HTML, or Structurizr DSL (`--diagram-format`)
+
+| `bausteinsicht export-table`
+| Export element attributes per view as an AsciiDoc or Markdown table (`--table-format adoc\|md`)
+
+| `bausteinsicht export-sequence`
+| Export dynamic views as PlantUML or Mermaid sequence diagrams
+
+| `bausteinsicht import`
+| Import a model from Structurizr DSL or LikeC4 (`--from structurizr\|likec4`)
+
+| `bausteinsicht repl`
+| Interactive shell for editing the model (add/remove/list/show/validate/undo/save)
+
+| `bausteinsicht lint`
+| Check the model against its architectural constraints
+
+| `bausteinsicht health`
+| Compute an architecture health score (completeness, conformance, complexity)
+
+| `bausteinsicht graph`
+| Analyse the relationship graph: cycles, centrality, dependency depth
+
+| `bausteinsicht stale` / `status` / `find` / `show`
+| Inspect the model: flag stale elements, list by lifecycle status, full-text search, show one element
+
+| `bausteinsicht snapshot` / `diff` / `changelog`
+| Versioned snapshots, as-is/to-be comparison, and architecture changelog
+
+| `bausteinsicht generate-template` / `layout` / `schema` / `workspace` / `overlay` / `adr`
+| Generate a template from the spec, lay out a diagram, generate the JSON Schema, merge multi-model workspaces, overlay metric heatmaps, and list ADRs
 |===
+
+For the complete flag-by-flag reference of every command, see link:02_cli_specification.html[CLI Specification].
 
 === Global Flags
 


### PR DESCRIPTION
Final slice of #423 (spec audit, section 5 — tutorial modernization).

## What
- **Step 2 (Explore the Sample Model):** updated the description to the current `templates/sample-model.jsonc` — 2 actors (Customer, Back-Office User), the Online Shop system with web frontend / mobile app / REST API (+ Product Catalog, Order Processing, Notification Service components) / database / cache / message queue / export storage, 2 external systems (Payment Provider, E-Mail Service), 3 views, and 2 dynamic views (Checkout Flow, Catalog Browse). The old text described only Customer + Frontend/API/DB.
- **Command Reference:** expanded from 7 commands to the full set, explicitly including `repl`, `import`, and `export-diagram` (the audit's named gaps), with a link to `02_cli_specification.html` for the flag-by-flag reference.

## Verification
- Sample-model facts checked against `templates/sample-model.jsonc` (element titles, views, dynamic views, the cited relationships).
- Command names/flags checked against the command sources (`--diagram-format`, `--table-format adoc|md`, `--from structurizr|likec4`, repl subcommands).
- `02_cli_specification` link uses `.html`; asciidoctor renders clean.

## #423 status
With this, all five audit sections are addressed: command coverage (#456/#458), data model (#457), contract form (#463 BR catalog, #464 entity model, #465 Cockburn UCs, #466 sync behaviors), E2E plan (#467), tutorial (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)