### PR TITLE
fix(ci): drop transient origin/origin artifact from branch-cleanup output

### DIFF
--- a/.github/workflows/check-stale-branches.yml
+++ b/.github/workflows/check-stale-branches.yml
@@ -26,7 +26,13 @@ jobs:
           # --format='%(refname:short)' avoids raw `git branch -r`'s 2-space
           # indent surviving as literal whitespace (see weekly-maintenance.yml
           # for where this bit in practice — found via a live test run).
-          for branch in $(git branch -r --format='%(refname:short)' | grep -v main | grep -v HEAD | sed 's|origin/||'); do
+          # grep -x 'origin/main'/'origin/HEAD' (exact, pre-strip) instead of
+          # substring match, plus a post-strip drop of bare "origin"/empty
+          # entries: a live run on 2026-07-03 (issue #532) produced one
+          # transient `origin/origin` entry from this same pipeline shape in
+          # weekly-maintenance.yml; not locally reproducible, so filtered
+          # defensively here too since the pipeline is identical.
+          for branch in $(git branch -r --format='%(refname:short)' | grep -vx 'origin/main' | grep -vx 'origin/HEAD' | sed 's|origin/||' | grep -vx '' | grep -vx origin); do
             COMMIT_DATE=$(git log -1 --format=%ai origin/$branch 2>/dev/null | cut -d' ' -f1)
             if [ -z "$COMMIT_DATE" ]; then
               continue

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -26,10 +26,22 @@ jobs:
           # whitespace on every branch name (found via a live test run of
           # this workflow after #522/#523 fixed the YAML syntax that had
           # prevented it from ever reaching this code before).
-          DELETED_LOCAL=$(git branch -d $(git branch --format='%(refname:short)' --merged origin/main | grep -v main | tr '\n' ' ') 2>&1 || echo "")
+          # grep -x (exact-line) instead of substring match: a hypothetical
+          # branch that merely *contains* "main" (e.g. "maintenance-fix")
+          # must not be silently dropped.
+          DELETED_LOCAL=$(git branch -d $(git branch --format='%(refname:short)' --merged origin/main | grep -vx main | tr '\n' ' ') 2>&1 || echo "")
 
           # List remote branches that should be deleted (already merged to main)
-          MERGED_REMOTE=$(git branch -r --format='%(refname:short)' --merged origin/main | grep -v main | grep -v HEAD | sed 's|origin/||')
+          # grep -vx origin (post-strip): a run on 2026-07-03 produced one
+          # transient `origin/origin` entry (issue #532) — the `origin/`
+          # prefix strip left a bare "origin" line, which the summary/body
+          # then re-rendered as "- origin/origin" and even injected into the
+          # suggested `git push origin --delete ... origin ...` command. The
+          # exact upstream cause (a fleeting remote-tracking ref present only
+          # at fetch time on that runner) wasn't reproducible locally, so
+          # this filters the corrupted entry out defensively rather than
+          # leaving a misleading branch name in the generated issue.
+          MERGED_REMOTE=$(git branch -r --format='%(refname:short)' --merged origin/main | grep -vx 'origin/main' | grep -vx 'origin/HEAD' | sed 's|origin/||' | grep -vx '' | grep -vx origin)
 
           if [ ! -z "$MERGED_REMOTE" ]; then
             echo "## 🧹 Auto-Cleanup Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Issue #532 (a live `weekly-maintenance.yml` run on 2026-07-03, on a commit that already contained the #531 whitespace fix) showed a phantom `origin/origin` entry in the generated branch-cleanup issue body, including inside the suggested `git push origin --delete ... --delete origin ...` command.
- Root cause not reproducible locally: no branch named `origin` currently exists on the remote, in reflog, or in PR history. It looks like a fleeting remote-tracking ref present only at fetch time on that specific runner.
- Rather than leave a misleading/corrupted branch name in an auto-generated cleanup command, both `weekly-maintenance.yml` and `check-stale-branches.yml` (same pipeline shape) now defensively drop any bare `origin`/empty entry after the `origin/` prefix strip.
- Also switched `grep -v main`/`grep -v HEAD` to exact-line matching (`grep -vx 'origin/main'`/`grep -vx 'origin/HEAD'`) — the previous substring match would have silently dropped a real branch merely *containing* "main" or "HEAD" (e.g. a hypothetical `maintenance-fix` branch).

## Test plan
- [x] Simulated both pipelines locally with injected `origin/origin`, `origin/main`, and a `maintenance-fix`-style branch — confirms the artifact is dropped and the substring-match regression is fixed
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both changed files
- [ ] CI green on this PR

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)