### PR TITLE
ci(go.yml): wire gosec/nilaway/govulncheck/gitleaks/test-race into CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -495,7 +495,7 @@ jobs:
         # internal/importer/xmi is excluded: its BigData.xmi test fixture is
         # ~118MB, and race instrumentation's memory overhead on top of
         # parsing it exhausts memory well before the package's own (fast,
-        # non-race) tests would ever suggest a problem. The other 32
+        # non-race) tests would ever suggest a problem. The other 33
         # packages are raced normally.
         run: go test -race $(go list ./... | grep -v '/internal/importer/xmi$')
 
@@ -520,7 +520,13 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
-      - run: go install github.com/zricethezav/gitleaks/v8@latest
+      # Pinned (unlike the other tools installed in this file): gitleaks'
+      # `detect` subcommand (used by `make gitleaks`) is already hidden from
+      # `gitleaks --help` in favor of `dir`/`git` as of v8.30.1 — an
+      # unpinned @latest could silently start failing this blocking gate
+      # whenever a future release removes `detect` outright, for reasons
+      # unrelated to any given PR's own changes.
+      - run: go install github.com/zricethezav/gitleaks/v8@v8.30.1
       - run: make gitleaks
 
   gosec:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -467,6 +467,90 @@ jobs:
         with:
           version: latest
 
+  # `make check` (vet staticcheck gosec nilaway govulncheck test-race
+  # schema-validate) previously only ran locally — a PR with a real gosec
+  # finding, a nilaway-catchable nil-pointer bug, a CVE in a dependency, a
+  # leaked secret, or a race condition passed CI green with none of these
+  # tools ever seeing it, even though CLAUDE.md's Risk Radar Assessment
+  # lists all of them as active mitigations. Closes #550.
+  #
+  # test-race and gitleaks run as blocking gates below (both verified clean
+  # against the current codebase, see #550). gosec and nilaway run
+  # non-blocking for now: gosec currently reports 35 pre-existing findings
+  # (file-permission hardening, tracked separately) and nilaway's memory/time
+  # footprint on a GitHub-hosted runner hasn't been validated yet — making
+  # either blocking today would fail CI on backlog unrelated to a given PR's
+  # own changes. Flip continue-on-error to false once each is clean/verified.
+
+  test-race:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - name: go test -race
+        # internal/importer/xmi is excluded: its BigData.xmi test fixture is
+        # ~118MB, and race instrumentation's memory overhead on top of
+        # parsing it exhausts memory well before the package's own (fast,
+        # non-race) tests would ever suggest a problem. The other 32
+        # packages are raced normally.
+        run: go test -race $(go list ./... | grep -v '/internal/importer/xmi$')
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: make govulncheck
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: go install github.com/zricethezav/gitleaks/v8@latest
+      - run: make gitleaks
+
+  gosec:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: make gosec
+        continue-on-error: true # 35 pre-existing findings, see #550
+        run: make gosec
+
+  nilaway:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: go install go.uber.org/nilaway/cmd/nilaway@latest
+      - name: make nilaway
+        continue-on-error: true # runtime/memory footprint on GH-hosted runners not yet validated, see #550
+        run: make nilaway
+
   format:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -508,7 +508,11 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: go.mod
-      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      # Pinned (same reasoning as gitleaks below): this is a blocking gate, so
+      # an unrelated upstream @latest release could start failing every PR's
+      # CI for reasons unconnected to that PR's own changes. Verified clean
+      # (0 vulnerabilities) against the current codebase before pinning.
+      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
       - run: make govulncheck
 
   gitleaks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,13 +223,13 @@ _Updated by `/risk-mitigate` on 2026-03-04_
 | Linter & Formatter | ✅ Present | `golangci-lint` in CI (`go.yml`), `go vet`, `staticcheck` via Makefile |
 | Type Checking | ✅ Present | Go is statically typed; `go build` enforces types |
 | Pre-Commit Hooks | ✅ Set up | `scripts/pre-commit` — gofmt, go vet, golangci-lint, gitleaks; install via `make install-hooks` |
-| Dependency Check | ✅ Present | `govulncheck` via Makefile; `gosec` for security scanning |
-| CI Build & Unit Tests | ✅ Present | GitHub Actions `go.yml`: build + test + golangci-lint |
+| Dependency Check | ✅ Present | `govulncheck` blocking in CI (`go.yml`) and via Makefile; `gosec` non-blocking in CI, tracked in #551 |
+| CI Build & Unit Tests | ✅ Present | GitHub Actions `go.yml`: build + test (+ `-race`, see below) + golangci-lint |
 
 #### Tier 2 — Extended Assurance
 | Measure | Status | Details |
 |---------|--------|---------|
-| SAST | ✅ Present | `gosec` (security scanner), `nilaway` (nil pointer analysis), `staticcheck` |
+| SAST | ✅ Present | `staticcheck` blocking (via `lint` job); `gosec`/`nilaway` run in CI non-blocking for now, tracked in #551 |
 | AI Code Review | ✅ Present | Claude Code with code-review plugin; PR merge policy requires review |
 | Property-Based Tests | ✅ Set up | `pgregory.net/rapid` — label roundtrip + escapeHTML + trimBrackets property tests |
 | SonarQube Quality Gate | ✅ Present | SonarCloud on all PRs; new-code coverage gate ≥ 80% (see override policy in PR Merge Policy section); `sonar.qualitygate.wait=true` in `sonar-project.properties` |

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -116,7 +116,7 @@ analysis) also run in CI but non-blocking (`continue-on-error: true`) for now: `
 reports 35 pre-existing file-permission findings (tracked separately), and `nilaway`'s memory/time
 footprint on a GitHub-hosted runner hasn't been validated as reliably fast/light enough to gate every
 PR on. `test-race` excludes `internal/importer/xmi` — its ~118MB `BigData.xmi` test fixture makes
-race instrumentation's memory overhead impractical; the other 32 packages are raced normally. See
+race instrumentation's memory overhead impractical; the other 33 packages are raced normally. See
 link:https://github.com/docToolchain/Bausteinsicht/issues/550[issue #550] for the follow-up to make
 `gosec`/`nilaway` blocking once their respective backlogs are addressed.
 

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -106,16 +106,19 @@ Security controls implemented across the codebase, keyed to threat IDs:
 
 | Dependency scanning
 | All
-| `govulncheck` via `make govulncheck`; no CVEs in called code as of last local run (2026-04-27)
+| `govulncheck` in CI (`govulncheck` job) and Makefile; no CVEs in called code (verified 2026-07-09)
 |===
 
-NOTE: As of 2026-07-09, `gosec` (SAST), `nilaway` (nil-pointer analysis), `govulncheck` (dependency
-scanning), `gitleaks` (secret scanning), and `go test -race` are runnable locally via `make check` /
-`make gitleaks`, but **none of them run in CI** — `.github/workflows/go.yml` only enforces
-`golangci-lint`, `go vet` (via the `lint` job), `gofmt` (via the `format` job), and `go test` without
-`-race` (via `build-and-test`). A PR with a real `gosec` finding, a known CVE in a dependency, or a
-race condition currently passes CI green. Wiring these into `go.yml` is tracked in
-link:https://github.com/docToolchain/Bausteinsicht/issues/550[issue #550].
+NOTE: As of 2026-07-09, `govulncheck`, `gitleaks` (secret scanning), and `go test -race` run as
+**blocking** CI jobs in `.github/workflows/go.yml` (`govulncheck`, `gitleaks`, `test-race`), all
+verified clean against the current codebase (#550). `gosec` (SAST) and `nilaway` (nil-pointer
+analysis) also run in CI but non-blocking (`continue-on-error: true`) for now: `gosec` currently
+reports 35 pre-existing file-permission findings (tracked separately), and `nilaway`'s memory/time
+footprint on a GitHub-hosted runner hasn't been validated as reliably fast/light enough to gate every
+PR on. `test-race` excludes `internal/importer/xmi` — its ~118MB `BigData.xmi` test fixture makes
+race instrumentation's memory overhead impractical; the other 32 packages are raced normally. See
+link:https://github.com/docToolchain/Bausteinsicht/issues/550[issue #550] for the follow-up to make
+`gosec`/`nilaway` blocking once their respective backlogs are addressed.
 
 === 8.3 Test Strategy
 

--- a/src/docs/arc42/chapters/08_concepts.adoc
+++ b/src/docs/arc42/chapters/08_concepts.adoc
@@ -106,8 +106,16 @@ Security controls implemented across the codebase, keyed to threat IDs:
 
 | Dependency scanning
 | All
-| `govulncheck` in CI and Makefile; no CVEs in called code (verified 2026-04-27)
+| `govulncheck` via `make govulncheck`; no CVEs in called code as of last local run (2026-04-27)
 |===
+
+NOTE: As of 2026-07-09, `gosec` (SAST), `nilaway` (nil-pointer analysis), `govulncheck` (dependency
+scanning), `gitleaks` (secret scanning), and `go test -race` are runnable locally via `make check` /
+`make gitleaks`, but **none of them run in CI** — `.github/workflows/go.yml` only enforces
+`golangci-lint`, `go vet` (via the `lint` job), `gofmt` (via the `format` job), and `go test` without
+`-race` (via `build-and-test`). A PR with a real `gosec` finding, a known CVE in a dependency, or a
+race condition currently passes CI green. Wiring these into `go.yml` is tracked in
+link:https://github.com/docToolchain/Bausteinsicht/issues/550[issue #550].
 
 === 8.3 Test Strategy
 


### PR DESCRIPTION
## Summary
- `make check`'s security/quality targets (`gosec`, `nilaway`, `govulncheck`, `gitleaks`, `test-race`) previously ran nowhere in CI — only `golangci-lint`, `go vet` (implicitly), and `gofmt` were enforced, despite CLAUDE.md's Risk Radar Assessment listing them as active mitigations.
- Verified each tool against the current codebase before deciding blocking status (see commit message for details):
  - **Blocking**: `govulncheck` (clean), `gitleaks` (clean after adding `.gitleaks.toml` to exclude a large XMI test fixture whose GUIDs false-positive as secrets), `test-race` (clean, excluding one package — see below).
  - **Non-blocking for now** (`continue-on-error: true`, visible but doesn't fail CI): `gosec` (35 pre-existing file-permission findings), `nilaway` (OOM'd in a memory-constrained sandbox; unverified on GitHub-hosted runners).
- `test-race` excludes `internal/importer/xmi`: its ~118MB `BigData.xmi` test fixture makes race instrumentation's memory overhead impractical (confirmed via local OOM). The other 32 packages run raced normally.
- Added `.gitleaks.toml` (repo root) with a scoped allowlist for `internal/importer/xmi/testdata/`.
- Updated `src/docs/arc42/chapters/08_concepts.adoc`'s CI-tooling note to describe the new state accurately.

Follow-up to flip `gosec`/`nilaway` to blocking once their respective backlogs are resolved: #551.

Closes #550.

## Test plan
- [x] Ran `gosec ./...`, `nilaway ./...`, `govulncheck ./...`, `gitleaks detect ...`, `go test -race ./...` locally against the current codebase to determine blocking status for each (see commit message)
- [x] `go build ./...` / `go test ./...` / `gofmt -l .` all clean
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Watch the actual GitHub Actions run for these new jobs once pushed (in particular `nilaway`'s runtime/memory on a real runner, and `test-race`'s timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)