### PR TITLE
fix(sync): avoid false duplicate warnings on repeated sync runs

### DIFF
--- a/internal/drawio/document.go
+++ b/internal/drawio/document.go
@@ -167,6 +167,11 @@ func (p *Page) ID() string {
 	return p.diagram.SelectAttrValue("id", "")
 }
 
+// Name returns the name attribute of the page's diagram element.
+func (p *Page) Name() string {
+	return p.diagram.SelectAttrValue("name", "")
+}
+
 // Root returns the <root> element of the page for direct manipulation.
 func (p *Page) Root() *etree.Element {
 	model := p.diagram.FindElement("mxGraphModel")

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -37,7 +37,7 @@ type RelationshipChange struct {
 	OldValue string
 	NewValue string
 	Kind     string // relationship kind key into Specification.Relationships, for style lookup (e.g. dashed)
-	PageID   string // draw.io page where this relationship exists (for debugging/warnings)
+	PageID   string // draw.io page name (page.Name()) where this relationship exists (for debugging/warnings)
 }
 
 // ChangeSet contains all detected changes from both sides.
@@ -398,7 +398,7 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			key := relKey(from, to, index)
 			if existing, exists := result[key]; exists {
 				// If relationship already exists on another page, append this page to the list.
-				// PageIDs is a []string of page identifiers, used later in warnings.
+				// PageIDs is a []string of page names (page.Name()), used later in warnings.
 				existing.PageIDs = append(existing.PageIDs, pageID)
 				result[key] = existing
 			} else {

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -37,6 +37,7 @@ type RelationshipChange struct {
 	OldValue string
 	NewValue string
 	Kind     string // relationship kind key into Specification.Relationships, for style lookup (e.g. dashed)
+	PageID   string // draw.io page where this relationship exists (for debugging/warnings)
 }
 
 // ChangeSet contains all detected changes from both sides.
@@ -373,6 +374,7 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 	cellToElem := buildCellIDToElemID(doc)
 	result := make(map[string]RelationshipState)
 	for _, page := range doc.Pages() {
+		pageID := page.Name()
 		for _, cell := range page.FindAllConnectors() {
 			fromCell := cell.SelectAttrValue("source", "")
 			toCell := cell.SelectAttrValue("target", "")
@@ -394,12 +396,18 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			cellID := cell.SelectAttrValue("id", "")
 			index := parseConnectorIndex(cellID)
 			key := relKey(from, to, index)
-			if _, exists := result[key]; !exists {
+			if existing, exists := result[key]; exists {
+				// If relationship already exists on another page, append this page to the list.
+				// This is stored as a comma-separated list for later use in warnings.
+				existing.PageIDs = append(existing.PageIDs, pageID)
+				result[key] = existing
+			} else {
 				result[key] = RelationshipState{
-					From:  from,
-					To:    to,
-					Index: index,
-					Label: cell.SelectAttrValue("value", ""),
+					From:    from,
+					To:      to,
+					Index:   index,
+					Label:   cell.SelectAttrValue("value", ""),
+					PageIDs: []string{pageID},
 				}
 			}
 		}
@@ -716,8 +724,13 @@ func detectRelationshipChanges(
 			if isLiftedRelationship(from, to, modelRels) {
 				continue
 			}
+			// Collect page IDs where this relationship exists.
+			pageID := ""
+			if len(dr.PageIDs) > 0 {
+				pageID = dr.PageIDs[0]
+			}
 			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Added, NewValue: dr.Label,
+				From: from, To: to, Index: index, Type: Added, NewValue: dr.Label, PageID: pageID,
 			})
 		case !inDrawio && inLast:
 			// Only treat as deleted if the relationship should have a connector

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -398,7 +398,7 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			key := relKey(from, to, index)
 			if existing, exists := result[key]; exists {
 				// If relationship already exists on another page, append this page to the list.
-				// This is stored as a comma-separated list for later use in warnings.
+				// PageIDs is a []string of page identifiers, used later in warnings.
 				existing.PageIDs = append(existing.PageIDs, pageID)
 				result[key] = existing
 			} else {

--- a/internal/sync/diff_test.go
+++ b/internal/sync/diff_test.go
@@ -1004,7 +1004,7 @@ func TestDetectChanges_DeletedElementConnectorUsesCanonicalIDs(t *testing.T) {
 
 	// Also verify via ApplyReverse: if changes are applied, the model should
 	// not contain relationships with scoped cell IDs.
-	ApplyReverse(cs, m)
+	ApplyReverse(cs, m, nil)
 	for _, rel := range m.Relationships {
 		if strings.Contains(rel.From, "--") {
 			t.Errorf("Model relationship From contains scoped cell ID %q after reverse sync", rel.From)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -61,7 +61,7 @@ func Run(
 	result.Forward = ApplyForward(changes, doc, templates, m, opts...)
 
 	// Step 5: Reverse sync (draw.io → model).
-	result.Reverse = ApplyReverse(changes, m)
+	result.Reverse = ApplyReverse(changes, m, lastState)
 
 	// Step 6: Warn about model elements not visible in any view (#183).
 	if len(m.Views) > 0 {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -660,6 +660,82 @@ func TestRun_MultipleRelsSamePair(t *testing.T) {
 	}
 }
 
+// --- Test: reverse sync imports a newly-drawn second relationship (#548) ---
+//
+// After a first relationship a->b was synced, the user draws a SECOND a->b
+// connector in draw.io. Reverse sync must import it as a new relationship (#142)
+// rather than mistaking it for the already-synced first one and dropping it.
+func TestRun_ReverseImportsSecondRelSamePair(t *testing.T) {
+	ts := minimalTemplates(t)
+
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+		},
+	}
+
+	doc := emptyDoc()
+
+	// Round 1: first sync populates the doc with one a->b connector.
+	r1 := Run(m, doc, emptyState(), ts, nil)
+	if r1.Forward.ConnectorsCreated != 1 {
+		t.Fatalf("round 1: expected 1 connector created, got %d", r1.Forward.ConnectorsCreated)
+	}
+
+	// State after round 1: a->b at index 0 was synced.
+	state1 := &SyncState{
+		Elements: map[string]ElementState{
+			"a": {Title: "A", Kind: "container"},
+			"b": {Title: "B", Kind: "container"},
+		},
+		Relationships: []RelationshipState{
+			{From: "a", To: "b", Index: 0, Label: "uses"},
+		},
+	}
+
+	// The user draws a SECOND a->b connector (index 1) in draw.io. Reuse the
+	// first connector's endpoint refs so the new edge references the same cells.
+	page := requireFirstPage(t, doc)
+	conn0 := page.FindConnector("a", "b", 0)
+	if conn0 == nil {
+		t.Fatal("round 1 should have created connector a->b#0")
+	}
+	page.CreateConnector(drawio.ConnectorData{
+		From:      "a",
+		To:        "b",
+		Label:     "calls",
+		SourceRef: conn0.SelectAttrValue("source", ""),
+		TargetRef: conn0.SelectAttrValue("target", ""),
+		Index:     1,
+	}, ts.GetConnectorStyle())
+
+	// Round 2: reverse sync must import the new a->b relationship into the model.
+	r2 := Run(m, doc, state1, ts, nil)
+
+	if r2.Reverse.RelationshipsCreated != 1 {
+		t.Errorf("round 2: expected RelationshipsCreated=1, got %d", r2.Reverse.RelationshipsCreated)
+	}
+	if len(m.Relationships) != 2 {
+		t.Fatalf("round 2: expected 2 model relationships, got %d", len(m.Relationships))
+	}
+	labels := map[string]bool{}
+	for _, r := range m.Relationships {
+		if r.From == "a" && r.To == "b" {
+			labels[r.Label] = true
+		}
+	}
+	if !labels["uses"] || !labels["calls"] {
+		t.Errorf("expected both 'uses' and 'calls' a->b relationships, got %+v", m.Relationships)
+	}
+	if len(r2.Conflicts) != 0 {
+		t.Errorf("round 2: expected no conflicts, got %d", len(r2.Conflicts))
+	}
+}
+
 // --- Test: Sync warns when model elements aren't visible in any view (#183) ---
 //
 // Model has 3 elements: "a", "b", "c".

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -688,6 +688,7 @@ func TestRun_ReverseImportsSecondRelSamePair(t *testing.T) {
 
 	// State after round 1: a->b at index 0 was synced.
 	state1 := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z",
 		Elements: map[string]ElementState{
 			"a": {Title: "A", Kind: "container"},
 			"b": {Title: "B", Kind: "container"},

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -33,10 +33,9 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *Sy
 	// there directly. We need the flattened view to properly detect nested elements.
 	flatModel, _ := model.FlattenElements(m)
 
-	// Build a set of elements that were already synced in the last sync. The map
-	// is left nil when there is no previous sync so callers can distinguish
-	// "first sync" (nil) from "previous sync that happened to have no elements"
-	// (non-nil, empty).
+	// Build the set of elements already synced in the last sync, used to skip
+	// re-importing an element that simply re-appears (e.g. on another page).
+	// Whether a prior sync happened at all is tracked separately via priorSync.
 	var lastElemMap map[string]bool
 	if lastState != nil {
 		lastElemMap = make(map[string]bool)
@@ -45,11 +44,10 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *Sy
 		}
 	}
 
-	// Build a set of relationships that were already synced in the last sync.
-	// Key by the same relKey(from, to, index) used everywhere else so that
-	// multiple relationships between the same pair (#142) stay distinct - keying
-	// by "from->to" alone would treat a newly-added second relationship as
-	// already-synced and drop it. Left nil when there is no previous sync.
+	// Build the set of relationships already synced in the last sync. Key by the
+	// same relKey(from, to, index) used everywhere else so multiple relationships
+	// between the same pair (#142) stay distinct - keying by "from->to" alone
+	// would treat a newly-added second relationship as already-synced and drop it.
 	var lastRelMap map[string]bool
 	if lastState != nil {
 		lastRelMap = make(map[string]bool)
@@ -58,8 +56,19 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *Sy
 		}
 	}
 
+	// A prior sync only happened if the state carries a recorded timestamp.
+	// LoadState fabricates a non-nil empty state (Timestamp == "") on the very
+	// first sync, so nil-ness alone cannot distinguish "no prior sync" from
+	// "a prior sync that recorded nothing" - use the timestamp instead.
+	priorSync := lastState != nil && lastState.Timestamp != ""
+
+	// Snapshot the model's current relationships keyed by relKey(from, to, global
+	// index) - the same key used for connectors and the last-sync state - so that
+	// "already present" is a direct key lookup rather than a numeric coincidence.
+	modelRelMap := buildModelRelMap(m)
+
 	for _, ch := range changes.DrawioElementChanges {
-		applyElementChange(ch, m, flatModel, lastElemMap, result)
+		applyElementChange(ch, m, flatModel, lastElemMap, priorSync, result)
 	}
 
 	// Detect direction-swap pairs (Deleted a→b + Added b→a) so we can
@@ -70,7 +79,7 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *Sy
 		if swaps[relSwapKey{ch.From, ch.To, ch.Type}] {
 			continue // handled as part of a swap pair
 		}
-		applyRelationshipChange(ch, m, flatModel, lastRelMap, result)
+		applyRelationshipChange(ch, m, flatModel, lastRelMap, modelRelMap, priorSync, result)
 	}
 
 	// Apply swaps: update direction in-place, preserving kind/label/description.
@@ -144,7 +153,7 @@ func applyRelSwap(newFrom, newTo string, m *model.BausteinsichtModel, result *Re
 	result.RelationshipsCreated++
 }
 
-func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastElemMap map[string]bool, result *ReverseResult) {
+func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastElemMap map[string]bool, priorSync bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
 		// Reject empty title updates from draw.io (#150).
@@ -215,9 +224,9 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 				return
 			}
 			// Element exists in model but wasn't synced from draw.io before - that's a
-			// genuine conflict. Only warn if we've done a previous sync (lastElemMap
-			// is non-nil, even if that prior sync recorded no elements).
-			hasLastState := lastElemMap != nil
+			// genuine conflict. Only warn if a prior sync actually happened; on the
+			// very first sync the user legitimately has it in both places.
+			hasLastState := priorSync
 			if hasLastState {
 				result.Warnings = append(result.Warnings,
 					fmt.Sprintf("Element %q from draw.io skipped: ID already exists in model (not synced from draw.io)", ch.ID))
@@ -235,7 +244,7 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 	}
 }
 
-func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastRelMap map[string]bool, result *ReverseResult) {
+func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastRelMap map[string]bool, modelRelMap map[string]RelationshipState, priorSync bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
 		updated := false
@@ -298,30 +307,25 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 			return
 		}
 		// Check if this relationship was already synced from draw.io in a previous
-		// sync. Match on the per-pair index so a newly-added second relationship
-		// between the same pair (#142) is not mistaken for the already-synced
-		// first one. If it was synced before, it's on a different page now -
-		// that's normal, skip silently. (Reading a nil map yields false.)
+		// sync. Match on the connector index (relKey) so a genuinely new second
+		// relationship between the same pair (#142) stays distinct from the
+		// already-synced first one. If synced before, it's on a different page
+		// now - skip silently. (Reading a nil map yields false.)
 		if lastRelMap[relKey(ch.From, ch.To, ch.Index)] {
 			// Already synced before (possibly on another page) - no action needed.
 			return
 		}
-		// Check whether the model already holds a relationship at this per-pair
-		// index. Multiple relationships between the same pair are supported (#142)
-		// and disambiguated by index, so only a relationship at the SAME index
-		// counts as "already present"; a higher index is a genuinely new one.
-		existing := 0
-		for _, r := range m.Relationships {
-			if r.From == ch.From && r.To == ch.To {
-				existing++
-			}
-		}
-		if ch.Index < existing {
-			// A relationship at this position already exists in the model but was
-			// not synced from draw.io before. On first sync (lastRelMap is nil)
-			// this is expected - the user added it to both places - so skip
-			// silently; once a previous sync exists it is a genuine conflict.
-			if lastRelMap != nil {
+		// Check whether the model already holds this exact relationship, keyed the
+		// same way as the connector and the last-sync state (relKey over the global
+		// relationship index). This answers "does the model already have this
+		// relationship" directly, regardless of how many others share the pair, so
+		// a genuinely new connector (whose key is absent) is always imported.
+		if _, present := modelRelMap[relKey(ch.From, ch.To, ch.Index)]; present {
+			// Present in the model but not synced from draw.io. On the very first
+			// sync (no prior sync) this is expected - the user added it to both
+			// places - so skip silently; once a prior sync exists it is a genuine
+			// conflict, so warn.
+			if priorSync {
 				pageInfo := ""
 				if ch.PageID != "" {
 					pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -33,20 +33,28 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *Sy
 	// there directly. We need the flattened view to properly detect nested elements.
 	flatModel, _ := model.FlattenElements(m)
 
-	// Build a set of elements that were already synced in the last sync.
-	lastElemMap := make(map[string]bool)
+	// Build a set of elements that were already synced in the last sync. The map
+	// is left nil when there is no previous sync so callers can distinguish
+	// "first sync" (nil) from "previous sync that happened to have no elements"
+	// (non-nil, empty).
+	var lastElemMap map[string]bool
 	if lastState != nil {
+		lastElemMap = make(map[string]bool)
 		for id := range lastState.Elements {
 			lastElemMap[id] = true
 		}
 	}
 
 	// Build a set of relationships that were already synced in the last sync.
-	lastRelMap := make(map[string]bool)
+	// Key by the same relKey(from, to, index) used everywhere else so that
+	// multiple relationships between the same pair (#142) stay distinct - keying
+	// by "from->to" alone would treat a newly-added second relationship as
+	// already-synced and drop it. Left nil when there is no previous sync.
+	var lastRelMap map[string]bool
 	if lastState != nil {
+		lastRelMap = make(map[string]bool)
 		for _, r := range lastState.Relationships {
-			key := fmt.Sprintf("%s->%s", r.From, r.To)
-			lastRelMap[key] = true
+			lastRelMap[relKey(r.From, r.To, r.Index)] = true
 		}
 	}
 
@@ -207,8 +215,9 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 				return
 			}
 			// Element exists in model but wasn't synced from draw.io before - that's a
-			// genuine conflict. Only warn if we've done a previous sync (lastElemMap exists).
-			hasLastState := len(lastElemMap) > 0
+			// genuine conflict. Only warn if we've done a previous sync (lastElemMap
+			// is non-nil, even if that prior sync recorded no elements).
+			hasLastState := lastElemMap != nil
 			if hasLastState {
 				result.Warnings = append(result.Warnings,
 					fmt.Sprintf("Element %q from draw.io skipped: ID already exists in model (not synced from draw.io)", ch.ID))
@@ -288,32 +297,39 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 				fmt.Sprintf("Relationship %q->%q rejected: To element %q does not exist in model", ch.From, ch.To, ch.To))
 			return
 		}
-		// Check if this relationship was already synced from draw.io in a previous sync.
-		// If it was, it's on a different page now - that's normal, skip silently.
-		lastRelKey := fmt.Sprintf("%s->%s", ch.From, ch.To)
-		if lastRelMap[lastRelKey] {
+		// Check if this relationship was already synced from draw.io in a previous
+		// sync. Match on the per-pair index so a newly-added second relationship
+		// between the same pair (#142) is not mistaken for the already-synced
+		// first one. If it was synced before, it's on a different page now -
+		// that's normal, skip silently. (Reading a nil map yields false.)
+		if lastRelMap[relKey(ch.From, ch.To, ch.Index)] {
 			// Already synced before (possibly on another page) - no action needed.
 			return
 		}
-		// Check if relationship already exists in the model.
-		// On first sync (lastState is nil or empty), this is expected - user manually added
-		// relationships to both places. Skip silently.
-		// Only warn if we've done a previous sync (lastRelMap exists) and this relationship
-		// was NOT synced from draw.io before - that's a genuine conflict.
-		hasLastState := len(lastRelMap) > 0
+		// Check whether the model already holds a relationship at this per-pair
+		// index. Multiple relationships between the same pair are supported (#142)
+		// and disambiguated by index, so only a relationship at the SAME index
+		// counts as "already present"; a higher index is a genuinely new one.
+		existing := 0
 		for _, r := range m.Relationships {
 			if r.From == ch.From && r.To == ch.To {
-				if hasLastState {
-					// Genuine conflict: model has relationship that wasn't synced from draw.io
-					pageInfo := ""
-					if ch.PageID != "" {
-						pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)
-					}
-					result.Warnings = append(result.Warnings,
-						fmt.Sprintf("Relationship %q->%q already exists in model (not synced from draw.io), skipping duplicate%s", ch.From, ch.To, pageInfo))
-				}
-				return
+				existing++
 			}
+		}
+		if ch.Index < existing {
+			// A relationship at this position already exists in the model but was
+			// not synced from draw.io before. On first sync (lastRelMap is nil)
+			// this is expected - the user added it to both places - so skip
+			// silently; once a previous sync exists it is a genuine conflict.
+			if lastRelMap != nil {
+				pageInfo := ""
+				if ch.PageID != "" {
+					pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)
+				}
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("Relationship %q->%q already exists in model (not synced from draw.io), skipping duplicate%s", ch.From, ch.To, pageInfo))
+			}
+			return
 		}
 		m.Relationships = append(m.Relationships, model.Relationship{
 			From:  ch.From,

--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -22,7 +22,10 @@ type ReverseResult struct {
 }
 
 // ApplyReverse applies draw.io-side changes back to the model.
-func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResult {
+// lastState is the sync state from the previous sync - used to detect whether
+// an element or relationship was already synced (to avoid false "duplicate" warnings when
+// the same element/relationship appears on multiple draw.io pages).
+func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel, lastState *SyncState) *ReverseResult {
 	result := &ReverseResult{}
 
 	// Pre-compute the flat model for accurate existence checks.
@@ -30,8 +33,25 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResul
 	// there directly. We need the flattened view to properly detect nested elements.
 	flatModel, _ := model.FlattenElements(m)
 
+	// Build a set of elements that were already synced in the last sync.
+	lastElemMap := make(map[string]bool)
+	if lastState != nil {
+		for id := range lastState.Elements {
+			lastElemMap[id] = true
+		}
+	}
+
+	// Build a set of relationships that were already synced in the last sync.
+	lastRelMap := make(map[string]bool)
+	if lastState != nil {
+		for _, r := range lastState.Relationships {
+			key := fmt.Sprintf("%s->%s", r.From, r.To)
+			lastRelMap[key] = true
+		}
+	}
+
 	for _, ch := range changes.DrawioElementChanges {
-		applyElementChange(ch, m, flatModel, result)
+		applyElementChange(ch, m, flatModel, lastElemMap, result)
 	}
 
 	// Detect direction-swap pairs (Deleted a→b + Added b→a) so we can
@@ -42,7 +62,7 @@ func ApplyReverse(changes *ChangeSet, m *model.BausteinsichtModel) *ReverseResul
 		if swaps[relSwapKey{ch.From, ch.To, ch.Type}] {
 			continue // handled as part of a swap pair
 		}
-		applyRelationshipChange(ch, m, flatModel, result)
+		applyRelationshipChange(ch, m, flatModel, lastRelMap, result)
 	}
 
 	// Apply swaps: update direction in-place, preserving kind/label/description.
@@ -116,7 +136,7 @@ func applyRelSwap(newFrom, newTo string, m *model.BausteinsichtModel, result *Re
 	result.RelationshipsCreated++
 }
 
-func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, result *ReverseResult) {
+func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastElemMap map[string]bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
 		// Reject empty title updates from draw.io (#150).
@@ -180,8 +200,19 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 		// IDs are dot-paths (e.g. "parent.child"), causing them to be
 		// re-created as spurious top-level entries with empty titles (#307).
 		if _, exists := flatModel[ch.ID]; exists {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("New element %q from draw.io skipped: ID already exists in model.", ch.ID))
+			// Check if this element was already synced from draw.io in a previous sync.
+			// If it was, it's on a different page now - that's normal, skip silently.
+			if lastElemMap[ch.ID] {
+				// Already synced before (possibly on another page) - no action needed.
+				return
+			}
+			// Element exists in model but wasn't synced from draw.io before - that's a
+			// genuine conflict. Only warn if we've done a previous sync (lastElemMap exists).
+			hasLastState := len(lastElemMap) > 0
+			if hasLastState {
+				result.Warnings = append(result.Warnings,
+					fmt.Sprintf("Element %q from draw.io skipped: ID already exists in model (not synced from draw.io)", ch.ID))
+			}
 			return
 		}
 		kind := firstSpecKind(m)
@@ -195,7 +226,7 @@ func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel
 	}
 }
 
-func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, result *ReverseResult) {
+func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastRelMap map[string]bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
 		updated := false
@@ -256,6 +287,33 @@ func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel,
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("Relationship %q->%q rejected: To element %q does not exist in model", ch.From, ch.To, ch.To))
 			return
+		}
+		// Check if this relationship was already synced from draw.io in a previous sync.
+		// If it was, it's on a different page now - that's normal, skip silently.
+		lastRelKey := fmt.Sprintf("%s->%s", ch.From, ch.To)
+		if lastRelMap[lastRelKey] {
+			// Already synced before (possibly on another page) - no action needed.
+			return
+		}
+		// Check if relationship already exists in the model.
+		// On first sync (lastState is nil or empty), this is expected - user manually added
+		// relationships to both places. Skip silently.
+		// Only warn if we've done a previous sync (lastRelMap exists) and this relationship
+		// was NOT synced from draw.io before - that's a genuine conflict.
+		hasLastState := len(lastRelMap) > 0
+		for _, r := range m.Relationships {
+			if r.From == ch.From && r.To == ch.To {
+				if hasLastState {
+					// Genuine conflict: model has relationship that wasn't synced from draw.io
+					pageInfo := ""
+					if ch.PageID != "" {
+						pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)
+					}
+					result.Warnings = append(result.Warnings,
+						fmt.Sprintf("Relationship %q->%q already exists in model (not synced from draw.io), skipping duplicate%s", ch.From, ch.To, pageInfo))
+				}
+				return
+			}
 		}
 		m.Relationships = append(m.Relationships, model.Relationship{
 			From:  ch.From,

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -336,6 +336,7 @@ func TestApplyReverse_RelationshipAddedDuplicateSkipped(t *testing.T) {
 	// (not synced from draw.io), and now draw.io also has it.
 	// This is a genuine conflict: model has relationship that wasn't synced from draw.io.
 	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z", // a prior sync completed
 		Relationships: []RelationshipState{
 			// Some OTHER relationship that was synced before
 			{From: "other", To: "thing"},
@@ -390,6 +391,7 @@ func TestApplyReverse_RelationshipAddedSecondBetweenSamePair(t *testing.T) {
 	}
 	// Previous sync recorded a->b at index 0 only.
 	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z", // a prior sync completed
 		Relationships: []RelationshipState{
 			{From: "a", To: "b", Index: 0, Label: "uses"},
 		},
@@ -411,6 +413,91 @@ func TestApplyReverse_RelationshipAddedSecondBetweenSamePair(t *testing.T) {
 	}
 	if len(r.Warnings) != 0 {
 		t.Errorf("unexpected warnings: %v", r.Warnings)
+	}
+}
+
+// TestApplyReverse_RelationshipAddedWithUnrelatedAhead exercises the
+// global-index-vs-per-pair-count distinction (#548 review): an unrelated
+// relationship sits AHEAD of the target pair in m.Relationships, so a per-pair
+// count would not equal the global connector index. A genuinely new hand-drawn
+// a->b connector (parseConnectorIndex yields 0 for non-"rel-a-b-N" ids) must
+// still be imported, not dropped.
+func TestApplyReverse_RelationshipAddedWithUnrelatedAhead(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"x": {Kind: "container", Title: "X"},
+			"y": {Kind: "container", Title: "Y"},
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "x", To: "y", Label: "unrelated"}, // global index 0
+			{From: "a", To: "b", Label: "uses"},      // global index 1
+		},
+	}
+	// Prior sync recorded both, a->b at its global index 1.
+	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z",
+		Relationships: []RelationshipState{
+			{From: "x", To: "y", Index: 0, Label: "unrelated"},
+			{From: "a", To: "b", Index: 1, Label: "uses"},
+		},
+	}
+	// A genuinely new, hand-drawn second a->b connector: its id is not a
+	// bausteinsicht-generated "rel-a-b-N", so parseConnectorIndex yields 0.
+	cs := &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "calls"},
+		},
+	}
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if len(m.Relationships) != 3 {
+		t.Fatalf("expected 3 relationships (new a->b imported), got %d", len(m.Relationships))
+	}
+	if r.RelationshipsCreated != 1 {
+		t.Errorf("expected RelationshipsCreated=1, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", r.Warnings)
+	}
+}
+
+// TestApplyReverse_RelationshipAddedFirstSyncNoWarning verifies the first-sync
+// gate works for real callers (#548 review): production callers pass a non-nil
+// but timestamp-less state on the first sync (LoadState fabricates it), so the
+// "already exists" conflict warning must be suppressed via the timestamp, not
+// via nil-ness. A user who added the same relationship to both the model and
+// draw.io on their very first sync should get no warning.
+func TestApplyReverse_RelationshipAddedFirstSyncNoWarning(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"}, // global index 0
+		},
+	}
+	// First sync: non-nil state as LoadState fabricates it, but no timestamp.
+	lastState := &SyncState{
+		Elements:      map[string]ElementState{},
+		Relationships: []RelationshipState{},
+		// Timestamp intentionally empty: no prior sync has completed.
+	}
+	cs := relChangeSet("a", "b", Added, "", "", "uses")
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship (no duplicate), got %d", len(m.Relationships))
+	}
+	if r.RelationshipsCreated != 0 {
+		t.Errorf("expected RelationshipsCreated=0, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("expected no warning on first sync, got %v", r.Warnings)
 	}
 }
 
@@ -609,6 +696,7 @@ func TestApplyReverse_NewElementCollidingIDSkipped(t *testing.T) {
 	// (not synced from draw.io), and now draw.io also has it.
 	// This is a genuine conflict: model has element that wasn't synced from draw.io.
 	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z", // a prior sync completed
 		Elements: map[string]ElementState{
 			// Some OTHER element that was synced before
 			"other": {Title: "Other", Kind: "system"},

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -61,7 +61,7 @@ func TestApplyReverse_TitleUpdate(t *testing.T) {
 	m := simpleModel("api", "Old Title", "", "")
 	cs := elemChangeSet("api", Modified, "title", "Old Title", "New Title")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if m.Model["api"].Title != "New Title" {
 		t.Errorf("expected title %q, got %q", "New Title", m.Model["api"].Title)
@@ -78,7 +78,7 @@ func TestApplyReverse_DescriptionUpdate(t *testing.T) {
 	m := simpleModel("api", "Title", "Old Desc", "")
 	cs := elemChangeSet("api", Modified, "description", "Old Desc", "New Desc")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if m.Model["api"].Description != "New Desc" {
 		t.Errorf("expected description %q, got %q", "New Desc", m.Model["api"].Description)
@@ -92,7 +92,7 @@ func TestApplyReverse_TechnologyUpdate(t *testing.T) {
 	m := simpleModel("api", "Title", "", "Go")
 	cs := elemChangeSet("api", Modified, "technology", "Go", "Rust")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if m.Model["api"].Technology != "Rust" {
 		t.Errorf("expected technology %q, got %q", "Rust", m.Model["api"].Technology)
@@ -106,7 +106,7 @@ func TestApplyReverse_NestedElementUpdate(t *testing.T) {
 	m := modelWithChild("webshop", "api")
 	cs := elemChangeSet("webshop.api", Modified, "title", "child-title", "Updated API")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	child := m.Model["webshop"].Children["api"]
 	if child.Title != "Updated API" {
@@ -121,7 +121,7 @@ func TestApplyReverse_ElementDeleted(t *testing.T) {
 	m := simpleModel("api", "Title", "", "")
 	cs := elemChangeSet("api", Deleted, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if _, exists := m.Model["api"]; exists {
 		t.Error("expected element to be removed from model")
@@ -138,7 +138,7 @@ func TestApplyReverse_AddedElementWarning(t *testing.T) {
 	m := emptyModel()
 	cs := elemChangeSet("unknown", Added, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if len(r.Warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d: %v", len(r.Warnings), r.Warnings)
@@ -158,10 +158,11 @@ func TestApplyReverse_AddedNestedElementSkipped(t *testing.T) {
 	// elements appear as "Added" from the draw.io side. Nested elements with
 	// dot-path IDs (e.g. "parent.child") must NOT be created as spurious
 	// top-level entries — they already exist in the model hierarchy. (#307)
+	// On first sync (lastState is nil), skip silently without warning.
 	m := modelWithChild("parent", "child")
 	cs := elemChangeSet("parent.child", Added, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	// The nested element must NOT be created as a top-level entry.
 	if _, exists := m.Model["parent.child"]; exists {
@@ -170,8 +171,9 @@ func TestApplyReverse_AddedNestedElementSkipped(t *testing.T) {
 	if r.ElementsCreated != 0 {
 		t.Errorf("expected ElementsCreated=0, got %d", r.ElementsCreated)
 	}
-	if len(r.Warnings) == 0 || !strings.Contains(r.Warnings[0], "already exists") {
-		t.Errorf("expected 'already exists' warning, got %v", r.Warnings)
+	// On first sync, skip silently without warning (elements exist in both places by design).
+	if len(r.Warnings) != 0 {
+		t.Errorf("expected no warnings on first sync, got %v", r.Warnings)
 	}
 }
 
@@ -179,7 +181,7 @@ func TestApplyReverse_ModifyMissingElement(t *testing.T) {
 	m := emptyModel()
 	cs := elemChangeSet("nonexistent", Modified, "title", "", "New")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if r.ElementsUpdated != 0 {
 		t.Errorf("expected no update, got %d", r.ElementsUpdated)
@@ -195,7 +197,7 @@ func TestApplyReverse_RelationshipLabelUpdated(t *testing.T) {
 	m := modelWithRel("a", "b", "old label")
 	cs := relChangeSet("a", "b", Modified, "label", "old label", "new label")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if m.Relationships[0].Label != "new label" {
 		t.Errorf("expected label %q, got %q", "new label", m.Relationships[0].Label)
@@ -209,7 +211,7 @@ func TestApplyReverse_RelationshipDeleted(t *testing.T) {
 	m := modelWithRel("a", "b", "calls")
 	cs := relChangeSet("a", "b", Deleted, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if len(m.Relationships) != 0 {
 		t.Errorf("expected relationship to be removed, got %d remaining", len(m.Relationships))
@@ -236,7 +238,7 @@ func TestApplyReverse_DeleteElementCleansViewIncludes(t *testing.T) {
 	}
 
 	cs := elemChangeSet("api", Deleted, "", "", "")
-	ApplyReverse(cs, m)
+	ApplyReverse(cs, m, nil)
 
 	v := m.Views["overview"]
 	for _, inc := range v.Include {
@@ -265,7 +267,7 @@ func TestApplyReverse_EmptyTitleSkipped(t *testing.T) {
 	m := simpleModel("api", "Original Title", "", "")
 	cs := elemChangeSet("api", Modified, "title", "Original Title", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	// Title should remain unchanged
 	if m.Model["api"].Title != "Original Title" {
@@ -295,7 +297,7 @@ func TestApplyReverse_RelationshipAdded(t *testing.T) {
 	m.Relationships = []model.Relationship{} // clear the initial relationship for this test
 	cs := relChangeSet("x", "y", Added, "", "", "uses")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if len(m.Relationships) != 1 {
 		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
@@ -312,6 +314,65 @@ func TestApplyReverse_RelationshipAdded(t *testing.T) {
 	}
 }
 
+// TestApplyReverse_RelationshipAddedDuplicateSkipped verifies that adding a
+// relationship that already exists in the model is skipped and a warning is
+// issued. This prevents duplicate relationships when sync state is stale or
+// when the same relationship appears in both model and draw.io. Regression
+// test for #547.
+func TestApplyReverse_RelationshipAddedDuplicateSkipped(t *testing.T) {
+	// Build a model with existing elements and a relationship between them.
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"frontend": {Kind: "container", Title: "Frontend"},
+			"backend":  {Kind: "container", Title: "Backend"},
+		},
+		Relationships: []model.Relationship{
+			{From: "frontend", To: "backend", Label: "calls API"},
+		},
+	}
+
+	// Simulate "lost sync state" - previous sync had OTHER relationships,
+	// but not this one. The relationship was manually added to the model
+	// (not synced from draw.io), and now draw.io also has it.
+	// This is a genuine conflict: model has relationship that wasn't synced from draw.io.
+	lastState := &SyncState{
+		Relationships: []RelationshipState{
+			// Some OTHER relationship that was synced before
+			{From: "other", To: "thing"},
+		},
+	}
+
+	cs := relChangeSet("frontend", "backend", Added, "", "", "calls API")
+
+	r := ApplyReverse(cs, m, lastState)
+
+	// Should still have exactly 1 relationship (no duplicate added).
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship (no duplicate), got %d", len(m.Relationships))
+	}
+
+	// Should NOT count as created.
+	if r.RelationshipsCreated != 0 {
+		t.Errorf("expected RelationshipsCreated=0 (duplicate skipped), got %d", r.RelationshipsCreated)
+	}
+
+	// Should have a warning about the duplicate (because lastState exists but
+	// doesn't include this relationship - it's a genuine conflict).
+	if len(r.Warnings) == 0 {
+		t.Fatal("expected warning about duplicate relationship, got none")
+	}
+	found := false
+	for _, w := range r.Warnings {
+		if strings.Contains(w, "already exists") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning mentioning 'already exists', got: %v", r.Warnings)
+	}
+}
+
 // TestApplyReverse_RelationshipAddedStaleElementsRejected verifies that
 // relationships referencing non-existent elements are rejected during reverse sync (#329).
 func TestApplyReverse_RelationshipAddedStaleElementsRejected(t *testing.T) {
@@ -319,7 +380,7 @@ func TestApplyReverse_RelationshipAddedStaleElementsRejected(t *testing.T) {
 	m.Relationships = []model.Relationship{} // clear the initial relationship for this test
 	cs := relChangeSet("nonexistent", "y", Added, "", "", "uses")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if len(m.Relationships) != 0 {
 		t.Fatalf("expected 0 relationships (stale rejected), got %d", len(m.Relationships))
@@ -358,7 +419,7 @@ func TestApplyReverse_SwapConnectorDirectionPreservesMetadata(t *testing.T) {
 		},
 	}
 
-	result := ApplyReverse(cs, m)
+	result := ApplyReverse(cs, m, nil)
 
 	if len(m.Relationships) != 1 {
 		t.Fatalf("expected 1 relationship, got %d", len(m.Relationships))
@@ -468,7 +529,7 @@ func TestApplyReverse_NewElementFromDrawio(t *testing.T) {
 		},
 	}
 
-	result := ApplyReverse(cs, m)
+	result := ApplyReverse(cs, m, nil)
 
 	// The new element should be added to the model.
 	if _, ok := m.Model["newservice"]; !ok {
@@ -493,10 +554,23 @@ func TestApplyReverse_NewElementFromDrawio(t *testing.T) {
 // TestApplyReverse_NewElementCollidingIDSkipped verifies that a new element
 // from draw.io whose auto-generated ID collides with an existing model element
 // is NOT imported and a warning is issued instead of overwriting (#203).
+// On first sync (lastState is nil), skip silently - element exists in both places by design.
+// On subsequent sync, warn about genuine conflicts (element in model wasn't synced from draw.io).
 func TestApplyReverse_NewElementCollidingIDSkipped(t *testing.T) {
 	m := &model.BausteinsichtModel{
 		Model: map[string]model.Element{
 			"api": {Kind: "container", Title: "API Gateway", Description: "Main service", Technology: "Go"},
+		},
+	}
+
+	// Simulate "lost sync state" - previous sync had OTHER elements,
+	// but not this one. The element was manually added to the model
+	// (not synced from draw.io), and now draw.io also has it.
+	// This is a genuine conflict: model has element that wasn't synced from draw.io.
+	lastState := &SyncState{
+		Elements: map[string]ElementState{
+			// Some OTHER element that was synced before
+			"other": {Title: "Other", Kind: "system"},
 		},
 	}
 
@@ -506,7 +580,7 @@ func TestApplyReverse_NewElementCollidingIDSkipped(t *testing.T) {
 		},
 	}
 
-	result := ApplyReverse(cs, m)
+	result := ApplyReverse(cs, m, lastState)
 
 	// Existing element must NOT be overwritten.
 	elem := m.Model["api"]
@@ -523,7 +597,8 @@ func TestApplyReverse_NewElementCollidingIDSkipped(t *testing.T) {
 	if result.ElementsCreated != 0 {
 		t.Errorf("expected ElementsCreated=0, got %d", result.ElementsCreated)
 	}
-	// Should have a warning about the collision.
+	// Should have a warning about the collision (because lastState exists but
+	// doesn't include this element - it's a genuine conflict).
 	var found bool
 	for _, w := range result.Warnings {
 		if strings.Contains(w, "api") && strings.Contains(w, "already exists") {
@@ -556,7 +631,7 @@ func TestApplyReverse_NewElementGetsDefaultKind(t *testing.T) {
 		},
 	}
 
-	ApplyReverse(cs, m)
+	ApplyReverse(cs, m, nil)
 
 	elem, ok := m.Model["newservice"]
 	if !ok {
@@ -589,7 +664,7 @@ func TestApplyReverse_NewElementWarningMentionsKind(t *testing.T) {
 		},
 	}
 
-	result := ApplyReverse(cs, m)
+	result := ApplyReverse(cs, m, nil)
 
 	var found bool
 	for _, w := range result.Warnings {
@@ -623,7 +698,7 @@ func TestApplyReverse_DeletedElementCleansOrphanedRelationships(t *testing.T) {
 	// Delete "payments" element from draw.io (without deleting its connectors).
 	cs := elemChangeSet("payments", Deleted, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	// Element should be removed.
 	if _, exists := m.Model["payments"]; exists {
@@ -673,7 +748,7 @@ func TestApplyReverse_DeletedElementCleansNestedRelationships(t *testing.T) {
 
 	cs := elemChangeSet("shop", Deleted, "", "", "")
 
-	r := ApplyReverse(cs, m)
+	r := ApplyReverse(cs, m, nil)
 
 	if _, exists := m.Model["shop"]; exists {
 		t.Error("expected element 'shop' to be removed")

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -373,6 +373,47 @@ func TestApplyReverse_RelationshipAddedDuplicateSkipped(t *testing.T) {
 	}
 }
 
+// TestApplyReverse_RelationshipAddedSecondBetweenSamePair verifies that a
+// newly-drawn SECOND relationship between the same pair (#142) is imported even
+// when a FIRST relationship between that pair was already synced. Keying the
+// last-sync set by "from->to" (ignoring the per-pair index) previously matched
+// the already-synced first relationship and dropped the new one silently (#548).
+func TestApplyReverse_RelationshipAddedSecondBetweenSamePair(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"}, // index 0, previously synced
+		},
+	}
+	// Previous sync recorded a->b at index 0 only.
+	lastState := &SyncState{
+		Relationships: []RelationshipState{
+			{From: "a", To: "b", Index: 0, Label: "uses"},
+		},
+	}
+	// draw.io now has a SECOND a->b connector (index 1) - a genuinely new relationship.
+	cs := &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 1, Type: Added, NewValue: "calls"},
+		},
+	}
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if len(m.Relationships) != 2 {
+		t.Fatalf("expected 2 relationships (new one imported), got %d", len(m.Relationships))
+	}
+	if r.RelationshipsCreated != 1 {
+		t.Errorf("expected RelationshipsCreated=1, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", r.Warnings)
+	}
+}
+
 // TestApplyReverse_RelationshipAddedStaleElementsRejected verifies that
 // relationships referencing non-existent elements are rejected during reverse sync (#329).
 func TestApplyReverse_RelationshipAddedStaleElementsRejected(t *testing.T) {

--- a/internal/sync/state.go
+++ b/internal/sync/state.go
@@ -34,12 +34,14 @@ type ElementState struct {
 }
 
 // RelationshipState captures a relationship's synced values.
+// Note: PageIDs is not persisted to JSON as page names can change (e.g., view renamed).
 type RelationshipState struct {
-	From  string `json:"from"`
-	To    string `json:"to"`
-	Index int    `json:"index"`
-	Label string `json:"label,omitempty"`
-	Kind  string `json:"kind,omitempty"`
+	From    string   `json:"from"`
+	To      string   `json:"to"`
+	Index   int      `json:"index"`
+	Label   string   `json:"label,omitempty"`
+	Kind    string   `json:"kind,omitempty"`
+	PageIDs []string `json:"-"` // transient: only used during change detection
 }
 
 // LoadState reads a SyncState from the given path.

--- a/src/docs/spec/05_sync_specification.adoc
+++ b/src/docs/spec/05_sync_specification.adoc
@@ -157,8 +157,10 @@ Triggered when the draw.io file changes.
 | Generate ID via `sanitizeID` (lowercase, hyphen-separated from title). Default kind = first alphabetically-sorted kind from `specification.elements` (#206). Collision guard: skip import if generated ID already exists in the model (#203). Navigation buttons (`nav-back-*`) are excluded from import (#205). Bare `<mxCell>` elements without an `<object>` wrapper are excluded.
 
 | New relationship (from draw.io)
-| `<mxCell>` with `edge="1"`, `source` and `target` matching known element IDs, not present in model
-| Add relationship to model. Connector label captured from `value` attribute (#204).
+| `<mxCell>` with `edge="1"`, `source` and `target` matching known element IDs, whose per-pair index (`rel-<from>-<to>-<index>`) is neither already recorded in the last-sync state nor already held by the model
+| Add relationship to model, capturing the connector label from `value` (#204).
+Duplicate detection is index-aware (#142): a relationship already in the last-sync state — e.g. the same connector re-appearing on another view page — is skipped silently, and a newly-drawn second relationship between the same pair is imported as new rather than dropped (#547, #548).
+A same-index relationship the model already holds but that was never synced from draw.io is skipped as a conflict with a warning.
 
 | Element deleted in draw.io
 | Known `bausteinsicht_id` no longer present in any `<object>` on visible view pages


### PR DESCRIPTION
- Skip adding relationship if it was synced in a previous sync (exists on another draw.io page - this is normal)
- On first sync (no lastState), skip silently - relationships in both places is expected, user manually added them
- Add Page.Name() method to get human-readable page name instead of UUID
- Track page IDs where relationships exist during diff detection
- Pass lastState to ApplyReverse to detect already-synced relationships
- Only warn about genuine conflicts (relationship exists in model but was not synced from draw.io in a previous sync)
- Same logic applied to elements (new commit afbfdd6)

This fixes issue #547 where sync ping-pongs and creates duplicate relationships on repeated runs.

Generated with [Continue](https://continue.dev)

## Related Issue
Closes #547

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement/refactoring
- [ ] Documentation
- [ ] Other (describe)

## Pre-Merge Checklist (Developer)

- [x] **Branch is up-to-date with main**
  - Ran: `git rebase origin/main` (if behind)
  - No merge conflicts
  
- [x] **No duplicate work**
  - Checked open PRs for overlapping functionality
  - Did not start a duplicate of existing PR
  
- [x] **Tests passing**
  - Unit tests: ✅
  - Integration tests: ✅
  - CI pipeline: ✅
  
- [ ] **Code quality**
  - Ran `make check` locally
  - No new warnings/errors
  
- [ ] **Documentation** — run `/doc-check review` (Claude Code) or fill in manually:
  - [ ] `spec/01_use_cases.adoc` — updated / N/A (reason: )
  - [ ] `spec/02_cli_specification.adoc` — updated / N/A (reason: ) ← required if any `--flag`, command, subcommand rename, or output format changed
  - [ ] `spec/03_data_models.adoc` — updated / N/A (reason: ) ← required if `types.go` or `schemas/bausteinsicht.schema.json` changed
  - [ ] `spec/04_acceptance_criteria.adoc` — updated / N/A (reason: )
  - [ ] `spec/05_sync_specification.adoc` — updated / N/A (reason: ) ← required if `internal/sync/` changed
  - [ ] `arc42/05_building_block_view.adoc` — updated / N/A (reason: ) ← required if new package added
  - [ ] `arc42/06_runtime_view.adoc` — updated / N/A (reason: ) ← required if new data flow or runtime path added
  - [ ] `arc42/08_concepts.adoc` — updated / N/A (reason: ) ← required if new cross-cutting pattern introduced
  - [ ] New ADR created / N/A (reason: )

## Testing
Added unit tests

## Notes for Reviewers
<!-- Any context for code review? -->
