### PR TITLE
fix: apply relationship dashed flag to rendering (#518)

### DIFF
--- a/.claude/agents/start_issue.md
+++ b/.claude/agents/start_issue.md
@@ -1,33 +1,33 @@
 ---
 name: start_issue
 description: >
-  Startet die Arbeit an einem GitHub Issue nach der docs-first-Konvention des Projekts:
-  führt das doc-check Skill im start-Modus für dieses Issue aus (identifiziert betroffene
-  Spec-/Architektur-Dokumente und aktualisiert sie vor der Implementierung).
-  Aufrufen mit "@start_issue 123" oder "@start_issue #123".
+  Starts work on a GitHub issue following the project's docs-first convention:
+  runs the doc-check skill in start mode for this issue (identifies affected
+  spec/architecture docs and updates them before implementation begins).
+  Invoke with "@start_issue 123" or "@start_issue #123".
 tools: Bash, Read, Write, Edit, Glob, Grep
 model: sonnet
 ---
 
-Du startest die Arbeit an einem GitHub Issue für Bausteinsicht, gemäß der "Ticket Start"-Regel
-in CLAUDE.md: docs-first, bevor Implementierung beginnt.
+You are starting work on a GitHub issue for Bausteinsicht, per the "Ticket Start" rule
+in CLAUDE.md: docs-first, before implementation begins.
 
-## Aufgabe
+## Task
 
-Du erhältst eine Issue-Nummer als Argument (z.B. `123` oder `#123`). Führe exakt das aus, was
-`/doc-check start #<issue>` tun würde:
+You receive an issue number as an argument (e.g. `123` or `#123`). Do exactly what
+`/doc-check start #<issue>` would do:
 
-1. Lies `.claude/skills/doc-check/SKILL.md` vollständig.
-2. Führe den Abschnitt **"Mode: start"** dieses Skills für die übergebene Issue-Nummer aus —
-   Schritt für Schritt, mit den dort beschriebenen `gh`/`git`-Befehlen und Doc-Update-Regeln.
-3. Wende die dort identifizierten Doku-Updates tatsächlich an (nicht nur auflisten).
-4. Fasse am Ende zusammen: welche Docs aktualisiert wurden, welche bewusst unverändert blieben
-   (mit Begründung), und was als Nächstes (Implementierung) ansteht.
+1. Read `.claude/skills/doc-check/SKILL.md` in full.
+2. Execute the **"Mode: start"** section of that skill for the given issue number —
+   step by step, using the `gh`/`git` commands and doc-update rules described there.
+3. Actually apply the doc updates identified there (not just list them).
+4. Summarize at the end: which docs were updated, which were deliberately left
+   unchanged (with reasoning), and what's next (implementation).
 
-Falls keine Issue-Nummer übergeben wurde: frage nach, statt ohne Nummer weiterzumachen — das
-Skill fällt sonst auf den aktuellen Branch zurück statt auf ein konkretes Ticket, was hier nicht
-gewollt ist.
+If no issue number was given: ask for one instead of proceeding without it — otherwise
+the skill falls back to the current branch instead of a specific ticket, which is not
+wanted here.
 
-Halte dich strikt an die im Skill beschriebene Logik (Quelle der Wahrheit); dupliziere sie hier
-nicht, sondern lies sie bei jedem Aufruf frisch aus `.claude/skills/doc-check/SKILL.md`, damit
-Änderungen am Skill automatisch übernommen werden.
+Stick strictly to the logic described in the skill (source of truth); don't duplicate it
+here — instead, read it fresh from `.claude/skills/doc-check/SKILL.md` on every invocation,
+so changes to the skill are picked up automatically.

--- a/.claude/agents/start_issue.md
+++ b/.claude/agents/start_issue.md
@@ -1,0 +1,33 @@
+---
+name: start_issue
+description: >
+  Startet die Arbeit an einem GitHub Issue nach der docs-first-Konvention des Projekts:
+  führt das doc-check Skill im start-Modus für dieses Issue aus (identifiziert betroffene
+  Spec-/Architektur-Dokumente und aktualisiert sie vor der Implementierung).
+  Aufrufen mit "@start_issue 123" oder "@start_issue #123".
+tools: Bash, Read, Write, Edit, Glob, Grep
+model: sonnet
+---
+
+Du startest die Arbeit an einem GitHub Issue für Bausteinsicht, gemäß der "Ticket Start"-Regel
+in CLAUDE.md: docs-first, bevor Implementierung beginnt.
+
+## Aufgabe
+
+Du erhältst eine Issue-Nummer als Argument (z.B. `123` oder `#123`). Führe exakt das aus, was
+`/doc-check start #<issue>` tun würde:
+
+1. Lies `.claude/skills/doc-check/SKILL.md` vollständig.
+2. Führe den Abschnitt **"Mode: start"** dieses Skills für die übergebene Issue-Nummer aus —
+   Schritt für Schritt, mit den dort beschriebenen `gh`/`git`-Befehlen und Doc-Update-Regeln.
+3. Wende die dort identifizierten Doku-Updates tatsächlich an (nicht nur auflisten).
+4. Fasse am Ende zusammen: welche Docs aktualisiert wurden, welche bewusst unverändert blieben
+   (mit Begründung), und was als Nächstes (Implementierung) ansteht.
+
+Falls keine Issue-Nummer übergeben wurde: frage nach, statt ohne Nummer weiterzumachen — das
+Skill fällt sonst auf den aktuellen Branch zurück statt auf ein konkretes Ticket, was hier nicht
+gewollt ist.
+
+Halte dich strikt an die im Skill beschriebene Logik (Quelle der Wahrheit); dupliziere sie hier
+nicht, sondern lies sie bei jedem Aufruf frisch aus `.claude/skills/doc-check/SKILL.md`, damit
+Änderungen am Skill automatisch übernommen werden.

--- a/e2e/dashed_relationship_test.go
+++ b/e2e/dashed_relationship_test.go
@@ -79,9 +79,7 @@ func TestDashedRelationship(t *testing.T) {
 	dir := t.TempDir()
 
 	modelPath := filepath.Join(dir, "architecture.jsonc")
-	if err := os.WriteFile(modelPath, []byte(dashedRelModelJSON), 0o644); err != nil {
-		t.Fatalf("write model: %v", err)
-	}
+	writeFile(t, modelPath, dashedRelModelJSON)
 
 	// ── Step 1: sync — draw.io connector style ──────────────────────────────
 	runCLI(t, bin, dir, "sync", "--model", "architecture.jsonc")

--- a/e2e/dashed_relationship_test.go
+++ b/e2e/dashed_relationship_test.go
@@ -1,0 +1,173 @@
+package e2e
+
+// TestDashedRelationship (#518) verifies that a relationship kind's
+// specification.relationships.<kind>.dashed flag is actually applied when
+// rendering, across every renderer that draws relationships as arrows:
+//
+//  1. sync → draw.io connector style contains "dashed=1" for the dashed
+//     kind's connector, and does not for the non-dashed kind's connector.
+//  2. export-diagram --diagram-format plantuml → dashed relationship uses a
+//     raw ".." arrow (C4-PlantUML's own per-relationship line-style
+//     override errors on the tested PlantUML versions), non-dashed uses
+//     the normal Rel(...) macro.
+//  3. export-diagram --diagram-format dot → dashed relationship's edge has
+//     style="dashed".
+//  4. export-diagram --diagram-format d2 → dashed relationship's edge has
+//     a style.stroke-dash block.
+//
+// Mermaid is deliberately not covered here: Mermaid's own C4 diagram docs
+// mark the dashed-line style override as "not yet implemented" upstream,
+// so there is nothing for this fix to wire up yet (see diagram.go comment
+// next to writeMermaid).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const dashedRelModelJSON = `{
+  "specification": {
+    "elements": {
+      "container": {
+        "notation": "Container",
+        "description": "A deployable unit"
+      }
+    },
+    "relationships": {
+      "sync": {
+        "notation": "uses"
+      },
+      "async": {
+        "notation": "publishes/subscribes",
+        "dashed": true
+      }
+    }
+  },
+  "model": {
+    "api": {
+      "kind": "container",
+      "title": "API",
+      "description": "Main backend service"
+    },
+    "worker": {
+      "kind": "container",
+      "title": "Worker",
+      "description": "Background job processor"
+    },
+    "queue": {
+      "kind": "container",
+      "title": "Queue",
+      "description": "Message queue"
+    }
+  },
+  "relationships": [
+    { "from": "api", "to": "worker", "kind": "sync", "label": "calls" },
+    { "from": "api", "to": "queue", "kind": "async", "label": "publishes to" }
+  ],
+  "views": {
+    "context": {
+      "title": "System Context",
+      "include": ["api", "worker", "queue"]
+    }
+  }
+}`
+
+func TestDashedRelationship(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(modelPath, []byte(dashedRelModelJSON), 0o644); err != nil {
+		t.Fatalf("write model: %v", err)
+	}
+
+	// ── Step 1: sync — draw.io connector style ──────────────────────────────
+	runCLI(t, bin, dir, "sync", "--model", "architecture.jsonc")
+
+	drawioBytes, err := os.ReadFile(filepath.Join(dir, "architecture.drawio"))
+	if err != nil {
+		t.Fatalf("read draw.io after sync: %v", err)
+	}
+	drawioContent := string(drawioBytes)
+
+	syncConn := extractConnectorStyle(t, drawioContent, "api", "worker")
+	asyncConn := extractConnectorStyle(t, drawioContent, "api", "queue")
+
+	if strings.Contains(syncConn, "dashed=1") {
+		t.Errorf("sync-kind connector (api->worker) unexpectedly dashed:\n%s", syncConn)
+	}
+	if !strings.Contains(asyncConn, "dashed=1") {
+		t.Errorf("async-kind connector (api->queue) missing dashed=1 in style:\n%s", asyncConn)
+	}
+
+	// ── Step 2: export-diagram --diagram-format plantuml ────────────────────
+	plantuml := runCLI(t, bin, dir, "export-diagram", "--model", "architecture.jsonc",
+		"--diagram-format", "plantuml", "--view", "context")
+	if !strings.Contains(plantuml, "Rel(api, worker") {
+		t.Errorf("plantuml: expected solid Rel(api, worker, ...) for sync relationship, got:\n%s", plantuml)
+	}
+	if !strings.Contains(plantuml, "api ..> queue") {
+		t.Errorf("plantuml: expected dashed 'api ..> queue' for async relationship, got:\n%s", plantuml)
+	}
+	if strings.Contains(plantuml, "Rel(api, queue") {
+		t.Errorf("plantuml: async relationship should not use the solid Rel() macro, got:\n%s", plantuml)
+	}
+
+	// ── Step 3: export-diagram --diagram-format dot ──────────────────────────
+	dot := runCLI(t, bin, dir, "export-diagram", "--model", "architecture.jsonc",
+		"--diagram-format", "dot", "--view", "context")
+	if !strings.Contains(dot, `api -> queue [label="publishes to" style="dashed"]`) {
+		t.Errorf("dot: expected dashed style on api->queue edge, got:\n%s", dot)
+	}
+	if !strings.Contains(dot, `api -> worker [label="calls"]`) {
+		t.Errorf("dot: expected plain (non-dashed) edge for sync relationship, got:\n%s", dot)
+	}
+	if strings.Contains(dot, `style="dashed"`) && strings.Count(dot, `style="dashed"`) != 1 {
+		t.Errorf("dot: expected exactly one dashed edge, got:\n%s", dot)
+	}
+
+	// ── Step 4: export-diagram --diagram-format d2 ───────────────────────────
+	d2 := runCLI(t, bin, dir, "export-diagram", "--model", "architecture.jsonc",
+		"--diagram-format", "d2", "--view", "context")
+	if !strings.Contains(d2, "style.stroke-dash") {
+		t.Errorf("d2: expected a style.stroke-dash block for the dashed relationship, got:\n%s", d2)
+	}
+	if !strings.Contains(d2, `api -> worker: "calls"`) {
+		t.Errorf("d2: expected plain (non-block) edge for sync relationship, got:\n%s", d2)
+	}
+}
+
+// extractConnectorStyle finds the mxCell edge whose bausteinsicht_from and
+// bausteinsicht_to attributes match from/to, and returns its style
+// attribute value. Fails the test if no matching connector is found.
+func extractConnectorStyle(t *testing.T, drawioContent, from, to string) string {
+	t.Helper()
+	// Cell refs are scoped per view ("<viewID>--<elementID>", see
+	// scopedCellID in internal/sync/forward.go) — the "context" view here
+	// makes them "context--api" etc.
+	marker := `source="context--` + from + `" target="context--` + to + `"`
+	idx := strings.Index(drawioContent, marker)
+	if idx < 0 {
+		t.Fatalf("no connector found for %s->%s in draw.io output:\n%s", from, to, drawioContent)
+	}
+	// The mxCell element containing this marker starts before it; search
+	// backward for the enclosing "<mxCell" and forward for the style attribute.
+	cellStart := strings.LastIndex(drawioContent[:idx], "<mxCell")
+	cellEnd := strings.Index(drawioContent[idx:], ">")
+	if cellStart < 0 || cellEnd < 0 {
+		t.Fatalf("could not locate mxCell bounds for %s->%s connector", from, to)
+	}
+	cell := drawioContent[cellStart : idx+cellEnd]
+	styleIdx := strings.Index(cell, `style="`)
+	if styleIdx < 0 {
+		t.Fatalf("connector %s->%s has no style attribute:\n%s", from, to, cell)
+	}
+	styleStart := styleIdx + len(`style="`)
+	styleEnd := strings.Index(cell[styleStart:], `"`)
+	if styleEnd < 0 {
+		t.Fatalf("unterminated style attribute for %s->%s connector:\n%s", from, to, cell)
+	}
+	return cell[styleStart : styleStart+styleEnd]
+}

--- a/internal/diagram/d2.go
+++ b/internal/diagram/d2.go
@@ -33,7 +33,7 @@ func RenderD2(m *model.BausteinsichtModel, viewKey string) (string, error) {
 	}
 
 	// Filter relationships
-	rels := filterRelationships(m.Relationships, elemSet)
+	rels := filterRelationships(m.Relationships, elemSet, &m.Specification)
 
 	var b strings.Builder
 	b.WriteString("direction: right\n\n")
@@ -68,13 +68,19 @@ func RenderD2(m *model.BausteinsichtModel, viewKey string) (string, error) {
 		b.WriteString("}\n\n")
 	}
 
-	// Write relationships
+	// Write relationships. Dashed ones use D2's edge style block
+	// (style.stroke-dash) — always paired with an explicit (possibly empty)
+	// label, since that's the documented/verified form for attaching a
+	// style block to an edge.
 	for _, r := range rels {
 		fromID := sanitizeD2ID(r.From)
 		toID := sanitizeD2ID(r.To)
-		if r.Label != "" {
+		switch {
+		case r.Dashed:
+			fmt.Fprintf(&b, "%s -> %s: %s {\n  style.stroke-dash: 3\n}\n", fromID, toID, escapeD2String(r.Label))
+		case r.Label != "":
 			fmt.Fprintf(&b, "%s -> %s: %s\n", fromID, toID, escapeD2String(r.Label))
-		} else {
+		default:
 			fmt.Fprintf(&b, "%s -> %s\n", fromID, toID)
 		}
 	}

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -171,11 +171,13 @@ type relEntry struct {
 
 // filterRelationships lifts relationship endpoints to visible elements,
 // deduplicates by (from, to) pair, and resolves each relationship's Dashed
-// flag from its kind in spec.Relationships (#518). spec may be nil, in
-// which case Dashed is always false.
+// flag from its kind in spec.Relationships (#518). When multiple
+// relationships collapse onto the same (from, to) pair (e.g. via endpoint
+// lifting), the rendered connector is dashed if any of them is, regardless
+// of iteration order.
 func filterRelationships(rels []model.Relationship, elemSet map[string]bool, spec *model.Specification) []relEntry {
 	var result []relEntry
-	seen := make(map[string]bool)
+	seenAt := make(map[string]int) // key -> index into result
 	for _, r := range rels {
 		from := liftToVisible(r.From, elemSet)
 		to := liftToVisible(r.To, elemSet)
@@ -183,14 +185,14 @@ func filterRelationships(rels []model.Relationship, elemSet map[string]bool, spe
 			continue
 		}
 		key := from + ":" + to
-		if seen[key] {
+		dashed := spec.IsDashed(r.Kind)
+		if idx, ok := seenAt[key]; ok {
+			if dashed {
+				result[idx].Dashed = true
+			}
 			continue
 		}
-		seen[key] = true
-		dashed := false
-		if spec != nil {
-			dashed = spec.Relationships[r.Kind].Dashed
-		}
+		seenAt[key] = len(result)
 		result = append(result, relEntry{from, to, r.Label, dashed})
 	}
 	return result

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -110,7 +110,7 @@ func FormatView(m *model.BausteinsichtModel, viewKey string, f Format) (string, 
 	if view.Scope != "" {
 		elemSet[view.Scope] = true
 	}
-	rels := filterRelationships(m.Relationships, elemSet)
+	rels := filterRelationships(m.Relationships, elemSet, &m.Specification)
 
 	var b strings.Builder
 	switch f {
@@ -163,12 +163,17 @@ func partitionElements(resolved []string, flat map[string]*model.Element, scope 
 }
 
 type relEntry struct {
-	From  string `json:"from"`
-	To    string `json:"to"`
-	Label string `json:"label,omitempty"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Label  string `json:"label,omitempty"`
+	Dashed bool   `json:"dashed,omitempty"`
 }
 
-func filterRelationships(rels []model.Relationship, elemSet map[string]bool) []relEntry {
+// filterRelationships lifts relationship endpoints to visible elements,
+// deduplicates by (from, to) pair, and resolves each relationship's Dashed
+// flag from its kind in spec.Relationships (#518). spec may be nil, in
+// which case Dashed is always false.
+func filterRelationships(rels []model.Relationship, elemSet map[string]bool, spec *model.Specification) []relEntry {
 	var result []relEntry
 	seen := make(map[string]bool)
 	for _, r := range rels {
@@ -182,7 +187,11 @@ func filterRelationships(rels []model.Relationship, elemSet map[string]bool) []r
 			continue
 		}
 		seen[key] = true
-		result = append(result, relEntry{from, to, r.Label})
+		dashed := false
+		if spec != nil {
+			dashed = spec.Relationships[r.Kind].Dashed
+		}
+		result = append(result, relEntry{from, to, r.Label, dashed})
 	}
 	return result
 }
@@ -267,12 +276,21 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 		}
 	}
 
-	// Relationships.
+	// Relationships. Dashed ones bypass the C4-PlantUML Rel() macro in favor
+	// of a raw dashed arrow (..>): C4-PlantUML's own per-relationship line
+	// style override (UpdateRelStyle($lineStyle=DashedLine())) errors with
+	// "Function not found" on the PlantUML versions tested (#518) — a plain
+	// PlantUML arrow renders correctly alongside C4-macro-created elements,
+	// since element aliases are valid regardless of which macro created them.
 	if len(rels) > 0 {
 		b.WriteString("\n")
 	}
 	for _, r := range rels {
-		fmt.Fprintf(b, "Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
+		if r.Dashed {
+			fmt.Fprintf(b, "%s ..> %s : \"%s\"\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
+		} else {
+			fmt.Fprintf(b, "Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
+		}
 	}
 
 	b.WriteString("@enduml\n")
@@ -322,6 +340,13 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 		}
 	}
 
+	// Relationships. r.Dashed is intentionally not applied here: Mermaid's
+	// own C4 diagram docs mark UpdateRelStyle's $lineStyle=DashedLine() as
+	// "not yet implemented" (https://mermaid.js.org/syntax/c4.html, checked
+	// 2026-07 — #518) — there is currently no dashed-line mechanism in
+	// Mermaid's C4 syntax to fall back to (unlike PlantUML, C4 diagrams
+	// don't support mixing in a raw arrow outside the C4 macro set). Revisit
+	// once Mermaid ships the feature.
 	if len(rels) > 0 {
 		b.WriteString("\n")
 	}

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -278,12 +278,19 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 		}
 	}
 
-	// Relationships. Dashed ones bypass the C4-PlantUML Rel() macro in favor
-	// of a raw dashed arrow (..>): C4-PlantUML's own per-relationship line
-	// style override (UpdateRelStyle($lineStyle=DashedLine())) errors with
-	// "Function not found" on the PlantUML versions tested (#518) — a plain
-	// PlantUML arrow renders correctly alongside C4-macro-created elements,
-	// since element aliases are valid regardless of which macro created them.
+	writePlantUMLRelationships(b, rels)
+
+	b.WriteString("@enduml\n")
+}
+
+// writePlantUMLRelationships writes the Rel() lines for a view. Dashed ones
+// bypass the C4-PlantUML Rel() macro in favor of a raw dashed arrow (..>):
+// C4-PlantUML's own per-relationship line style override
+// (UpdateRelStyle($lineStyle=DashedLine())) errors with "Function not found"
+// on the PlantUML versions tested (#518) — a plain PlantUML arrow renders
+// correctly alongside C4-macro-created elements, since element aliases are
+// valid regardless of which macro created them.
+func writePlantUMLRelationships(b *strings.Builder, rels []relEntry) {
 	if len(rels) > 0 {
 		b.WriteString("\n")
 	}
@@ -294,8 +301,6 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 			fmt.Fprintf(b, "Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
 		}
 	}
-
-	b.WriteString("@enduml\n")
 }
 
 func writePlantUMLElement(b *strings.Builder, e elemEntry, indent string) {

--- a/internal/diagram/diagram_test.go
+++ b/internal/diagram/diagram_test.go
@@ -47,6 +47,40 @@ func testModel() *model.BausteinsichtModel {
 	}
 }
 
+// TestFilterRelationships_LiftedDashedIsOrderIndependent verifies that when
+// two relationships with different kinds lift to the same visible (from, to)
+// pair, the resulting entry is dashed if ANY contributing relationship is
+// dashed — regardless of which one is encountered first. Regression test
+// for #518.
+func TestFilterRelationships_LiftedDashedIsOrderIndependent(t *testing.T) {
+	spec := &model.Specification{
+		Relationships: map[string]model.RelationshipKind{
+			"sync":  {Notation: "sync"},
+			"async": {Notation: "async", Dashed: true},
+		},
+	}
+	elemSet := map[string]bool{"a": true, "b": true}
+
+	nonDashedFirst := []model.Relationship{
+		{From: "a", To: "b", Kind: "sync"},
+		{From: "a", To: "b", Kind: "async"},
+	}
+	dashedFirst := []model.Relationship{
+		{From: "a", To: "b", Kind: "async"},
+		{From: "a", To: "b", Kind: "sync"},
+	}
+
+	for i, rels := range [][]model.Relationship{nonDashedFirst, dashedFirst} {
+		result := filterRelationships(rels, elemSet, spec)
+		if len(result) != 1 {
+			t.Fatalf("case %d: expected 1 deduplicated entry, got %d", i, len(result))
+		}
+		if !result[0].Dashed {
+			t.Errorf("case %d: expected deduplicated entry to be dashed regardless of order, got %+v", i, result[0])
+		}
+	}
+}
+
 // --- PlantUML Tests ---
 
 func TestPlantUML_ContextView(t *testing.T) {

--- a/internal/diagram/diagram_test.go
+++ b/internal/diagram/diagram_test.go
@@ -47,6 +47,34 @@ func testModel() *model.BausteinsichtModel {
 	}
 }
 
+// dashedTestModel returns a model with one dashed ("async") and one
+// non-dashed ("sync") relationship kind, used to test that #518's dashed
+// rendering is applied per renderer.
+func dashedTestModel() *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"container": {Notation: "Container"},
+			},
+			Relationships: map[string]model.RelationshipKind{
+				"sync":  {Notation: "calls"},
+				"async": {Notation: "publishes/subscribes", Dashed: true},
+			},
+		},
+		Model: map[string]model.Element{
+			"api":   {Kind: "container", Title: "API"},
+			"queue": {Kind: "container", Title: "Queue"},
+		},
+		Relationships: []model.Relationship{
+			{From: "api", To: "queue", Label: "calls", Kind: "sync"},
+			{From: "queue", To: "api", Label: "notifies", Kind: "async"},
+		},
+		Views: map[string]model.View{
+			"context": {Title: "Context", Include: []string{"api", "queue"}},
+		},
+	}
+}
+
 // TestFilterRelationships_LiftedDashedIsOrderIndependent verifies that when
 // two relationships with different kinds lift to the same visible (from, to)
 // pair, the resulting entry is dashed if ANY contributing relationship is
@@ -146,6 +174,27 @@ func TestPlantUML_Relationships(t *testing.T) {
 	}
 }
 
+// TestPlantUML_DashedRelationship verifies that a relationship whose kind is
+// marked dashed renders as a raw "..>" arrow instead of the Rel() macro,
+// while a non-dashed relationship keeps using Rel(). Regression test for #518.
+func TestPlantUML_DashedRelationship(t *testing.T) {
+	m := dashedTestModel()
+	result, err := FormatView(m, "context", PlantUML)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "Rel(api, queue") {
+		t.Errorf("expected Rel() macro for non-dashed relationship, got:\n%s", result)
+	}
+	if !strings.Contains(result, "queue ..> api") {
+		t.Errorf("expected raw dashed arrow for dashed relationship, got:\n%s", result)
+	}
+	if strings.Contains(result, "Rel(queue, api") {
+		t.Errorf("dashed relationship should not use the Rel() macro, got:\n%s", result)
+	}
+}
+
 func TestPlantUML_InvalidView(t *testing.T) {
 	m := testModel()
 	_, err := FormatView(m, "nonexistent", PlantUML)
@@ -210,6 +259,24 @@ func TestMermaid_Relationships(t *testing.T) {
 	}
 }
 
+// TestMermaid_DashedRelationshipUnsupported documents that Mermaid's C4
+// syntax has no dashed-line mechanism (#518): a dashed-kind relationship
+// renders identically to a non-dashed one via the plain Rel() macro.
+func TestMermaid_DashedRelationshipUnsupported(t *testing.T) {
+	m := dashedTestModel()
+	result, err := FormatView(m, "context", Mermaid)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, `Rel(api, queue, "calls")`) {
+		t.Errorf("expected Rel() macro for non-dashed relationship, got:\n%s", result)
+	}
+	if !strings.Contains(result, `Rel(queue, api, "notifies")`) {
+		t.Errorf("expected the dashed-kind relationship to still use the plain Rel() macro (no Mermaid dashed support), got:\n%s", result)
+	}
+}
+
 // --- DOT Tests ---
 
 func TestDOT_ContextView(t *testing.T) {
@@ -245,6 +312,23 @@ func TestDOT_WithColor(t *testing.T) {
 	}
 	if !strings.Contains(result, "color=") {
 		t.Error("expected color attribute for edges")
+	}
+}
+
+// TestDOT_DashedRelationship verifies a dashed-kind relationship gets
+// style="dashed" while a non-dashed one does not. Regression test for #518.
+func TestDOT_DashedRelationship(t *testing.T) {
+	m := dashedTestModel()
+	result, err := RenderDOT(m, "context")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, `queue -> api [label="notifies" style="dashed"]`) {
+		t.Errorf("expected dashed style on dashed-kind edge, got:\n%s", result)
+	}
+	if !strings.Contains(result, `api -> queue [label="calls"]`) {
+		t.Errorf("expected plain (non-dashed) edge for non-dashed relationship, got:\n%s", result)
 	}
 }
 
@@ -288,6 +372,24 @@ func TestD2_WithRelationships(t *testing.T) {
 	}
 	if !strings.Contains(result, "uses") {
 		t.Error("expected relationship labels")
+	}
+}
+
+// TestD2_DashedRelationship verifies a dashed-kind relationship gets a
+// style.stroke-dash edge block while a non-dashed one uses the plain
+// "from -> to: label" form. Regression test for #518.
+func TestD2_DashedRelationship(t *testing.T) {
+	m := dashedTestModel()
+	result, err := RenderD2(m, "context")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "queue -> api: \"notifies\" {\n  style.stroke-dash: 3\n}") {
+		t.Errorf("expected style.stroke-dash block for dashed relationship, got:\n%s", result)
+	}
+	if !strings.Contains(result, "api -> queue: \"calls\"\n") {
+		t.Errorf("expected plain (non-block) edge for non-dashed relationship, got:\n%s", result)
 	}
 }
 
@@ -351,6 +453,48 @@ func TestHTML_ValidJSON(t *testing.T) {
 	}
 	if len(data.Nodes) == 0 {
 		t.Error("expected nodes in diagram data")
+	}
+}
+
+// TestHTML_DashedRelationship verifies the embedded diagram-data JSON marks
+// a dashed-kind relationship's edge as dashed, and a non-dashed one as not.
+// Regression test for #518.
+func TestHTML_DashedRelationship(t *testing.T) {
+	m := dashedTestModel()
+	result, err := RenderHTML(m, "context")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	start := strings.Index(result, "const DIAGRAM_DATA = ")
+	if start < 0 {
+		t.Fatal("could not find DIAGRAM_DATA in HTML")
+	}
+	start += len("const DIAGRAM_DATA = ")
+	end := strings.Index(result[start:], ";")
+	if end < 0 {
+		t.Fatal("could not find end of DIAGRAM_DATA")
+	}
+
+	var data HTMLDiagramData
+	if err := json.Unmarshal([]byte(result[start:start+end]), &data); err != nil {
+		t.Fatalf("embedded JSON is invalid: %v", err)
+	}
+
+	var sawDashed, sawPlain bool
+	for _, e := range data.Edges {
+		switch {
+		case e.From == "queue" && e.To == "api":
+			sawDashed = e.Dashed
+		case e.From == "api" && e.To == "queue":
+			sawPlain = !e.Dashed
+		}
+	}
+	if !sawDashed {
+		t.Errorf("expected dashed-kind edge queue->api to have Dashed=true, edges: %+v", data.Edges)
+	}
+	if !sawPlain {
+		t.Errorf("expected non-dashed edge api->queue to have Dashed=false, edges: %+v", data.Edges)
 	}
 }
 

--- a/internal/diagram/dot.go
+++ b/internal/diagram/dot.go
@@ -33,7 +33,7 @@ func RenderDOT(m *model.BausteinsichtModel, viewKey string) (string, error) {
 	}
 
 	// Filter relationships
-	rels := filterRelationships(m.Relationships, elemSet)
+	rels := filterRelationships(m.Relationships, elemSet, &m.Specification)
 
 	var b strings.Builder
 	b.WriteString("digraph \"" + escapeQuotes(view.Title) + "\" {\n")
@@ -69,8 +69,15 @@ func RenderDOT(m *model.BausteinsichtModel, viewKey string) (string, error) {
 		for _, r := range rels {
 			fromID := sanitizeID(r.From)
 			toID := sanitizeID(r.To)
+			var attrs []string
 			if r.Label != "" {
-				fmt.Fprintf(&b, "  %s -> %s [label=\"%s\"]\n", fromID, toID, escapeQuotes(r.Label))
+				attrs = append(attrs, fmt.Sprintf("label=\"%s\"", escapeQuotes(r.Label)))
+			}
+			if r.Dashed {
+				attrs = append(attrs, `style="dashed"`)
+			}
+			if len(attrs) > 0 {
+				fmt.Fprintf(&b, "  %s -> %s [%s]\n", fromID, toID, strings.Join(attrs, " "))
 			} else {
 				fmt.Fprintf(&b, "  %s -> %s\n", fromID, toID)
 			}

--- a/internal/diagram/html.go
+++ b/internal/diagram/html.go
@@ -57,7 +57,7 @@ func RenderHTML(m *model.BausteinsichtModel, viewKey string) (string, error) {
 	}
 
 	// Filter relationships
-	rels := filterRelationships(m.Relationships, elemSet)
+	rels := filterRelationships(m.Relationships, elemSet, &m.Specification)
 
 	// Build node list with simple grid layout
 	nodes := []HTMLNode{}
@@ -266,6 +266,9 @@ func generateHTMLTemplate(title, dataJSON string) string {
           line.setAttribute('y2', toNode.y + 40);
           line.setAttribute('stroke', '#999');
           line.setAttribute('stroke-width', '2');
+          if (edge.dashed) {
+            line.setAttribute('stroke-dasharray', '6,4');
+          }
           line.setAttribute('marker-end', 'url(#arrowhead)');
           line.classList.add('edge');
           line.dataset.from = edge.from;

--- a/internal/drawio/connector.go
+++ b/internal/drawio/connector.go
@@ -97,6 +97,22 @@ func (p *Page) UpdateConnectorLabel(from, to string, index int, label string) {
 	}
 }
 
+// SetConnectorStyle overwrites the style attribute on the connector between
+// from and to, mirroring UpdateElementKind's full-replacement approach when
+// an element's kind (and therefore its template style) changes.
+func (p *Page) SetConnectorStyle(from, to string, index int, style string) {
+	conn := p.FindConnector(from, to, index)
+	if conn == nil {
+		return
+	}
+	attr := conn.SelectAttr("style")
+	if attr != nil {
+		attr.Value = style
+	} else {
+		conn.CreateAttr("style", style)
+	}
+}
+
 // DeleteConnector removes the connector between from and to at the given index.
 func (p *Page) DeleteConnector(from, to string, index int) {
 	root := p.Root()

--- a/internal/drawio/connector_test.go
+++ b/internal/drawio/connector_test.go
@@ -106,6 +106,32 @@ func TestUpdateConnectorLabel(t *testing.T) {
 	}
 }
 
+func TestSetConnectorStyle(t *testing.T) {
+	p := newTestPage(t)
+	p.CreateConnector(drawio.ConnectorData{From: "x", To: "y"}, testStyle)
+
+	p.SetConnectorStyle("x", "y", 0, "endArrow=block;dashed=1;")
+
+	conn := p.FindConnector("x", "y", 0)
+	if conn == nil {
+		t.Fatal("connector not found after style update")
+	}
+	if got := conn.SelectAttrValue("style", ""); got != "endArrow=block;dashed=1;" {
+		t.Errorf("style = %q, want %q", got, "endArrow=block;dashed=1;")
+	}
+}
+
+func TestSetConnectorStyle_MissingConnectorIsNoop(t *testing.T) {
+	p := newTestPage(t)
+
+	// Should not panic when the connector doesn't exist.
+	p.SetConnectorStyle("nonexistent", "also-nonexistent", 0, "dashed=1;")
+
+	if p.FindConnector("nonexistent", "also-nonexistent", 0) != nil {
+		t.Error("expected no connector to be created by SetConnectorStyle")
+	}
+}
+
 func TestDeleteConnector(t *testing.T) {
 	p := newTestPage(t)
 	p.CreateConnector(drawio.ConnectorData{From: "a", To: "b"}, testStyle)

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -235,6 +235,15 @@ type RelationshipKind struct {
 	Dashed   bool   `json:"dashed,omitempty"`
 }
 
+// IsDashed reports whether the given relationship kind is defined in the
+// specification with Dashed: true. An empty or unknown kind is never dashed.
+func (s *Specification) IsDashed(kind string) bool {
+	if s == nil || kind == "" {
+		return false
+	}
+	return s.Relationships[kind].Dashed
+}
+
 type Element struct {
 	Kind         string             `json:"kind"`
 	Title        string             `json:"title"`

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -199,3 +199,32 @@ func TestNestedChildren(t *testing.T) {
 		t.Errorf("expected handler title 'Handler', got '%s'", handler.Title)
 	}
 }
+
+func TestSpecification_IsDashed(t *testing.T) {
+	spec := &Specification{
+		Relationships: map[string]RelationshipKind{
+			"uses":  {Notation: "uses"},
+			"async": {Notation: "async", Dashed: true},
+		},
+	}
+
+	cases := []struct {
+		name string
+		spec *Specification
+		kind string
+		want bool
+	}{
+		{"dashed kind", spec, "async", true},
+		{"non-dashed kind", spec, "uses", false},
+		{"unknown kind", spec, "nonexistent", false},
+		{"empty kind", spec, "", false},
+		{"nil specification", nil, "async", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.spec.IsDashed(c.kind); got != c.want {
+				t.Errorf("IsDashed(%q) = %v, want %v", c.kind, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -700,10 +700,10 @@ func detectRelationshipChanges(
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
 				From: from, To: to, Index: index, Type: Deleted,
 			})
-		case inModel && inLast && mr.Label != lr.Label:
+		case inModel && inLast && (mr.Label != lr.Label || mr.Kind != lr.Kind):
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
 				From: from, To: to, Index: index, Type: Modified, Field: "label",
-				OldValue: lr.Label, NewValue: mr.Label,
+				OldValue: lr.Label, NewValue: mr.Label, Kind: mr.Kind,
 			})
 		}
 

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -36,6 +36,7 @@ type RelationshipChange struct {
 	Field    string // "label", "" for add/delete
 	OldValue string
 	NewValue string
+	Kind     string // relationship kind key into Specification.Relationships, for style lookup (e.g. dashed)
 }
 
 // ChangeSet contains all detected changes from both sides.
@@ -693,7 +694,7 @@ func detectRelationshipChanges(
 		switch {
 		case inModel && !inLast:
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Added, NewValue: mr.Label,
+				From: from, To: to, Index: index, Type: Added, NewValue: mr.Label, Kind: mr.Kind,
 			})
 		case !inModel && inLast:
 			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -258,6 +258,30 @@ func TestDetectChanges_RelationshipModifiedLabel(t *testing.T) {
 	}
 }
 
+func TestDetectChanges_RelationshipModifiedKind(t *testing.T) {
+	state := emptyState()
+	state.Relationships = []RelationshipState{
+		{From: "a", To: "b", Label: "calls", Kind: "sync"},
+	}
+	m := &model.BausteinsichtModel{
+		Model:         map[string]model.Element{},
+		Relationships: []model.Relationship{{From: "a", To: "b", Label: "calls", Kind: "async"}},
+	}
+	doc := emptyDoc()
+
+	cs := DetectChanges(m, doc, state, nil)
+
+	found := false
+	for _, ch := range cs.ModelRelationshipChanges {
+		if ch.From == "a" && ch.To == "b" && ch.Type == Modified && ch.Kind == "async" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected kind-only change (sync -> async) to be reported as Modified, changes: %+v", cs.ModelRelationshipChanges)
+	}
+}
+
 func TestDetectChanges_RelationshipDeleted(t *testing.T) {
 	state := emptyState()
 	state.Relationships = []RelationshipState{

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -340,6 +340,24 @@ func populateNewPage(
 	}
 }
 
+// connectorStyle returns baseStyle with "dashed=1;" appended if the given
+// relationship kind is defined in the specification with Dashed: true (#518).
+// kind may be empty (no kind set on the relationship) or unknown (not found
+// in spec.Relationships), in which case baseStyle is returned unchanged.
+func connectorStyle(baseStyle, kind string, spec *model.Specification) string {
+	if kind == "" || spec == nil {
+		return baseStyle
+	}
+	rk, ok := spec.Relationships[kind]
+	if !ok || !rk.Dashed {
+		return baseStyle
+	}
+	if baseStyle != "" && !strings.HasSuffix(baseStyle, ";") {
+		baseStyle += ";"
+	}
+	return baseStyle + "dashed=1;"
+}
+
 // populateConnectors creates connectors for all model relationships whose
 // (possibly lifted) endpoints are both on the page but no connector exists yet.
 // This ensures relationships involving newly populated elements are rendered (#231).
@@ -386,7 +404,7 @@ func populateConnectors(
 		if page.FindConnector(srcRef, tgtRef, i) != nil {
 			continue // Already exists.
 		}
-		style := templates.GetConnectorStyle()
+		style := connectorStyle(templates.GetConnectorStyle(), rel.Kind, &m.Specification)
 		data := drawio.ConnectorData{
 			From:      from,
 			To:        to,
@@ -606,7 +624,7 @@ func applyChangesToPage(
 				if pass == 1 && !isLifted {
 					continue // Second pass: only lifted relationships
 				}
-				lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue}
+				lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue, Kind: ch.Kind}
 				switch ch.Type {
 				case Added:
 					// Only deduplicate lifted relationships. When multiple
@@ -628,7 +646,7 @@ func applyChangesToPage(
 						// the same pair are suppressed in pass 1. (#197)
 						liftedSeen[pairKey] = true
 					}
-					applyRelAdded(lifted, viewID, page, templates, result)
+					applyRelAdded(lifted, viewID, page, templates, spec, result)
 				case Modified:
 					page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
 					result.ConnectorsUpdated++
@@ -1074,6 +1092,7 @@ func applyRelAdded(
 	viewID string,
 	page *drawio.Page,
 	templates *drawio.TemplateSet,
+	spec *model.Specification,
 	result *ForwardResult,
 ) {
 	srcRef := scopedCellID(viewID, ch.From)
@@ -1084,7 +1103,7 @@ func applyRelAdded(
 		return
 	}
 
-	style := templates.GetConnectorStyle()
+	style := connectorStyle(templates.GetConnectorStyle(), ch.Kind, spec)
 	data := drawio.ConnectorData{
 		From:      ch.From,
 		To:        ch.To,

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -340,22 +340,15 @@ func populateNewPage(
 	}
 }
 
-// connectorStyle returns baseStyle with "dashed=1;" appended if the given
+// connectorStyle returns baseStyle merged with "dashed=1;" if the given
 // relationship kind is defined in the specification with Dashed: true (#518).
-// kind may be empty (no kind set on the relationship) or unknown (not found
-// in spec.Relationships), in which case baseStyle is returned unchanged.
+// Uses mergeStyles so a baseStyle that already sets dashed= (e.g. from a
+// user-edited connector template) is overridden rather than duplicated.
 func connectorStyle(baseStyle, kind string, spec *model.Specification) string {
-	if kind == "" || spec == nil {
+	if !spec.IsDashed(kind) {
 		return baseStyle
 	}
-	rk, ok := spec.Relationships[kind]
-	if !ok || !rk.Dashed {
-		return baseStyle
-	}
-	if baseStyle != "" && !strings.HasSuffix(baseStyle, ";") {
-		baseStyle += ";"
-	}
-	return baseStyle + "dashed=1;"
+	return mergeStyles(baseStyle, "dashed=1;")
 }
 
 // populateConnectors creates connectors for all model relationships whose
@@ -370,6 +363,26 @@ func populateConnectors(
 	templates *drawio.TemplateSet,
 	result *ForwardResult,
 ) {
+	// Pre-compute, per lifted (from,to) pair, whether ANY contributing
+	// relationship is dashed. Multiple relationships can collapse onto the
+	// same rendered connector (endpoint lifting); without this, only the
+	// first-processed relationship's kind would decide the connector's
+	// style, making it depend on m.Relationships array order (#518).
+	dashedForPair := make(map[string]bool)
+	for _, rel := range m.Relationships {
+		from := liftEndpoint(rel.From, elemSet)
+		to := liftEndpoint(rel.To, elemSet)
+		if from == "" || to == "" || (from == to && (from != rel.From || to != rel.To)) {
+			continue
+		}
+		if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
+			continue
+		}
+		if m.Specification.IsDashed(rel.Kind) {
+			dashedForPair[from+"->"+to] = true
+		}
+	}
+
 	liftedSeen := make(map[string]bool)
 	for i, rel := range m.Relationships {
 		from := liftEndpoint(rel.From, elemSet)
@@ -404,7 +417,10 @@ func populateConnectors(
 		if page.FindConnector(srcRef, tgtRef, i) != nil {
 			continue // Already exists.
 		}
-		style := connectorStyle(templates.GetConnectorStyle(), rel.Kind, &m.Specification)
+		style := templates.GetConnectorStyle()
+		if dashedForPair[pairKey] {
+			style = mergeStyles(style, "dashed=1;")
+		}
 		data := drawio.ConnectorData{
 			From:      from,
 			To:        to,
@@ -649,6 +665,11 @@ func applyChangesToPage(
 					applyRelAdded(lifted, viewID, page, templates, spec, result)
 				case Modified:
 					page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
+					// Recompute style from the template base rather than
+					// patching the existing style, so a kind change that
+					// flips dashed on or off is reflected either way (#518),
+					// mirroring UpdateElementKind's full-replacement approach.
+					page.SetConnectorStyle(from, to, ch.Index, connectorStyle(templates.GetConnectorStyle(), ch.Kind, spec))
 					result.ConnectorsUpdated++
 				}
 			}

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -273,6 +273,115 @@ func TestApplyForward_NewRelationship(t *testing.T) {
 	}
 }
 
+// TestApplyForward_RelationshipModifiedKindAppliesDashedStyle verifies that a
+// Modified relationship change re-applies the connector style so a kind
+// change to a dashed kind is reflected on an already-existing connector, not
+// just on newly-created ones. Regression test for #518.
+func TestApplyForward_RelationshipModifiedKindAppliesDashedStyle(t *testing.T) {
+	doc := drawio.NewDocument()
+	page := doc.AddPage("p1", "Page 1")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "a", CellID: "a", Kind: "container", Title: "A",
+	}, "")
+	_ = page.CreateElement(drawio.ElementData{
+		ID: "b", CellID: "b", Kind: "container", Title: "B",
+	}, "")
+	page.CreateConnector(drawio.ConnectorData{
+		From: "a", To: "b", Label: "calls",
+		SourceRef: "a", TargetRef: "b",
+	}, "endArrow=block;")
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "calls", Kind: "async"},
+		},
+		Specification: model.Specification{
+			Relationships: map[string]model.RelationshipKind{
+				"async": {Notation: "async", Dashed: true},
+			},
+		},
+	}
+	ts := minimalTemplates(t)
+
+	cs := &ChangeSet{
+		ModelRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Type: Modified, Field: "label", OldValue: "calls", NewValue: "calls", Kind: "async"},
+		},
+	}
+
+	ApplyForward(cs, doc, ts, m)
+
+	conn := page.FindConnector("a", "b", 0)
+	if conn == nil {
+		t.Fatal("connector 'a->b' not found")
+	}
+	style := conn.SelectAttrValue("style", "")
+	if !strings.Contains(style, "dashed=1") {
+		t.Errorf("expected connector style to contain dashed=1 after kind changed to a dashed kind, got: %q", style)
+	}
+}
+
+// TestPopulateConnectors_LiftedDashedIsOrderIndependent verifies that when two
+// relationships with different kinds lift to the same visible connector pair,
+// the rendered connector is dashed if ANY of the contributing relationships
+// is dashed — regardless of which one happens to be processed first.
+// Regression test for #518.
+func TestPopulateConnectors_LiftedDashedIsOrderIndependent(t *testing.T) {
+	newModel := func(rels []model.Relationship) *model.BausteinsichtModel {
+		return &model.BausteinsichtModel{
+			Model: map[string]model.Element{
+				"api": {Kind: "container", Title: "API", Children: map[string]model.Element{
+					"sub1": {Kind: "component", Title: "Sub1"},
+					"sub2": {Kind: "component", Title: "Sub2"},
+				}},
+				"queue": {Kind: "container", Title: "Queue"},
+			},
+			Relationships: rels,
+			Specification: model.Specification{
+				Relationships: map[string]model.RelationshipKind{
+					"sync":  {Notation: "sync"},
+					"async": {Notation: "async", Dashed: true},
+				},
+			},
+		}
+	}
+	elemSet := map[string]bool{"api": true, "queue": true}
+	ts := minimalTemplates(t)
+
+	// Non-dashed relationship first, dashed one second.
+	doc1 := drawio.NewDocument()
+	page1 := doc1.AddPage("p1", "Page 1")
+	m1 := newModel([]model.Relationship{
+		{From: "api.sub1", To: "queue", Kind: "sync"},
+		{From: "api.sub2", To: "queue", Kind: "async"},
+	})
+	populateConnectors(page1, "", "", m1, elemSet, ts, &ForwardResult{})
+
+	// Dashed relationship first, non-dashed one second (reversed order).
+	doc2 := drawio.NewDocument()
+	page2 := doc2.AddPage("p1", "Page 1")
+	m2 := newModel([]model.Relationship{
+		{From: "api.sub2", To: "queue", Kind: "async"},
+		{From: "api.sub1", To: "queue", Kind: "sync"},
+	})
+	populateConnectors(page2, "", "", m2, elemSet, ts, &ForwardResult{})
+
+	for i, page := range []*drawio.Page{page1, page2} {
+		conn := page.FindConnector("api", "queue", 0)
+		if conn == nil {
+			t.Fatalf("case %d: connector 'api->queue' not found", i)
+		}
+		style := conn.SelectAttrValue("style", "")
+		if !strings.Contains(style, "dashed=1") {
+			t.Errorf("case %d: expected lifted connector to be dashed regardless of relationship order, got style: %q", i, style)
+		}
+	}
+}
+
 // TestApplyForward_MultipleNewElementsNoOverlap verifies placement doesn't overlap elements.
 func TestApplyForward_MultipleNewElementsNoOverlap(t *testing.T) {
 	doc := emptyDoc()

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -919,6 +919,7 @@ Exports views as text diagrams in one of several formats (C4-PlantUML, Mermaid, 
 * Auto-detects the C4 level (Context, Container, or Component) from the view content.
 * Generates diagram source in the requested format. C4-PlantUML uses the stdlib include syntax (`!include <C4/C4_Context>`, etc.).
 * Relationships are filtered to those visible in the view. Endpoints are lifted to visible ancestor elements when the original endpoints are not included in the view.
+* A relationship whose `kind` resolves to `specification.relationships.<kind>.dashed: true` renders as a dashed line: `style="dashed"` edge attribute in DOT, a `style.stroke-dash` block in D2, a `stroke-dasharray` SVG line in HTML, and a raw `..>` arrow instead of the `Rel()` macro in PlantUML (C4-PlantUML's own dashed-line style override errors on the versions tested). Mermaid does not yet support a dashed-line override in its C4 syntax, so dashed relationships render the same as solid ones there (#518).
 * Without `--output`, the diagram(s) are written to stdout. With `--output <dir>`, per-view files are named `<view-key>.<ext>`, where `<ext>` is `puml`, `mmd`, `dot`, `d2`, or `html`.
 * `--diagram-format structurizr` is special: it exports the entire workspace as a single `workspace.dsl` file and rejects `--view` (exit code 1).
 * Creates the output directory if it does not exist.

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -113,7 +113,7 @@ Triggered when the JSON model changes.
 | Remove `<object>`, its child text sub-cells, and all connectors where `source` or `target` matches the element's cell ID.
 
 | New relationship
-| Create `<mxCell>` with `edge="1"`, `source`, `target`, and label. Use `id="rel-<from>-<to>-<index>"`. No `exitX`/`entryX` (auto-routing). Use `parent="1"` (layer, not container).
+| Create `<mxCell>` with `edge="1"`, `source`, `target`, and label. Use `id="rel-<from>-<to>-<index>"`. No `exitX`/`entryX` (auto-routing). Use `parent="1"` (layer, not container). If the relationship's `kind` resolves to a `specification.relationships.<kind>.dashed: true` entry, append `dashed=1;` to the connector style (#518).
 
 | Updated relationship (label)
 | Update `value` attribute on the connector `<mxCell>`.


### PR DESCRIPTION
## Summary
- `specification.relationships.<kind>.dashed` was parsed from the JSONC model but never applied by any renderer — a relationship kind with `"dashed": true` rendered identically to a plain synchronous relationship everywhere.
- Fixes that across all renderers:
  - **draw.io** (`internal/sync/forward.go`): forward-sync now appends `dashed=1` to the connector style when the relationship's kind resolves to `Dashed: true` in `Specification.Relationships`.
  - **DOT** (`internal/diagram/dot.go`): `style="dashed"` edge attribute.
  - **D2** (`internal/diagram/d2.go`): `style.stroke-dash` edge style block.
  - **HTML** (`internal/diagram/html.go`): SVG `stroke-dasharray`.
  - **PlantUML** (`internal/diagram/diagram.go`): falls back to a raw `..>` arrow for dashed relationships, since C4-PlantUML's own `UpdateRelStyle($lineStyle=DashedLine())` errors with "Function not found" on the versions tested.
  - **Mermaid**: intentionally left unchanged — its C4 diagram syntax has no dashed-line mechanism to fall back to yet (documented inline in code, per Mermaid's own docs marking that feature "not yet implemented"). Revisit once Mermaid ships it.
- Adds `.claude/agents/start_issue.md`, a Claude agent that runs the `doc-check` "start" skill for a given issue number (docs-first ticket start convention from CLAUDE.md).

Closes #518.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages pass, including new `e2e/dashed_relationship_test.go`)
- [ ] `/doc-check review` — not yet run against this PR
- [ ] Security review — not yet run
- [ ] Code review — not yet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)