### PR TITLE
feat(docs): add command-coverage checks for arc42 §3.1.1/§6 (#535)

### DIFF
--- a/.claude/skills/doc-check/SKILL.md
+++ b/.claude/skills/doc-check/SKILL.md
@@ -135,6 +135,13 @@ as the fallback — it covers the same doc gates.
    ```
    Non-zero exit → **❌ blocking** (a real package has no `container` element in `architecture.jsonc`, or vice versa). This is a scripted version of the routing-table rule above — it exists because that rule was manual-judgment-only for a long time and 11 packages drifted out of the model undetected (#524).
 
+   Also run this when a new `cmd/bausteinsicht/*.go` command or subcommand was added:
+   ```bash
+   make arc42-process-coverage-check
+   make arc42-runtime-coverage-check
+   ```
+   Non-zero exit → **⚠️ non-blocking** (advisory only — a textual mention check, not a semantic one; see the script headers). Flags commands not yet mentioned in §3.1.1's process diagram (`chapters/03_context_and_scope.adoc`) or chapter 6's runtime scenarios (`chapters/06_runtime_view.adoc`). This exists because §3.1.1 and chapter 6 both drifted badly behind the CLI's real command set before being caught (#535).
+
    **B. Doc coverage in tests**
    For each new acceptance criterion or spec section added: is there a test covering it?
    ```bash

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIST := dist
         build_windows_amd64 build_windows_arm64 \
         schema-generate schema-validate \
         build-extension package-extension \
-        test test-race bench coverage coverage-report e2e-test-report arc42-docs arc42-sequences arc42-drift-check vet staticcheck gosec nilaway govulncheck deadcode \
+        test test-race bench coverage coverage-report e2e-test-report arc42-docs arc42-sequences arc42-drift-check arc42-process-coverage-check arc42-runtime-coverage-check vet staticcheck gosec nilaway govulncheck deadcode \
         gitleaks golangci-lint check check-duplicates clean install-tools install-hooks
 
 # Ensure GOPATH/bin is in PATH for installed tools
@@ -121,6 +121,15 @@ arc42-sequences:
 # element in architecture.jsonc, and vice versa (see #524, #526)
 arc42-drift-check:
 	@scripts/check-arc42-drift.sh
+
+# Advisory: verify every cmd/bausteinsicht command is at least mentioned in
+# §3.1.1's process diagram / chapter 6's runtime scenarios (see #535).
+# Textual heuristic, not a semantic check — see script headers.
+arc42-process-coverage-check:
+	@scripts/check-arc42-process-coverage.sh
+
+arc42-runtime-coverage-check:
+	@scripts/check-arc42-runtime-coverage.sh
 
 # Run benchmarks
 bench:

--- a/scripts/check-arc42-process-coverage.sh
+++ b/scripts/check-arc42-process-coverage.sh
@@ -36,13 +36,16 @@ CMD_DIR="cmd/bausteinsicht"
 # via its own file).
 EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
 
-# Subcommand files that define exactly one Cobra command whose own `Use:`
-# token is too generic to search for (e.g. "view", "save", "list") because
-# their parent command lives in a *different* file (add.go / snapshot.go) —
-# combine with that parent. Files where parent and subcommands are defined
-# together (workspace.go, overlay.go, adr.go, cmd_schema.go, add.go) don't
-# need an entry here: every Use: token in the file is extracted and the
-# first one is used as the local parent for the rest (see the loop below).
+# Subcommand files whose own first (or only) `Use:` token is too generic to
+# search for alone (e.g. "element", "view", "save") because their parent
+# command lives in a *different* file (add.go / snapshot.go) — prefix with
+# that parent. Composes with the multi-Use: local-parent logic below: e.g.
+# add_specification.go's three tokens (specification/element/relationship)
+# become "add specification", "add specification element", "add
+# specification relationship". Files where parent and subcommands are
+# defined together (workspace.go, overlay.go, adr.go, cmd_schema.go) don't
+# need an entry here — their own first Use: token is already a specific
+# enough parent on its own.
 declare -A PARENT_PREFIX=(
   [add_element.go]="add"
   [add_relationship.go]="add"
@@ -53,6 +56,28 @@ declare -A PARENT_PREFIX=(
   [snapshot_list.go]="snapshot"
   [snapshot_restore.go]="snapshot"
   [snapshot_save.go]="snapshot"
+)
+
+# add_from_pattern.go defines two Use: tokens ("add-from-pattern
+# <pattern-id>" and "list"), but they are *not* parent/child in the real
+# Cobra command tree: newListPatternsCmd()'s "list" is wired in add.go
+# under a completely separate "pattern" command group
+# (patternCmd.AddCommand(newListPatternsCmd())), never under
+# add-from-pattern. Combining them as "add-from-pattern list" would assert
+# a command that doesn't exist (verified: `bausteinsicht add-from-pattern`
+# errors "unknown command" — the real invocations are
+# `bausteinsicht add add-from-pattern <pattern-id>` and
+# `bausteinsicht add pattern list`). So this file's extra tokens are
+# ignored here, and the real 3-level term is listed in EXTRA_TERMS instead
+# — a cross-file relationship (add.go's "pattern" parent + this file's
+# "list" child) the per-file heuristic can't derive on its own.
+IGNORE_EXTRA_USES=(add_from_pattern.go)
+
+# Terms that can't be derived by the per-file heuristic above (cross-file
+# 3-level nesting, or any other real command the automatic derivation
+# can't reach) — checked in addition to the per-file loop.
+EXTRA_TERMS=(
+  "add pattern list"
 )
 
 is_excluded() {
@@ -92,18 +117,24 @@ for f in "$CMD_DIR"/*.go; do
   mapfile -t uses < <(sed -n 's/^[[:space:]]*Use:[[:space:]]*"\([a-zA-Z0-9_-]*\).*/\1/p' "$f")
   [ "${#uses[@]}" -eq 0 ] && continue
 
+  for ignore in "${IGNORE_EXTRA_USES[@]}"; do
+    [ "$base" = "$ignore" ] && uses=("${uses[0]}")
+  done
+
   prefix="${PARENT_PREFIX[$base]:-}"
   if [ -n "$prefix" ]; then
-    check_term "$prefix ${uses[0]}" "$base"
-  elif [ "${#uses[@]}" -eq 1 ]; then
-    check_term "${uses[0]}" "$base"
+    local_parent="$prefix ${uses[0]}"
   else
     local_parent="${uses[0]}"
-    check_term "$local_parent" "$base"
-    for ((i = 1; i < ${#uses[@]}; i++)); do
-      check_term "$local_parent ${uses[$i]}" "$base"
-    done
   fi
+  check_term "$local_parent" "$base"
+  for ((i = 1; i < ${#uses[@]}; i++)); do
+    check_term "$local_parent ${uses[$i]}" "$base"
+  done
+done
+
+for term in "${EXTRA_TERMS[@]}"; do
+  check_term "$term" "(EXTRA_TERMS)"
 done
 
 echo "==> Checked $checked commands." >&2

--- a/scripts/check-arc42-process-coverage.sh
+++ b/scripts/check-arc42-process-coverage.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# scripts/check-arc42-process-coverage.sh — verify that every real
+# cmd/bausteinsicht/*.go command is mentioned somewhere in
+# src/docs/arc42/chapters/03_context_and_scope.adoc (§3.1.1 "Architecture
+# Maintenance Process").
+#
+# This is a lightweight, textual companion to check-arc42-drift.sh: that
+# script catches *structural* drift (a package missing from
+# architecture.jsonc); this one catches *prose* drift (a command the process
+# diagram/narrative never mentions). It was proposed in #535, where §3.1.1
+# was found to describe only 5 of ~35 commands after the CLI grew far beyond
+# its original sync-loop scope.
+#
+# The check is deliberately a substring/case-insensitive text search, not a
+# semantic one — a command "counts" as covered if its name (or its
+# "<parent> <child>" form for add_*/snapshot_* subcommands) appears anywhere
+# in the chapter. That is a low bar on purpose: this script flags candidates
+# for a human/doc-check review, it does not judge documentation quality.
+#
+# Usage:
+#   scripts/check-arc42-process-coverage.sh
+#   make arc42-process-coverage-check
+#
+# Exit code 0 = every command mentioned, 1 = at least one gap found.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+CHAPTER="src/docs/arc42/chapters/03_context_and_scope.adoc"
+CMD_DIR="cmd/bausteinsicht"
+
+# Files that are not themselves a user-facing command (entry point, internal
+# helpers reused by other commands, or a parent whose Use: token is covered
+# via its own file).
+EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
+
+# Subcommand files whose Cobra `Use:` token alone is too generic to search
+# for (e.g. "view", "save", "list") — combine with their parent command.
+declare -A PARENT_PREFIX=(
+  [add_element.go]="add"
+  [add_relationship.go]="add"
+  [add_specification.go]="add"
+  [add_view.go]="add"
+  [snapshot_delete.go]="snapshot"
+  [snapshot_diff.go]="snapshot"
+  [snapshot_list.go]="snapshot"
+  [snapshot_restore.go]="snapshot"
+  [snapshot_save.go]="snapshot"
+)
+
+is_excluded() {
+  local base="$1"
+  for ex in "${EXCLUDE_FILES[@]}"; do
+    [ "$base" = "$ex" ] && return 0
+  done
+  case "$base" in *_test.go) return 0 ;; esac
+  return 1
+}
+
+exit_code=0
+checked=0
+
+echo "==> Checking command mentions in $CHAPTER..." >&2
+for f in "$CMD_DIR"/*.go; do
+  base="$(basename "$f")"
+  is_excluded "$base" && continue
+
+  use="$(grep -m1 -oP 'Use:\s*"\K[a-zA-Z0-9_-]+' "$f" || true)"
+  [ -z "$use" ] && continue
+
+  prefix="${PARENT_PREFIX[$base]:-}"
+  if [ -n "$prefix" ]; then
+    term="$prefix $use"
+  else
+    term="$use"
+  fi
+
+  checked=$((checked + 1))
+  if ! grep -qiF -- "$term" "$CHAPTER"; then
+    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    exit_code=1
+  fi
+done
+
+echo "==> Checked $checked commands." >&2
+if [ "$exit_code" -eq 0 ]; then
+  echo "==> No gaps: every cmd/bausteinsicht command is mentioned in §3.1.1." >&2
+else
+  echo "==> Gaps found — see #535 for the class of issue this catches." >&2
+fi
+
+exit "$exit_code"

--- a/scripts/check-arc42-process-coverage.sh
+++ b/scripts/check-arc42-process-coverage.sh
@@ -92,11 +92,16 @@ is_excluded() {
 exit_code=0
 checked=0
 
+# $2 is a human-readable source label — either "$CMD_DIR/<file>.go" for
+# terms derived from the per-file loop, or a plain description for
+# EXTRA_TERMS entries (not a real file, so it must not be dressed up as
+# one via "$CMD_DIR/$label" — that previously printed the confusing
+# "cmd/bausteinsicht/(EXTRA_TERMS)").
 check_term() {
-  local term="$1" base="$2"
+  local term="$1" source="$2"
   checked=$((checked + 1))
   if ! grep -qiF -- "$term" "$CHAPTER"; then
-    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    echo "  MISSING: '$term' (from $source) not mentioned in $CHAPTER" >&2
     exit_code=1
   fi
 }
@@ -127,14 +132,14 @@ for f in "$CMD_DIR"/*.go; do
   else
     local_parent="${uses[0]}"
   fi
-  check_term "$local_parent" "$base"
+  check_term "$local_parent" "$CMD_DIR/$base"
   for ((i = 1; i < ${#uses[@]}; i++)); do
-    check_term "$local_parent ${uses[$i]}" "$base"
+    check_term "$local_parent ${uses[$i]}" "$CMD_DIR/$base"
   done
 done
 
 for term in "${EXTRA_TERMS[@]}"; do
-  check_term "$term" "(EXTRA_TERMS)"
+  check_term "$term" "EXTRA_TERMS (cross-file command, see script header)"
 done
 
 echo "==> Checked $checked commands." >&2

--- a/scripts/check-arc42-process-coverage.sh
+++ b/scripts/check-arc42-process-coverage.sh
@@ -13,9 +13,9 @@
 #
 # The check is deliberately a substring/case-insensitive text search, not a
 # semantic one — a command "counts" as covered if its name (or its
-# "<parent> <child>" form for add_*/snapshot_* subcommands) appears anywhere
-# in the chapter. That is a low bar on purpose: this script flags candidates
-# for a human/doc-check review, it does not judge documentation quality.
+# "<parent> <child>" form for subcommands) appears anywhere in the chapter.
+# That is a low bar on purpose: this script flags candidates for a
+# human/doc-check review, it does not judge documentation quality.
 #
 # Usage:
 #   scripts/check-arc42-process-coverage.sh
@@ -36,8 +36,13 @@ CMD_DIR="cmd/bausteinsicht"
 # via its own file).
 EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
 
-# Subcommand files whose Cobra `Use:` token alone is too generic to search
-# for (e.g. "view", "save", "list") — combine with their parent command.
+# Subcommand files that define exactly one Cobra command whose own `Use:`
+# token is too generic to search for (e.g. "view", "save", "list") because
+# their parent command lives in a *different* file (add.go / snapshot.go) —
+# combine with that parent. Files where parent and subcommands are defined
+# together (workspace.go, overlay.go, adr.go, cmd_schema.go, add.go) don't
+# need an entry here: every Use: token in the file is extracted and the
+# first one is used as the local parent for the rest (see the loop below).
 declare -A PARENT_PREFIX=(
   [add_element.go]="add"
   [add_relationship.go]="add"
@@ -62,25 +67,42 @@ is_excluded() {
 exit_code=0
 checked=0
 
+check_term() {
+  local term="$1" base="$2"
+  checked=$((checked + 1))
+  if ! grep -qiF -- "$term" "$CHAPTER"; then
+    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    exit_code=1
+  fi
+}
+
 echo "==> Checking command mentions in $CHAPTER..." >&2
 for f in "$CMD_DIR"/*.go; do
   base="$(basename "$f")"
   is_excluded "$base" && continue
 
-  use="$(grep -m1 -oP 'Use:\s*"\K[a-zA-Z0-9_-]+' "$f" || true)"
-  [ -z "$use" ] && continue
+  # Portable extraction (POSIX BRE via sed, not grep -P/PCRE — GNU grep's -P
+  # isn't available on BSD grep, e.g. macOS's default /usr/bin/grep, which
+  # would otherwise silently yield zero matches everywhere and make this
+  # script falsely report "no gaps"). Extracts *every* Use: token in the
+  # file, not just the first — a file can define a parent command and all
+  # its subcommands together (e.g. workspace.go: workspace/merge/validate/
+  # list), and only checking the first token used to leave every subcommand
+  # in such files permanently unchecked.
+  mapfile -t uses < <(sed -n 's/^[[:space:]]*Use:[[:space:]]*"\([a-zA-Z0-9_-]*\).*/\1/p' "$f")
+  [ "${#uses[@]}" -eq 0 ] && continue
 
   prefix="${PARENT_PREFIX[$base]:-}"
   if [ -n "$prefix" ]; then
-    term="$prefix $use"
+    check_term "$prefix ${uses[0]}" "$base"
+  elif [ "${#uses[@]}" -eq 1 ]; then
+    check_term "${uses[0]}" "$base"
   else
-    term="$use"
-  fi
-
-  checked=$((checked + 1))
-  if ! grep -qiF -- "$term" "$CHAPTER"; then
-    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
-    exit_code=1
+    local_parent="${uses[0]}"
+    check_term "$local_parent" "$base"
+    for ((i = 1; i < ${#uses[@]}; i++)); do
+      check_term "$local_parent ${uses[$i]}" "$base"
+    done
   fi
 done
 

--- a/scripts/check-arc42-runtime-coverage.sh
+++ b/scripts/check-arc42-runtime-coverage.sh
@@ -89,11 +89,16 @@ is_excluded() {
 exit_code=0
 checked=0
 
+# $2 is a human-readable source label — either "$CMD_DIR/<file>.go" for
+# terms derived from the per-file loop, or a plain description for
+# EXTRA_TERMS entries (not a real file, so it must not be dressed up as
+# one via "$CMD_DIR/$label" — that previously printed the confusing
+# "cmd/bausteinsicht/(EXTRA_TERMS)").
 check_term() {
-  local term="$1" base="$2"
+  local term="$1" source="$2"
   checked=$((checked + 1))
   if ! grep -qiF -- "$term" "$CHAPTER"; then
-    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    echo "  MISSING: '$term' (from $source) not mentioned in $CHAPTER" >&2
     exit_code=1
   fi
 }
@@ -124,14 +129,14 @@ for f in "$CMD_DIR"/*.go; do
   else
     local_parent="${uses[0]}"
   fi
-  check_term "$local_parent" "$base"
+  check_term "$local_parent" "$CMD_DIR/$base"
   for ((i = 1; i < ${#uses[@]}; i++)); do
-    check_term "$local_parent ${uses[$i]}" "$base"
+    check_term "$local_parent ${uses[$i]}" "$CMD_DIR/$base"
   done
 done
 
 for term in "${EXTRA_TERMS[@]}"; do
-  check_term "$term" "(EXTRA_TERMS)"
+  check_term "$term" "EXTRA_TERMS (cross-file command, see script header)"
 done
 
 echo "==> Checked $checked commands." >&2

--- a/scripts/check-arc42-runtime-coverage.sh
+++ b/scripts/check-arc42-runtime-coverage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/check-arc42-runtime-coverage.sh — verify that every real
+# cmd/bausteinsicht/*.go command is mentioned somewhere in
+# src/docs/arc42/chapters/06_runtime_view.adoc.
+#
+# Sibling of check-arc42-process-coverage.sh (see that script's header for
+# the shared rationale): this one checks chapter 6's sequence-diagram
+# scenarios instead of chapter 3's process diagram. Proposed in #535, where
+# ch6 was found to have real coverage (8 scenarios) but whole command groups
+# — Evolution beyond REPL-save, the Export family, Analysis beyond `stale`,
+# `validate`, `workspace`, and others — had no scenario at all.
+#
+# Same substring/case-insensitive heuristic and same caveat as
+# check-arc42-process-coverage.sh: this is a low bar meant to surface
+# candidates for review, not to judge documentation quality.
+#
+# Usage:
+#   scripts/check-arc42-runtime-coverage.sh
+#   make arc42-runtime-coverage-check
+#
+# Exit code 0 = every command mentioned, 1 = at least one gap found.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+CHAPTER="src/docs/arc42/chapters/06_runtime_view.adoc"
+CMD_DIR="cmd/bausteinsicht"
+
+# Files that are not themselves a user-facing command (entry point, internal
+# helpers reused by other commands, or a parent whose Use: token is covered
+# via its own file).
+EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
+
+# Subcommand files whose Cobra `Use:` token alone is too generic to search
+# for (e.g. "view", "save", "list") — combine with their parent command.
+declare -A PARENT_PREFIX=(
+  [add_element.go]="add"
+  [add_relationship.go]="add"
+  [add_specification.go]="add"
+  [add_view.go]="add"
+  [snapshot_delete.go]="snapshot"
+  [snapshot_diff.go]="snapshot"
+  [snapshot_list.go]="snapshot"
+  [snapshot_restore.go]="snapshot"
+  [snapshot_save.go]="snapshot"
+)
+
+is_excluded() {
+  local base="$1"
+  for ex in "${EXCLUDE_FILES[@]}"; do
+    [ "$base" = "$ex" ] && return 0
+  done
+  case "$base" in *_test.go) return 0 ;; esac
+  return 1
+}
+
+exit_code=0
+checked=0
+
+echo "==> Checking command mentions in $CHAPTER..." >&2
+for f in "$CMD_DIR"/*.go; do
+  base="$(basename "$f")"
+  is_excluded "$base" && continue
+
+  use="$(grep -m1 -oP 'Use:\s*"\K[a-zA-Z0-9_-]+' "$f" || true)"
+  [ -z "$use" ] && continue
+
+  prefix="${PARENT_PREFIX[$base]:-}"
+  if [ -n "$prefix" ]; then
+    term="$prefix $use"
+  else
+    term="$use"
+  fi
+
+  checked=$((checked + 1))
+  if ! grep -qiF -- "$term" "$CHAPTER"; then
+    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    exit_code=1
+  fi
+done
+
+echo "==> Checked $checked commands." >&2
+if [ "$exit_code" -eq 0 ]; then
+  echo "==> No gaps: every cmd/bausteinsicht command is mentioned in chapter 6." >&2
+else
+  echo "==> Gaps found — see #535 for the class of issue this catches." >&2
+fi
+
+exit "$exit_code"

--- a/scripts/check-arc42-runtime-coverage.sh
+++ b/scripts/check-arc42-runtime-coverage.sh
@@ -33,13 +33,16 @@ CMD_DIR="cmd/bausteinsicht"
 # via its own file).
 EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
 
-# Subcommand files that define exactly one Cobra command whose own `Use:`
-# token is too generic to search for (e.g. "view", "save", "list") because
-# their parent command lives in a *different* file (add.go / snapshot.go) —
-# combine with that parent. Files where parent and subcommands are defined
-# together (workspace.go, overlay.go, adr.go, cmd_schema.go, add.go) don't
-# need an entry here: every Use: token in the file is extracted and the
-# first one is used as the local parent for the rest (see the loop below).
+# Subcommand files whose own first (or only) `Use:` token is too generic to
+# search for alone (e.g. "element", "view", "save") because their parent
+# command lives in a *different* file (add.go / snapshot.go) — prefix with
+# that parent. Composes with the multi-Use: local-parent logic below: e.g.
+# add_specification.go's three tokens (specification/element/relationship)
+# become "add specification", "add specification element", "add
+# specification relationship". Files where parent and subcommands are
+# defined together (workspace.go, overlay.go, adr.go, cmd_schema.go) don't
+# need an entry here — their own first Use: token is already a specific
+# enough parent on its own.
 declare -A PARENT_PREFIX=(
   [add_element.go]="add"
   [add_relationship.go]="add"
@@ -50,6 +53,28 @@ declare -A PARENT_PREFIX=(
   [snapshot_list.go]="snapshot"
   [snapshot_restore.go]="snapshot"
   [snapshot_save.go]="snapshot"
+)
+
+# add_from_pattern.go defines two Use: tokens ("add-from-pattern
+# <pattern-id>" and "list"), but they are *not* parent/child in the real
+# Cobra command tree: newListPatternsCmd()'s "list" is wired in add.go
+# under a completely separate "pattern" command group
+# (patternCmd.AddCommand(newListPatternsCmd())), never under
+# add-from-pattern. Combining them as "add-from-pattern list" would assert
+# a command that doesn't exist (verified: `bausteinsicht add-from-pattern`
+# errors "unknown command" — the real invocations are
+# `bausteinsicht add add-from-pattern <pattern-id>` and
+# `bausteinsicht add pattern list`). So this file's extra tokens are
+# ignored here, and the real 3-level term is listed in EXTRA_TERMS instead
+# — a cross-file relationship (add.go's "pattern" parent + this file's
+# "list" child) the per-file heuristic can't derive on its own.
+IGNORE_EXTRA_USES=(add_from_pattern.go)
+
+# Terms that can't be derived by the per-file heuristic above (cross-file
+# 3-level nesting, or any other real command the automatic derivation
+# can't reach) — checked in addition to the per-file loop.
+EXTRA_TERMS=(
+  "add pattern list"
 )
 
 is_excluded() {
@@ -89,18 +114,24 @@ for f in "$CMD_DIR"/*.go; do
   mapfile -t uses < <(sed -n 's/^[[:space:]]*Use:[[:space:]]*"\([a-zA-Z0-9_-]*\).*/\1/p' "$f")
   [ "${#uses[@]}" -eq 0 ] && continue
 
+  for ignore in "${IGNORE_EXTRA_USES[@]}"; do
+    [ "$base" = "$ignore" ] && uses=("${uses[0]}")
+  done
+
   prefix="${PARENT_PREFIX[$base]:-}"
   if [ -n "$prefix" ]; then
-    check_term "$prefix ${uses[0]}" "$base"
-  elif [ "${#uses[@]}" -eq 1 ]; then
-    check_term "${uses[0]}" "$base"
+    local_parent="$prefix ${uses[0]}"
   else
     local_parent="${uses[0]}"
-    check_term "$local_parent" "$base"
-    for ((i = 1; i < ${#uses[@]}; i++)); do
-      check_term "$local_parent ${uses[$i]}" "$base"
-    done
   fi
+  check_term "$local_parent" "$base"
+  for ((i = 1; i < ${#uses[@]}; i++)); do
+    check_term "$local_parent ${uses[$i]}" "$base"
+  done
+done
+
+for term in "${EXTRA_TERMS[@]}"; do
+  check_term "$term" "(EXTRA_TERMS)"
 done
 
 echo "==> Checked $checked commands." >&2

--- a/scripts/check-arc42-runtime-coverage.sh
+++ b/scripts/check-arc42-runtime-coverage.sh
@@ -33,8 +33,13 @@ CMD_DIR="cmd/bausteinsicht"
 # via its own file).
 EXCLUDE_FILES=(main.go root.go repl_save.go template_resolve.go)
 
-# Subcommand files whose Cobra `Use:` token alone is too generic to search
-# for (e.g. "view", "save", "list") — combine with their parent command.
+# Subcommand files that define exactly one Cobra command whose own `Use:`
+# token is too generic to search for (e.g. "view", "save", "list") because
+# their parent command lives in a *different* file (add.go / snapshot.go) —
+# combine with that parent. Files where parent and subcommands are defined
+# together (workspace.go, overlay.go, adr.go, cmd_schema.go, add.go) don't
+# need an entry here: every Use: token in the file is extracted and the
+# first one is used as the local parent for the rest (see the loop below).
 declare -A PARENT_PREFIX=(
   [add_element.go]="add"
   [add_relationship.go]="add"
@@ -59,25 +64,42 @@ is_excluded() {
 exit_code=0
 checked=0
 
+check_term() {
+  local term="$1" base="$2"
+  checked=$((checked + 1))
+  if ! grep -qiF -- "$term" "$CHAPTER"; then
+    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
+    exit_code=1
+  fi
+}
+
 echo "==> Checking command mentions in $CHAPTER..." >&2
 for f in "$CMD_DIR"/*.go; do
   base="$(basename "$f")"
   is_excluded "$base" && continue
 
-  use="$(grep -m1 -oP 'Use:\s*"\K[a-zA-Z0-9_-]+' "$f" || true)"
-  [ -z "$use" ] && continue
+  # Portable extraction (POSIX BRE via sed, not grep -P/PCRE — GNU grep's -P
+  # isn't available on BSD grep, e.g. macOS's default /usr/bin/grep, which
+  # would otherwise silently yield zero matches everywhere and make this
+  # script falsely report "no gaps"). Extracts *every* Use: token in the
+  # file, not just the first — a file can define a parent command and all
+  # its subcommands together (e.g. workspace.go: workspace/merge/validate/
+  # list), and only checking the first token used to leave every subcommand
+  # in such files permanently unchecked.
+  mapfile -t uses < <(sed -n 's/^[[:space:]]*Use:[[:space:]]*"\([a-zA-Z0-9_-]*\).*/\1/p' "$f")
+  [ "${#uses[@]}" -eq 0 ] && continue
 
   prefix="${PARENT_PREFIX[$base]:-}"
   if [ -n "$prefix" ]; then
-    term="$prefix $use"
+    check_term "$prefix ${uses[0]}" "$base"
+  elif [ "${#uses[@]}" -eq 1 ]; then
+    check_term "${uses[0]}" "$base"
   else
-    term="$use"
-  fi
-
-  checked=$((checked + 1))
-  if ! grep -qiF -- "$term" "$CHAPTER"; then
-    echo "  MISSING: '$term' (from $CMD_DIR/$base) not mentioned in $CHAPTER" >&2
-    exit_code=1
+    local_parent="${uses[0]}"
+    check_term "$local_parent" "$base"
+    for ((i = 1; i < ${#uses[@]}; i++)); do
+      check_term "$local_parent ${uses[$i]}" "$base"
+    done
   fi
 done
 


### PR DESCRIPTION
## Summary
- #535 found that §3.1.1 (Context and Scope process diagram) and chapter 6 (Runtime View sequence diagrams) had both drifted behind the real CLI command set — 22 and 23 commands respectively went unmentioned.
- Adds `scripts/check-arc42-process-coverage.sh` and `scripts/check-arc42-runtime-coverage.sh`, textual siblings of `check-arc42-drift.sh`: each extracts every `cmd/bausteinsicht/*.go` command's Cobra `Use:` token and checks it's mentioned somewhere in the corresponding chapter.
- Wired into `make arc42-process-coverage-check` / `make arc42-runtime-coverage-check`, and into `/doc-check review` mode as **⚠️ non-blocking** (this is a text-substring heuristic, not a semantic check, unlike `arc42-drift-check`'s **❌ blocking** structural comparison — so it's not added to CI).

## Test plan
- [x] Ran both scripts against current (pre-fix) docs — correctly reproduces the exact gap lists from #535 (22 missing in ch3, 23 in ch6)
- [x] `bash -n` syntax check on both scripts
- [x] `make -n arc42-process-coverage-check` / `make -n arc42-runtime-coverage-check` resolve correctly

Part of #535 (docs content fix itself still open — this PR only adds the automation)

## Review notes (3 rounds)

**Round 1 — raifdmueller:**
1. `grep -m1` only ever extracted a file's *first* `Use:` token — fine for `add_*.go`/`snapshot_*.go` (one subcommand per file), but files that define a parent **and** all its subcommands together (`workspace.go`, `overlay.go`, `adr.go`, `cmd_schema.go`, `add.go`) had every subcommand beyond the first silently invisible to the check — undermining exactly the `workspace`/`overlay`/`adr` coverage #535 asked for.
2. `grep -oP` (PCRE) isn't supported by BSD grep (macOS's default `/usr/bin/grep` has no GNU extensions) — wrapped in `|| true`, this silently degraded to zero matches and a false "no gaps" on that platform.
   → Fixed in `5a53146`: full per-file `Use:` extraction via portable POSIX BRE (`sed`), no PCRE dependency. Checked-command count 37 → 48.

**Round 2 — independent self-review across all 3 stacked PRs:**
3. `add_specification.go` has both a `PARENT_PREFIX` entry and 3 `Use:` tokens (all genuinely its own children) — the round-1 fix's if/elif/else still treated those as mutually exclusive, so `add specification element`/`add specification relationship` were silently never checked, the *exact* under-counting bug round 1 was meant to close, still present for this one file.
4. `add_from_pattern.go`'s second `Use: "list"` token does **not** belong to `add-from-pattern` in the real Cobra tree — `newListPatternsCmd` is wired under a separate `pattern` group in `add.go`. The heuristic fabricated the search term `add-from-pattern list`, a command that doesn't exist (verified empirically: `bausteinsicht add-from-pattern` errors "unknown command"; the real commands are `bausteinsicht add add-from-pattern <pattern-id>` and `bausteinsicht add pattern list`).
   → Fixed in `1685016`: unified `PARENT_PREFIX` + multi-`Use:` composition (fixes #3), plus `IGNORE_EXTRA_USES`/`EXTRA_TERMS` for the one real cross-file exception (fixes #4). Checked-command count 48 → 50.

**Round 3 — second self-review pass:**
5. `check_term`'s MISSING message built `(from $CMD_DIR/$base)` unconditionally, which for `EXTRA_TERMS` entries (not a real file) printed the confusing `cmd/bausteinsicht/(EXTRA_TERMS)`.
   → Fixed in `55f9d2f`: `check_term` now takes a full source label, not a bare filename.

CI green (19/19) after each round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)