### PR TITLE
docs(arc42): drift-check script + CI/doc-check wiring (follow-up to #526)

### DIFF
--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -63,7 +63,7 @@ as the fallback — it covers the same doc gates.
    | New or changed `cmd/bausteinsicht/*.go` (non-test) | spec/01, spec/02 |
    | `internal/model/types.go` or `schemas/bausteinsicht.schema.json` or `internal/schema/` | spec/03 |
    | `internal/sync/` | spec/05 |
-   | New `internal/<pkg>/` directory | arc42/05, arc42/06 |
+   | New `internal/<pkg>/` directory | arc42/05, arc42/06, **and** `src/docs/arc42/architecture.jsonc` (the self-hosted model itself — run `make arc42-drift-check` to confirm; see #524/#526, where 11 packages went undetected in the model for a long time because this was only a manual judgment call) |
    | New runtime data flow within an existing package | arc42/06 |
    | New cross-cutting pattern (error handling, logging, concurrency model) | arc42/08 |
    | Any other existing `internal/<pkg>/` with user-visible output change | spec/01, spec/02 |
@@ -123,11 +123,17 @@ as the fallback — it covers the same doc gates.
    - `cmd/bausteinsicht/*.go` → `spec/02` and `spec/01`
    - `internal/model/types.go` / `schemas/` / `internal/schema/` → `spec/03`
    - `internal/sync/*.go` → `spec/05`
-   - New `internal/<pkg>/` directory → `arc42/05`, `arc42/06`
+   - New `internal/<pkg>/` directory → `arc42/05`, `arc42/06`, **and** `architecture.jsonc`
    - New runtime data flow in existing package → `arc42/06`
    - New cross-cutting pattern → `arc42/08`
    - Any other `internal/<pkg>/` with user-visible change → `spec/01`, `spec/02`
    - Significant design tradeoff → new ADR in `src/docs/arc42/ADRs/`
+
+   Always run this concrete check (not just judgment) when any `internal/` or `cmd/` directory was added, renamed, or removed in the diff:
+   ```bash
+   make arc42-drift-check
+   ```
+   Non-zero exit → **❌ blocking** (a real package has no `container` element in `architecture.jsonc`, or vice versa). This is a scripted version of the routing-table rule above — it exists because that rule was manual-judgment-only for a long time and 11 packages drifted out of the model undetected (#524).
 
    **B. Doc coverage in tests**
    For each new acceptance criterion or spec section added: is there a test covering it?

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -420,6 +420,22 @@ jobs:
           go-version-file: go.mod
       - run: make schema-validate
 
+  # Verifies src/docs/arc42/architecture.jsonc (the self-hosted architecture
+  # model) hasn't drifted from the real internal/ and cmd/ package
+  # structure — the class of gap found and fixed in #524/#526. No draw.io
+  # CLI needed (unlike `make arc42-docs`): this only reads the model via
+  # `export-table --format json`, no headless export.
+  arc42-drift-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: make arc42-drift-check
+
   lint:
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ When starting work on a ticket:
 
 ### PR Merge Policy
 Before merging any PR:
-1. **Doc check** — run `/doc-check review` to verify spec/architecture is consistent with implementation and tests
+1. **Doc check** — run `/doc-check review` to verify spec/architecture is consistent with implementation and tests. If the diff adds/renames/removes an `internal/` or `cmd/` directory, also run `make arc42-drift-check` — it verifies every real package has a matching `container` element in the self-hosted `src/docs/arc42/architecture.jsonc`, and vice versa. This exists because that check used to be manual-judgment-only, and 11 packages drifted out of the model undetected for a long time before being caught (#524, #526); CI runs it on every PR (`arc42-drift-check` job in `go.yml`).
 2. **E2E coverage check** — part of `/doc-check review` (see "E2E test coverage" in the doc-check skill): every new CLI command, new flag, or bug fix that spans more than one command (e.g. import → sync → export pipelines) must have a corresponding scenario under `e2e/*_test.go`. A user-visible change with no e2e test is a blocking (❌) finding, not just a suggestion — see [Issue #512](https://github.com/docToolchain/Bausteinsicht/issues/512), where an import bug shipped in v1.2.0 with zero test coverage anywhere in the repo.
 3. **Security review** on the changes
 4. **Code review** on the changes

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIST := dist
         build_windows_amd64 build_windows_arm64 \
         schema-generate schema-validate \
         build-extension package-extension \
-        test test-race bench coverage coverage-report e2e-test-report arc42-docs vet staticcheck gosec nilaway govulncheck deadcode \
+        test test-race bench coverage coverage-report e2e-test-report arc42-docs arc42-drift-check vet staticcheck gosec nilaway govulncheck deadcode \
         gitleaks golangci-lint check check-duplicates clean install-tools install-hooks
 
 # Ensure GOPATH/bin is in PATH for installed tools
@@ -111,6 +111,11 @@ e2e-test-report:
 # PNG diagrams) from src/docs/arc42/architecture.jsonc (see #524, #526)
 arc42-docs:
 	@scripts/generate-arc42-docs.sh
+
+# Verify every real internal/ and cmd/ package has a matching container
+# element in architecture.jsonc, and vice versa (see #524, #526)
+arc42-drift-check:
+	@scripts/check-arc42-drift.sh
 
 # Run benchmarks
 bench:

--- a/scripts/check-arc42-drift.sh
+++ b/scripts/check-arc42-drift.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/check-arc42-drift.sh — verify that every real internal/<pkg> and
+# cmd/<binary> Go package has a matching `container` element in
+# src/docs/arc42/architecture.jsonc, and vice versa.
+#
+# This is the check that would have caught #524 (11 internal/ packages
+# missing from the model) before it happened. It uses `bausteinsicht
+# export-table --format json` — the same CLI the model itself is built
+# with — to get a machine-readable element list, rather than re-parsing
+# the JSONC by hand.
+#
+# Usage:
+#   scripts/check-arc42-drift.sh
+#   make arc42-drift-check
+#
+# Exit code 0 = no drift, 1 = drift found (real package with no container,
+# or container with no matching real package) — usable as a CI gate.
+#
+# Deliberately excluded from the "every real package needs a container"
+# check (kept in sync with the JSONC comment above the container list and
+# with 05_building_block_view.adoc's NOTE — if you add a new deliberate
+# exception, update all three places):
+#   - internal/benchmarks, internal/chaos, internal/e2eplan — test/tooling
+#     packages, not product architecture (see architecture.jsonc's own
+#     comment on this, added in #524)
+#   - cmd/bausteinsicht-lsp — a thin binary entry point reusing
+#     internal/lsp's logic, not an independent package group; "lsp"
+#     already covers it
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+MODEL="src/docs/arc42/architecture.jsonc"
+EXCLUDE_PACKAGES=(benchmarks chaos e2eplan)
+
+BIN="${BAUSTEINSICHT_BIN:-}"
+if [ -z "$BIN" ]; then
+  if command -v bausteinsicht >/dev/null 2>&1; then
+    BIN="bausteinsicht"
+  elif [ -x "./bausteinsicht" ]; then
+    BIN="./bausteinsicht"
+  else
+    echo "==> Building bausteinsicht (no BAUSTEINSICHT_BIN set, none on PATH)..." >&2
+    go build -o /tmp/bausteinsicht-arc42-drift-check ./cmd/bausteinsicht
+    BIN="/tmp/bausteinsicht-arc42-drift-check"
+  fi
+fi
+
+# ── Modeled container short-names (last dot-path segment) ──────────────────
+modeled="$("$BIN" export-table --model "$MODEL" --view containers --format json \
+  | python3 -c '
+import json, sys
+for e in json.load(sys.stdin):
+    if e["kind"] == "container":
+        print(e["id"].rsplit(".", 1)[-1])
+')"
+
+# ── Real package short-names ────────────────────────────────────────────────
+real_internal="$(ls -d internal/*/ | xargs -n1 basename)"
+# cmd/bausteinsicht maps to the "cli" container; cmd/bausteinsicht-lsp is a
+# deliberate exception (see header comment).
+real_cmd="cli"
+
+exit_code=0
+
+echo "==> Checking for real internal/ packages missing from the model..." >&2
+for pkg in $real_internal; do
+  skip=false
+  for ex in "${EXCLUDE_PACKAGES[@]}"; do
+    if [ "$pkg" = "$ex" ]; then
+      skip=true
+      break
+    fi
+  done
+  $skip && continue
+  if ! grep -qx "$pkg" <<<"$modeled"; then
+    echo "  MISSING: internal/$pkg has no container element in $MODEL" >&2
+    exit_code=1
+  fi
+done
+
+echo "==> Checking cmd/ packages..." >&2
+if ! grep -qx "$real_cmd" <<<"$modeled"; then
+  echo "  MISSING: cmd/bausteinsicht ('cli') has no container element in $MODEL" >&2
+  exit_code=1
+fi
+
+echo "==> Checking for modeled containers with no matching real package..." >&2
+all_real="$real_internal
+$real_cmd"
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if ! grep -qx "$name" <<<"$all_real"; then
+    echo "  STALE: container '$name' in $MODEL has no matching internal/$name or cmd/ package (renamed or removed?)" >&2
+    exit_code=1
+  fi
+done <<<"$modeled"
+
+if [ "$exit_code" -eq 0 ]; then
+  echo "==> No drift: every real internal/ and cmd/ package (except deliberate exceptions) has a matching container element, and vice versa." >&2
+else
+  echo "==> Drift found — see #524/#526 for how this class of gap was found and fixed before; run 'make arc42-docs' after updating $MODEL." >&2
+fi
+
+exit "$exit_code"


### PR DESCRIPTION
## Summary

Continues #526 (already closed via #527's merge, but two commits from that branch landed *after* #527 was merged and were stranded on the now-closed PR — this PR carries them forward cleanly, cherry-picked onto current `main`).

- `scripts/check-arc42-drift.sh` (+ `make arc42-drift-check`): verifies every real `internal/<pkg>`/`cmd/<binary>` Go package has a matching `container` element in `src/docs/arc42/architecture.jsonc`, and vice versa, via `bausteinsicht export-table --format json`. Verified against the pre-#524 model state — correctly flags exactly the 11 packages that issue found missing.
- New `arc42-drift-check` job in `.github/workflows/go.yml`, mirroring the `schema-validation` job's shape. No draw.io CLI needed (only reads the model), so it's cheap on every PR.
- `.claude/skills/doc-check/SKILL.md`: the "New `internal/<pkg>/` directory → arc42/05, arc42/06" routing rule now also points at `architecture.jsonc`, and `review` mode gets a concrete `make arc42-drift-check` step instead of relying purely on manual judgment.
- `CLAUDE.md`'s PR Merge Policy doc-check bullet references the same check.

Full context and status: see #526's (consolidated) description.

## Test plan

- [x] `make arc42-drift-check` — exit 0 on current `main`, exit 1 (correctly flagging the 11 originally-missing packages) when run against the pre-#524 model snapshot
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `actionlint .github/workflows/*.yml` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)