### PR TITLE
fix(ci): strip leading whitespace from git branch -r output

### DIFF
--- a/.github/workflows/check-stale-branches.yml
+++ b/.github/workflows/check-stale-branches.yml
@@ -23,7 +23,10 @@ jobs:
           STALE_BRANCHES=""
           BRANCH_COUNT=0
 
-          for branch in $(git branch -r | grep -v main | grep -v HEAD | sed 's|origin/||'); do
+          # --format='%(refname:short)' avoids raw `git branch -r`'s 2-space
+          # indent surviving as literal whitespace (see weekly-maintenance.yml
+          # for where this bit in practice — found via a live test run).
+          for branch in $(git branch -r --format='%(refname:short)' | grep -v main | grep -v HEAD | sed 's|origin/||'); do
             COMMIT_DATE=$(git log -1 --format=%ai origin/$branch 2>/dev/null | cut -d' ' -f1)
             if [ -z "$COMMIT_DATE" ]; then
               continue

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -20,10 +20,16 @@ jobs:
           git fetch origin
 
           # Delete local branches that are merged to main
-          DELETED_LOCAL=$(git branch -d $(git branch --merged origin/main | grep -v main | tr '\n' ' ') 2>&1 || echo "")
+          # --format='%(refname:short)' avoids the raw `git branch` listing
+          # format's 2-space indent / current-branch "* " marker, which
+          # otherwise survives into MERGED_REMOTE below as literal leading
+          # whitespace on every branch name (found via a live test run of
+          # this workflow after #522/#523 fixed the YAML syntax that had
+          # prevented it from ever reaching this code before).
+          DELETED_LOCAL=$(git branch -d $(git branch --format='%(refname:short)' --merged origin/main | grep -v main | tr '\n' ' ') 2>&1 || echo "")
 
           # List remote branches that should be deleted (already merged to main)
-          MERGED_REMOTE=$(git branch -r --merged origin/main | grep -v main | grep -v HEAD | sed 's|origin/||')
+          MERGED_REMOTE=$(git branch -r --format='%(refname:short)' --merged origin/main | grep -v main | grep -v HEAD | sed 's|origin/||')
 
           if [ ! -z "$MERGED_REMOTE" ]; then
             echo "## 🧹 Auto-Cleanup Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Found via a live `workflow_dispatch` test run of `weekly-maintenance.yml` (triggered to verify #522/#523's YAML fix actually works end-to-end, not just parses). It ran successfully and created a real issue — but every branch name had a doubled leading space, e.g. `origin/  388-drawio-cli-detection-windows` instead of `origin/388-drawio-cli-detection-windows`.

**Root cause**: `git branch -r` (and `git branch`, no `-r`) prefix every line with a 2-space indent (their standard listing format). The existing `sed 's|origin/||'` only strips the `origin/` substring, leaving that indent as literal leading whitespace. This was invisible until now because both workflows were YAML-invalid (#522) and never actually reached this code in a real run.

**Fix**: `git branch -r --format='%(refname:short)'` (and the local equivalent) gives clean refnames with no listing-format decoration.

Applied to:
- `weekly-maintenance.yml` — where the bug was visible (the leading whitespace survives through `sed`/`printf` text manipulation into the created issue's body)
- `check-stale-branches.yml` — same raw `git branch -r` pattern; practical impact there is less certain (its `for branch in $(...)` loop's word-splitting may already absorb the whitespace), but the fix is strictly more correct regardless

Test-artifact issues #529 and #530 (duplicate, from triggering the workflow twice while testing) closed as not-actionable.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` + `actionlint` clean on both files
- [x] Locally simulated the fixed pipeline (`git branch -r --format=... | ... | sed 's/^/- origin\//'`) — confirmed clean output, no leading whitespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)