### PR TITLE
fix(release): correct goreleaser SBOM config (unblocks v1.2.0 release)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,22 +24,28 @@ builds:
       - "7"
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"
 
 sboms:
-  - artifacts: archive
-    format: spdx-json
-    output: "{{ .ArtifactName }}.spdx.json"
-  - artifacts: archive
-    format: cyclonedx-json
-    output: "{{ .ArtifactName }}.cyclonedx.json"
+  - id: spdx
+    artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
+    cmd: syft
+    args: ["$artifact", "--output", "spdx-json=$document"]
+  - id: cyclonedx
+    artifacts: archive
+    documents:
+      - "${artifact}.cyclonedx.json"
+    cmd: syft
+    args: ["$artifact", "--output", "cyclonedx-json=$document"]
 
 changelog:
   use: github


### PR DESCRIPTION
## Problem

The `v1.2.0` release workflow failed: goreleaser rejected `.goreleaser.yml` with

```
yaml: unmarshal errors:
  line 38: field format not found in type config.SBOM
  line 39: field output not found in type config.SBOM
```

The `sboms` block used `format:` and `output:` keys that **do not exist** in goreleaser v2's SBOM schema. This config was introduced after v1.1.0 (the SBOM/SLSA feature) and had never run in a real tagged release, so the error surfaced only now.

## Fix

- Rewrite each `sboms` entry using the documented `cmd` / `args` / `documents` form with the `$artifact` / `$document` variables, emitting both **SPDX-JSON** and **CycloneDX-JSON** per archive.
- Modernize the deprecated `archives.format` / `format_overrides[].format` → `formats: [...]`.

## Verification

Validated locally with the same goreleaser version CI uses (v2.16.0):

```
$ goreleaser check
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

## Review notes

- **Code review:** config-only change; field names corrected against the [official SBOM docs](https://goreleaser.com/customization/sbom/). No build/test logic touched.
- **Security review:** improves supply-chain posture — SBOM generation (SLSA L2) was silently broken and now actually produces SBOMs. No new inputs, no shell injection surface (syft args are static).

After merge, the `v1.2.0` tag will be moved to the fixed commit and re-pushed to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)