### PR TITLE
fix(ci): repair invalid YAML in 5 GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-branch-freshness.yml
+++ b/.github/workflows/check-branch-freshness.yml
@@ -8,7 +8,7 @@ jobs:
   freshness:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -33,19 +33,8 @@ jobs:
             if [ "$COMMITS_BEHIND" -gt 0 ]; then
               echo "- ⚠️ Branch is behind main" >> $GITHUB_STEP_SUMMARY
 
-              gh pr comment ${{ github.event.pull_request.number }} \
-                --body "⚠️ **Branch is behind main by $COMMITS_BEHIND commit(s)**
-
-This may cause merge conflicts or miss recent bug fixes/improvements.
-
-**Recommended action:**
-\`\`\`bash
-git fetch origin
-git rebase origin/main
-git push --force-with-lease
-\`\`\`
-
-This ensures compatibility with the latest main and prevents conflicts."
+              BODY=$(printf '⚠️ **Branch is behind main by %s commit(s)**\n\nThis may cause merge conflicts or miss recent bug fixes/improvements.\n\n**Recommended action:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nThis ensures compatibility with the latest main and prevents conflicts.' "$COMMITS_BEHIND")
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
             fi
           else
             echo "✅ Branch is up-to-date with main" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-branch-origin.yml
+++ b/.github/workflows/check-branch-origin.yml
@@ -8,7 +8,7 @@ jobs:
   verify-from-main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -41,21 +41,8 @@ jobs:
             echo "  git push --force-with-lease"
             echo ""
 
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "⚠️ **Branch Behind Main**
-
-This branch is based on an older commit from main and is behind by **$COMMITS_BEHIND commit(s)**.
-
-This often happens when a feature branch is created from another feature branch instead of from main directly.
-
-**Recommendation:**
-\`\`\`bash
-git fetch origin
-git rebase origin/main
-git push --force-with-lease
-\`\`\`
-
-After rebasing, this warning will disappear."
+            BODY=$(printf '⚠️ **Branch Behind Main**\n\nThis branch is based on an older commit from main and is behind by **%s commit(s)**.\n\nThis often happens when a feature branch is created from another feature branch instead of from main directly.\n\n**Recommendation:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nAfter rebasing, this warning will disappear.' "$COMMITS_BEHIND")
+            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
 
             # Don't fail - let it proceed with warning
           fi

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -8,7 +8,7 @@ jobs:
   check-duplicates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -46,15 +46,8 @@ jobs:
             echo -e "$DUPLICATES"
             echo ""
 
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "⚠️ **Potential Duplicate Work Detected**
-
-This PR may overlap with other open PRs:$(echo -e "$DUPLICATES")
-
-Please review and coordinate:
-1. Confirm this PR doesn't duplicate existing work
-2. If duplicate, consider closing this PR
-3. If improvements, consider cherry-picking into existing PR instead"
+            BODY=$(printf '⚠️ **Potential Duplicate Work Detected**\n\nThis PR may overlap with other open PRs:%s\n\nPlease review and coordinate:\n1. Confirm this PR does not duplicate existing work\n2. If duplicate, consider closing this PR\n3. If improvements, consider cherry-picking into existing PR instead' "$(echo -e "$DUPLICATES")")
+            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
           else
             echo "✅ No overlapping work detected"
           fi

--- a/.github/workflows/check-stale-branches.yml
+++ b/.github/workflows/check-stale-branches.yml
@@ -9,7 +9,7 @@ jobs:
   check-stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -34,8 +34,10 @@ jobs:
             # Check if merged to main
             if ! git merge-base --is-ancestor origin/$branch origin/main 2>/dev/null; then
               if [ "$DAYS_OLD" -gt 7 ]; then
-                STALE_BRANCHES="$STALE_BRANCHES- \`$branch\` ($DAYS_OLD days old)
-"
+                # The trailing \n must be appended outside $(...): command
+                # substitution strips trailing newlines, which would run
+                # consecutive entries together on one line.
+                STALE_BRANCHES="${STALE_BRANCHES}$(printf -- '- `%s` (%s days old)' "$branch" "$DAYS_OLD")"$'\n'
                 BRANCH_COUNT=$((BRANCH_COUNT + 1))
               fi
             fi
@@ -49,23 +51,10 @@ jobs:
             echo "$STALE_BRANCHES" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
+            BODY=$(printf 'Found stale branches (not merged to main, >7 days old):\n\n%s\n\n**Recommendation:**\nReview if these branches should be:\n1. Merged (if still relevant work)\n2. Deleted (if work is abandoned or superseded)\n\nDelete with:\n```bash\ngit fetch origin\ngit branch -D <branch>\ngit push origin --delete <branch>\n```' "$STALE_BRANCHES")
             gh issue create \
               --title "🧹 Cleanup: Stale branches found" \
-              --body "Found stale branches (not merged to main, >7 days old):
-
-$STALE_BRANCHES
-
-**Recommendation:**
-Review if these branches should be:
-1. Merged (if still relevant work)
-2. Deleted (if work is abandoned or superseded)
-
-Delete with:
-\`\`\`bash
-git fetch origin
-git branch -D <branch>
-git push origin --delete <branch>
-\`\`\`" \
+              --body "$BODY" \
               --label infrastructure \
               2>/dev/null || echo "Issue already exists or other error"
           else

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -9,7 +9,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
 
@@ -36,20 +36,13 @@ jobs:
             BRANCH_LIST=$(echo "$MERGED_REMOTE" | tr '\n' ' ')
 
             # Create issue for notification
+            BODY=$(printf 'Found branches merged to main. Safe to delete:\n\n%s\n\n**How to clean up:**\n```bash\ngit fetch origin\ngit branch -d %s\ngit push origin %s\n```\n\nOr delete individually in GitHub web UI: Settings → Branches' \
+              "$(echo "$MERGED_REMOTE" | sed 's/^/- origin\//')" \
+              "$BRANCH_LIST" \
+              "$(echo "$MERGED_REMOTE" | sed 's/^/--delete /' | tr '\n' ' ')")
             gh issue create \
               --title "🧹 Cleanup: Merged branches ready for deletion" \
-              --body "Found branches merged to main. Safe to delete:
-
-$(echo "$MERGED_REMOTE" | sed 's/^/- origin\//')
-
-**How to clean up:**
-\`\`\`bash
-git fetch origin
-git branch -d $(echo "$MERGED_REMOTE" | tr '\n' ' ')
-git push origin $(echo "$MERGED_REMOTE" | sed 's/^/--delete /' | tr '\n' ' ')
-\`\`\`
-
-Or delete individually in GitHub web UI: Settings → Branches" \
+              --body "$BODY" \
               --label infrastructure \
               2>/dev/null || echo "Issue creation skipped (may already exist)"
           else


### PR DESCRIPTION
## Summary

Fixes #522.

5 workflow files (`check-duplicate-prs.yml`, `check-branch-freshness.yml`, `check-branch-origin.yml`, `check-stale-branches.yml`, `weekly-maintenance.yml`) embedded a multi-line bash string (a `gh pr comment`/`gh issue create --body "..."` argument) directly inside a YAML `run: |` block, with a continuation line at zero/insufficient indentation. That breaks the YAML block scalar early — GitHub can't parse the file at all, which is what surfaced as "Invalid workflow file ... error in your yaml syntax on line 52" for `check-duplicate-prs.yml` (and the identical class of error in the other 4, confirmed with `pyyaml` + `actionlint`).

**Fix**: build each comment/issue body with `printf` + explicit `\n` escapes on a single logical line, stored in a `BODY` variable, instead of a raw embedded multi-line string — no literal newline in the YAML source, so there's nothing for indentation rules to trip on. `check-stale-branches.yml` had a second instance of the same root cause in its `STALE_BRANCHES` accumulation loop.

Also bumped `actions/checkout@v3` → the same SHA-pinned v4 already used in `go.yml` in all 5 files (`actionlint` flagged v3 as deprecated; free fix since these files were already open).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — all 11 workflow files parse cleanly (not just the 5 fixed)
- [x] `actionlint .github/workflows/*.yml` — zero findings
- [x] `bash -n` on every extracted `run:` script — no syntax errors
- [x] Manually simulated all 5 rewritten comment/issue bodies with sample data and confirmed the output formatting matches the original intent exactly (including catching and fixing a real bug of my own: command substitution strips trailing newlines, so the `STALE_BRANCHES` loop's `\n` had to move outside the `$(...)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)