### PR TITLE
fix(release): install syft for goreleaser SBOM step (unblocks v1.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
+      # syft is required by goreleaser's `sboms` step; it is not bundled.
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6
         with:
           version: latest


### PR DESCRIPTION
## Problem

The v1.2.0 release run got past config parsing (after #470) and successfully built **all binaries, archives, and checksums**, then failed at the final SBOM step:

```
⨯ release failed  error=exec: "syft": executable file not found in $PATH
  cmd=syft artifact=dist/Bausteinsicht_1.2.0_linux_arm.tar.gz
```

goreleaser's `sboms` feature shells out to **syft** to catalog each archive. goreleaser does not bundle syft, and the GitHub runner does not preinstall it.

## Fix

Add the canonical `anchore/sbom-action/download-syft` step before goreleaser, pinned to the **v0.24.0 commit SHA** (`e22c389…`) to match this workflow's existing pin-every-action-by-SHA convention.

## Review notes

- **Code review:** one added `uses:` step; no `run:` blocks, no untrusted input, no injection surface. Pinned by SHA, not a floating tag.
- **Security review:** uses the official Anchore action (the syft maintainers); SHA-pinned for supply-chain integrity. Strengthens the release's SLSA posture by making SBOM generation actually run.

After merge, the `v1.2.0` tag moves to the new commit and re-pushes to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)