### PR TITLE
fix(export): detect draw.io.exe on PATH and correct Scoop apps directory (#385)

### DIFF
--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -69,8 +69,9 @@ func verifyExplicitBinary(path, source string) (string, error) {
 func DetectDrawioBinary() (string, error) {
 	var searched strings.Builder
 
-	// Try PATH first
-	for _, name := range []string{"drawio-export", "drawio"} {
+	// Try PATH first. "draw.io" is included because Scoop on Windows installs
+	// the binary as draw.io.exe and exec.LookPath resolves the .exe extension.
+	for _, name := range []string{"drawio-export", "drawio", "draw.io"} {
 		path, err := exec.LookPath(name)
 		if err == nil {
 			return path, nil

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -53,6 +53,27 @@ func TestDetectDrawioBinary_FallsBackToDrawio(t *testing.T) {
 	}
 }
 
+// TestDetectDrawioBinary_FallsBackToDrawioDotExe verifies that draw.io (with dot) is found
+// on PATH. Regression test for #385: Scoop on Windows installs draw.io.exe, which
+// exec.LookPath("drawio") cannot find — only exec.LookPath("draw.io") resolves it.
+func TestDetectDrawioBinary_FallsBackToDrawioDotExe(t *testing.T) {
+	dir := t.TempDir()
+	fakeBin := fakeBinary(t, dir, "draw.io")
+	// PATH contains only draw.io; drawio-export and drawio must NOT be found.
+	t.Setenv("PATH", dir)
+	old := platformPaths
+	platformPaths = func() []string { return nil }
+	t.Cleanup(func() { platformPaths = old })
+
+	bin, err := DetectDrawioBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != fakeBin {
+		t.Errorf("expected %q, got %q", fakeBin, bin)
+	}
+}
+
 func TestDetectDrawioBinary_ErrorWhenNotFound(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	// Override platform paths so filesystem installs don't interfere.
@@ -494,6 +515,35 @@ func TestDetectDrawioBinary_macOSHomebrewIntel(t *testing.T) {
 	platformPaths = func() []string {
 		return []string{exePath}
 	}
+	t.Cleanup(func() { platformPaths = old })
+
+	bin, err := DetectDrawioBinary()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bin != exePath {
+		t.Errorf("expected %q, got %q", exePath, bin)
+	}
+}
+
+// TestDetectDrawioBinary_WindowsScoopAppsDrawIoDotPath verifies detection of the canonical
+// Scoop apps directory name "draw.io" (with dot). Regression test for #385: the previous
+// code used "drawio" (no dot) which never matched because Scoop names the app "draw.io".
+func TestDetectDrawioBinary_WindowsScoopAppsDrawIoDotPath(t *testing.T) {
+	dir := t.TempDir()
+	// Simulate C:\Users\<user>\scoop\apps\draw.io\current\draw.io.exe
+	appsDir := filepath.Join(dir, "scoop", "apps", "draw.io", "current")
+	if err := os.MkdirAll(appsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	exePath := filepath.Join(appsDir, "draw.io.exe")
+	if err := os.WriteFile(exePath, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", "")
+	old := platformPaths
+	platformPaths = func() []string { return []string{exePath} }
 	t.Cleanup(func() { platformPaths = old })
 
 	bin, err := DetectDrawioBinary()

--- a/internal/export/platform_windows.go
+++ b/internal/export/platform_windows.go
@@ -9,6 +9,7 @@ import (
 )
 
 const drawioExe = "draw.io.exe"
+const drawioAppDir = "draw.io"
 
 // platformDrawioPaths returns platform-native draw.io install locations for Windows.
 // Search order: Scoop → Chocolatey → Official Installer → Program Files
@@ -19,17 +20,15 @@ func platformDrawioPaths() []string {
 	// First, try SCOOP env var if set (allows override).
 	// If not set, try default: C:\Users\<username>\scoop\
 	if scoop := os.Getenv("SCOOP"); scoop != "" {
-		// Scoop bucket uses "draw.io" as the app name (with dot), so the install
-		// directory is apps\draw.io\current. "drawio" (no dot) is kept as a
-		// fallback in case a custom bucket uses a different naming convention.
-		paths = append(paths, filepath.Join(scoop, "apps", "draw.io", "current", drawioExe))
+		// Scoop uses "draw.io" (with dot) as the app directory; keep "drawio" as fallback.
+		paths = append(paths, filepath.Join(scoop, "apps", drawioAppDir, "current", drawioExe))
 		paths = append(paths, filepath.Join(scoop, "apps", "drawio", "current", drawioExe))
 		paths = append(paths, filepath.Join(scoop, "shims", drawioExe))
 	} else {
 		// Fallback: try default Scoop location if user home dir is available
 		if currentUser, err := user.Current(); err == nil {
 			scoopHome := filepath.Join(currentUser.HomeDir, "scoop")
-			paths = append(paths, filepath.Join(scoopHome, "apps", "draw.io", "current", drawioExe))
+			paths = append(paths, filepath.Join(scoopHome, "apps", drawioAppDir, "current", drawioExe))
 			paths = append(paths, filepath.Join(scoopHome, "apps", "drawio", "current", drawioExe))
 			paths = append(paths, filepath.Join(scoopHome, "shims", drawioExe))
 		}
@@ -44,13 +43,13 @@ func platformDrawioPaths() []string {
 
 	// Official installer (per-user install - LOCALAPPDATA).
 	if localApp := os.Getenv("LOCALAPPDATA"); localApp != "" {
-		paths = append(paths, filepath.Join(localApp, "Programs", "draw.io", drawioExe))
+		paths = append(paths, filepath.Join(localApp, "Programs", drawioAppDir, drawioExe))
 	}
 
 	// System-wide install (Program Files).
 	for _, prog := range []string{os.Getenv("PROGRAMFILES"), os.Getenv("PROGRAMFILES(X86)")} {
 		if prog != "" {
-			paths = append(paths, filepath.Join(prog, "draw.io", drawioExe))
+			paths = append(paths, filepath.Join(prog, drawioAppDir, drawioExe))
 		}
 	}
 

--- a/internal/export/platform_windows.go
+++ b/internal/export/platform_windows.go
@@ -19,12 +19,17 @@ func platformDrawioPaths() []string {
 	// First, try SCOOP env var if set (allows override).
 	// If not set, try default: C:\Users\<username>\scoop\
 	if scoop := os.Getenv("SCOOP"); scoop != "" {
+		// Scoop bucket uses "draw.io" as the app name (with dot), so the install
+		// directory is apps\draw.io\current. "drawio" (no dot) is kept as a
+		// fallback in case a custom bucket uses a different naming convention.
+		paths = append(paths, filepath.Join(scoop, "apps", "draw.io", "current", drawioExe))
 		paths = append(paths, filepath.Join(scoop, "apps", "drawio", "current", drawioExe))
 		paths = append(paths, filepath.Join(scoop, "shims", drawioExe))
 	} else {
 		// Fallback: try default Scoop location if user home dir is available
 		if currentUser, err := user.Current(); err == nil {
 			scoopHome := filepath.Join(currentUser.HomeDir, "scoop")
+			paths = append(paths, filepath.Join(scoopHome, "apps", "draw.io", "current", drawioExe))
 			paths = append(paths, filepath.Join(scoopHome, "apps", "drawio", "current", drawioExe))
 			paths = append(paths, filepath.Join(scoopHome, "shims", drawioExe))
 		}

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -755,7 +755,18 @@ Exports draw.io diagram views to image files (PNG or SVG) using the draw.io CLI.
 | Embed the draw.io XML source in the exported image file.
 | No
 | `false`
+
+| `--drawio-path`
+| Explicit path to the draw.io CLI binary. Overrides `BAUSTEINSICHT_DRAWIO_PATH` and auto-detection. Exits with code 2 if the path does not exist.
+| No
+| (auto-detected)
 |===
+
+**draw.io binary resolution** (highest precedence first):
+
+. `--drawio-path` flag — must point at an existing file
+. `BAUSTEINSICHT_DRAWIO_PATH` environment variable — must point at an existing file
+. Auto-detection: `drawio-export` or `drawio` or `draw.io` on `PATH`, then platform-native install paths (Scoop, Chocolatey, Homebrew, standard installer)
 
 **Behavior:**
 


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented draw.io detection when installed via Scoop on Windows:

**Bug 1 — `draw.io.exe` not found on PATH**
`exec.LookPath` was only searching for `drawio` and `drawio-export`, but Scoop installs the binary as `draw.io.exe`. Added `draw.io` as a third PATH candidate; `exec.LookPath` resolves the `.exe` extension automatically on Windows.

**Bug 2 — Wrong Scoop apps directory name**
`platform_windows.go` used `apps\drawio\current` (no dot), but Scoop names the app `draw.io`, making the actual install path `apps\draw.io\current\draw.io.exe`. Now checks `apps\draw.io\current` first (correct), keeps `apps\drawio\current` as fallback for custom buckets.

**Doc fix (pre-existing gap from PR #388)**
`spec/02_cli_specification.adoc` was missing `--drawio-path` and `BAUSTEINSICHT_DRAWIO_PATH` — both added with the full resolution precedence order.

## Root cause from issue thread

The user had `C:\Users\<name>\scoop\apps\draw.io\current` in PATH. Detection failed because:
- PATH search used `exec.LookPath("drawio")` — doesn't match `draw.io.exe`
- Platform path searched `apps\drawio\` — doesn't match Scoop's `apps\draw.io\` directory

## Test plan

- [ ] `go test ./internal/export/` — new tests `TestDetectDrawioBinary_FallsBackToDrawioDotExe` and `TestDetectDrawioBinary_WindowsScoopAppsDrawIoDotPath` pass
- [ ] All existing export detection tests still pass
- [ ] Manual: install draw.io via Scoop on Windows, run `bausteinsicht export`

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)