### PR TITLE
fix: remove Git LFS for BigData.xmi, fetch from separate repo + synthetic fallback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,4 +14,3 @@
 *.gif  binary
 *.ico  binary
 *.pdf  binary
-BigData.xmi filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -500,6 +500,11 @@ jobs:
   # can't recur unnoticed. Isolated from build-and-test/test-race/coverage
   # so the ~118MB download only happens once, in one job, not multiplied
   # across the OS matrix or every test-running job.
+  #
+  # TestImport_SyntheticBigData (same package) complements this: it exercises
+  # the importer at the same rough scale/depth via a generated fixture, with
+  # no fetch dependency, so every other job still gets baseline scale
+  # coverage even if this job's fetch ever fails or the fixture repo is down.
   xmi-bigdata-integration:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -486,3 +486,36 @@ jobs:
             exit 1
           fi
           echo "All Go files are gofmt-clean."
+
+  # internal/importer/xmi/testdata/BigData.xmi (a real ~118MB Enterprise
+  # Architect/AUTOSAR export) is fetched from the separate
+  # docToolchain/bausteinsicht-testdata repo rather than committed/Git-LFS-
+  # tracked here (#553) — the repo was previously paying Git LFS's
+  # complexity/quota cost without CI ever actually exercising the real-file
+  # integration test (no `actions/checkout` step anywhere set `lfs: true`,
+  # so every CI checkout only ever saw the ~130-byte LFS pointer, and
+  # TestImport_BigData's own >1MB presence check silently skipped it in
+  # every run). This dedicated job fetches the real fixture and explicitly
+  # fails if the test unexpectedly skips, so that class of silent drift
+  # can't recur unnoticed. Isolated from build-and-test/test-race/coverage
+  # so the ~118MB download only happens once, in one job, not multiplied
+  # across the OS matrix or every test-running job.
+  xmi-bigdata-integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version-file: go.mod
+      - run: make fetch-testdata
+      - name: go test -run TestImport_BigData (must not skip)
+        shell: bash
+        run: |
+          OUTPUT=$(go test -run TestImport_BigData -v ./internal/importer/xmi/... 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q -- '--- SKIP'; then
+            echo "::error::TestImport_BigData was skipped — the BigData.xmi fetch likely failed silently."
+            exit 1
+          fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -518,8 +518,20 @@ jobs:
       - name: go test -run TestImport_BigData (must not skip)
         shell: bash
         run: |
+          # GitHub Actions runs bash steps with `-e` by default, which would
+          # abort this script at the `OUTPUT=$(...)` line (before printing
+          # anything) if `go test` itself fails outright — masking the very
+          # diagnostics this step exists to surface. Disable it around the
+          # capture so a real test failure's full -v output reaches the log.
+          set +e
           OUTPUT=$(go test -run TestImport_BigData -v ./internal/importer/xmi/... 2>&1)
+          CODE=$?
+          set -e
           echo "$OUTPUT"
+          if [ "$CODE" -ne 0 ]; then
+            echo "::error::TestImport_BigData failed (exit $CODE) — see output above."
+            exit 1
+          fi
           if echo "$OUTPUT" | grep -q -- '--- SKIP'; then
             echo "::error::TestImport_BigData was skipped — the BigData.xmi fetch likely failed silently."
             exit 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -489,7 +489,7 @@ jobs:
 
   # internal/importer/xmi/testdata/BigData.xmi (a real ~118MB Enterprise
   # Architect/AUTOSAR export) is fetched from the separate
-  # docToolchain/bausteinsicht-testdata repo rather than committed/Git-LFS-
+  # docToolchain/Bausteinsicht-Testdata repo rather than committed/Git-LFS-
   # tracked here (#553) — the repo was previously paying Git LFS's
   # complexity/quota cost without CI ever actually exercising the real-file
   # integration test (no `actions/checkout` step anywhere set `lfs: true`,

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ coverage-report.md
 coverage/
 
 # Large XMI integration-test fixture, fetched on demand from the separate
-# docToolchain/bausteinsicht-testdata repo instead of being committed/LFS-
+# docToolchain/Bausteinsicht-Testdata repo instead of being committed/LFS-
 # tracked here (#553). See scripts/fetch-xmi-testdata.sh / `make fetch-testdata`.
 internal/importer/xmi/testdata/BigData.xmi
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ coverage-report.md
 /bausteinsicht-lsp.exe
 coverage/
 
+# Large XMI integration-test fixture, fetched on demand from the separate
+# docToolchain/bausteinsicht-testdata repo instead of being committed/LFS-
+# tracked here (#553). See scripts/fetch-xmi-testdata.sh / `make fetch-testdata`.
+internal/importer/xmi/testdata/BigData.xmi
+
 # MCP server caches
 # .playwright-mcp/ holds the Playwright MCP server's session data (logs,
 # screenshots, browser profiles). Pure cache — never commit it.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+title = "Bausteinsicht gitleaks config"
+
+[extend]
+useDefault = true
+
+# internal/importer/xmi/testdata/BigData.xmi is fetched on demand from a
+# separate repo (#553), gitignored here, never committed. Still allowlisted
+# defensively: if a contributor runs `make fetch-testdata` locally and then
+# `make gitleaks` / the pre-commit hook (which scan the working directory,
+# not just tracked/committed files), the real file's EAID_* GUIDs would
+# otherwise false-positive as generic-api-key/square-access-token secrets.
+#
+# Scoped to this exact file, not the whole testdata/ directory — a broader
+# glob would silently allowlist any future real secret placed anywhere else
+# under testdata/ too (verified: an injected fake secret in a sibling
+# testdata file went undetected under a directory-wide pattern).
+[allowlist]
+description = "Non-secret high-entropy IDs in the BigData.xmi test fixture"
+paths = [
+  '''internal/importer/xmi/testdata/BigData\.xmi$''',
+]

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,12 @@ check-duplicates:
 	@echo "🔍 Checking for duplicate branches..."
 	bash scripts/check-duplicate-branches.sh
 
+# Fetch the large XMI integration-test fixture from the separate
+# docToolchain/bausteinsicht-testdata repo (#553). Safe to skip if the
+# fixture repo is unreachable — see script header for details.
+fetch-testdata:
+	bash scripts/fetch-xmi-testdata.sh
+
 # Run all checks (lint + security + tests)
 check: vet staticcheck gosec nilaway govulncheck test-race schema-validate
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ check-duplicates:
 	bash scripts/check-duplicate-branches.sh
 
 # Fetch the large XMI integration-test fixture from the separate
-# docToolchain/bausteinsicht-testdata repo (#553). Safe to skip if the
+# docToolchain/Bausteinsicht-Testdata repo (#553). Safe to skip if the
 # fixture repo is unreachable — see script header for details.
 fetch-testdata:
 	bash scripts/fetch-xmi-testdata.sh

--- a/internal/importer/xmi/synthetic_bigdata_test.go
+++ b/internal/importer/xmi/synthetic_bigdata_test.go
@@ -31,6 +31,22 @@ var syntheticStereotypes = []string{
 // for most of its occurrences.
 const stereotypeEvery = 7
 
+// syntheticWriter wraps a *bufio.Writer and captures the first write error
+// instead of requiring every fmt.Fprintf call site to check one — with dozens
+// of writes in writeSyntheticXMI, checking each individually would swamp the
+// generation logic; sink() below reports whatever was captured once, at the end.
+type syntheticWriter struct {
+	bw  *bufio.Writer
+	err error
+}
+
+func (w *syntheticWriter) printf(format string, args ...any) {
+	if w.err != nil {
+		return
+	}
+	_, w.err = fmt.Fprintf(w.bw, format, args...)
+}
+
 // writeSyntheticXMI writes a synthetic XMI 2.1 / UML 2.1 document to w that
 // mirrors the shape of a real large Enterprise Architect / AUTOSAR export —
 // numBranches top-level packages (real exports have several, e.g. AUTOSAR /
@@ -44,17 +60,17 @@ const stereotypeEvery = 7
 // so the generated fixture doesn't introduce non-determinism into the test.
 func writeSyntheticXMI(w io.Writer, numElements, depth, numBranches int) error {
 	rng := rand.New(rand.NewSource(42)) // #nosec G404 -- deterministic test fixture, not security-sensitive
-	bw := bufio.NewWriter(w)
+	sw := &syntheticWriter{bw: bufio.NewWriter(w)}
 
 	genID := func(prefix string) string {
 		return fmt.Sprintf("%s_%08X_%04X_%04x_%04X_%012X",
 			prefix, rng.Uint32(), rng.Uint32()&0xFFFF, rng.Uint32()&0xFFFF, rng.Uint32()&0xFFFF, rng.Uint64()&0xFFFFFFFFFFFF)
 	}
 
-	fmt.Fprint(bw, "<?xml version='1.0' encoding='windows-1252' ?>\n")
-	fmt.Fprint(bw, "<xmi:XMI xmlns:xmi=\"http://schema.omg.org/spec/XMI/2.1\" xmi:version=\"2.1\" xmlns:uml=\"http://schema.omg.org/spec/UML/2.1\">\n")
-	fmt.Fprint(bw, "\t<xmi:Documentation exporter=\"Bausteinsicht synthetic generator\" exporterVersion=\"1.0\"/>\n")
-	fmt.Fprint(bw, "\t<uml:Model xmi:type=\"uml:Model\" name=\"EA_Model\" visibility=\"public\">\n")
+	sw.printf("<?xml version='1.0' encoding='windows-1252' ?>\n")
+	sw.printf("<xmi:XMI xmlns:xmi=\"http://schema.omg.org/spec/XMI/2.1\" xmi:version=\"2.1\" xmlns:uml=\"http://schema.omg.org/spec/UML/2.1\">\n")
+	sw.printf("\t<xmi:Documentation exporter=\"Bausteinsicht synthetic generator\" exporterVersion=\"1.0\"/>\n")
+	sw.printf("\t<uml:Model xmi:type=\"uml:Model\" name=\"EA_Model\" visibility=\"public\">\n")
 
 	generatedIDs := make([]string, 0, numElements)
 	elementsPerBranch := numElements / numBranches
@@ -67,7 +83,7 @@ func writeSyntheticXMI(w io.Writer, numElements, depth, numBranches int) error {
 		// like a real export's AUTOSAR/ReadMe/ExportConfiguration/... roots.
 		indent := "\t\t"
 		for i := 0; i < depth; i++ {
-			fmt.Fprintf(bw, "%s<packagedElement xmi:type=\"uml:Package\" xmi:id=\"%s\" name=\"Branch%d_Package%d\" visibility=\"public\">\n",
+			sw.printf("%s<packagedElement xmi:type=\"uml:Package\" xmi:id=\"%s\" name=\"Branch%d_Package%d\" visibility=\"public\">\n",
 				indent, genID("EAPK"), b, i)
 			indent += "\t"
 		}
@@ -85,43 +101,46 @@ func writeSyntheticXMI(w io.Writer, numElements, depth, numBranches int) error {
 			id := genID("EAID")
 			generatedIDs = append(generatedIDs, id)
 
-			fmt.Fprintf(bw, "%s<packagedElement xmi:type=\"uml:%s\" xmi:id=\"%s\" name=\"Element%d\" visibility=\"public\">\n",
+			sw.printf("%s<packagedElement xmi:type=\"uml:%s\" xmi:id=\"%s\" name=\"Element%d\" visibility=\"public\">\n",
 				indent, kind, id, elemIdx)
 
 			if elemIdx%3 == 0 {
-				fmt.Fprintf(bw, "%s\t<ownedAttribute xmi:type=\"uml:Property\" xmi:id=\"%s\" name=\"attr%d\" visibility=\"private\"/>\n",
+				sw.printf("%s\t<ownedAttribute xmi:type=\"uml:Property\" xmi:id=\"%s\" name=\"attr%d\" visibility=\"private\"/>\n",
 					indent, genID("EAID"), elemIdx)
 			}
 			if elemIdx%4 == 0 {
-				fmt.Fprintf(bw, "%s\t<ownedComment xmi:type=\"uml:Comment\" xmi:id=\"%s\" body=\"Synthetic comment for element %d, used for scale testing only.\"/>\n",
+				sw.printf("%s\t<ownedComment xmi:type=\"uml:Comment\" xmi:id=\"%s\" body=\"Synthetic comment for element %d, used for scale testing only.\"/>\n",
 					indent, genID("EAID"), elemIdx)
 			}
 			if elemIdx%stereotypeEvery == 0 {
 				stereo := syntheticStereotypes[(elemIdx/stereotypeEvery)%len(syntheticStereotypes)]
-				fmt.Fprintf(bw, "%s\t<xmi:Extension extender=\"Bausteinsicht synthetic generator\">\n", indent)
-				fmt.Fprintf(bw, "%s\t\t<stereotype xmi:id=\"%s\" name=\"%s\"/>\n", indent, genID("EAID"), stereo)
-				fmt.Fprintf(bw, "%s\t</xmi:Extension>\n", indent)
+				sw.printf("%s\t<xmi:Extension extender=\"Bausteinsicht synthetic generator\">\n", indent)
+				sw.printf("%s\t\t<stereotype xmi:id=\"%s\" name=\"%s\"/>\n", indent, genID("EAID"), stereo)
+				sw.printf("%s\t</xmi:Extension>\n", indent)
 			}
 
 			// Every 5th element depends on an earlier one, once enough exist.
 			if elemIdx%5 == 0 && len(generatedIDs) > 1 {
 				target := generatedIDs[rng.Intn(len(generatedIDs)-1)]
-				fmt.Fprintf(bw, "%s\t<packagedElement xmi:type=\"uml:Dependency\" xmi:id=\"%s\" name=\"dep%d\" client=\"%s\" supplier=\"%s\"/>\n",
+				sw.printf("%s\t<packagedElement xmi:type=\"uml:Dependency\" xmi:id=\"%s\" name=\"dep%d\" client=\"%s\" supplier=\"%s\"/>\n",
 					indent, genID("EAID"), elemIdx, id, target)
 			}
 
-			fmt.Fprintf(bw, "%s</packagedElement>\n", indent)
+			sw.printf("%s</packagedElement>\n", indent)
 		}
 
 		// Close this branch's package chain in reverse order.
 		for i := depth - 1; i >= 0; i-- {
 			indent = indent[:len(indent)-1]
-			fmt.Fprintf(bw, "%s</packagedElement>\n", indent)
+			sw.printf("%s</packagedElement>\n", indent)
 		}
 	}
 
-	fmt.Fprint(bw, "\t</uml:Model>\n")
-	fmt.Fprint(bw, "</xmi:XMI>\n")
+	sw.printf("\t</uml:Model>\n")
+	sw.printf("</xmi:XMI>\n")
 
-	return bw.Flush()
+	if sw.err != nil {
+		return sw.err
+	}
+	return sw.bw.Flush()
 }

--- a/internal/importer/xmi/synthetic_bigdata_test.go
+++ b/internal/importer/xmi/synthetic_bigdata_test.go
@@ -1,0 +1,116 @@
+package xmi_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"math/rand"
+)
+
+// syntheticElementKinds mirrors the UML types defaultKindMap resolves to
+// concrete Bausteinsicht kinds (see xmi.go) — used to generate a realistic
+// mix of leaf elements.
+var syntheticElementKinds = []string{
+	"Component", "Class", "Artifact", "Interface", "Node",
+	"DataType", "Enumeration", "Subsystem", "UseCase", "Collaboration",
+}
+
+// syntheticStereotypes mirrors common AUTOSAR/EA stereotype names — applied
+// to a fraction of generated elements to exercise the stereotype-as-kind path.
+var syntheticStereotypes = []string{
+	"SWComponent", "BSWModule", "PortInterface", "ECUAbstraction", "",
+}
+
+// writeSyntheticXMI writes a synthetic XMI 2.1 / UML 2.1 document to w that
+// mirrors the shape of a real large Enterprise Architect / AUTOSAR export —
+// numBranches top-level packages (real exports have several, e.g. AUTOSAR /
+// ReadMe / ExportConfiguration / ...), each nested down to depth, with
+// numElements leaf elements distributed across the branches' deepest
+// packages (mixed types, occasional stereotypes/attributes/comments, and
+// relationships between them). Used by TestImport_SyntheticBigData to
+// provide scale/depth coverage in every CI job without a network fetch,
+// complementing TestImport_BigData's real-file (fetched, #553) coverage.
+// Deterministic (fixed seed): repeated runs produce byte-identical output,
+// so the generated fixture doesn't introduce non-determinism into the test.
+func writeSyntheticXMI(w io.Writer, numElements, depth, numBranches int) error {
+	rng := rand.New(rand.NewSource(42)) // #nosec G404 -- deterministic test fixture, not security-sensitive
+	bw := bufio.NewWriter(w)
+
+	genID := func(prefix string) string {
+		return fmt.Sprintf("%s_%08X_%04X_%04x_%04X_%012X",
+			prefix, rng.Uint32(), rng.Uint32()&0xFFFF, rng.Uint32()&0xFFFF, rng.Uint32()&0xFFFF, rng.Uint64()&0xFFFFFFFFFFFF)
+	}
+
+	fmt.Fprint(bw, "<?xml version='1.0' encoding='windows-1252' ?>\n")
+	fmt.Fprint(bw, "<xmi:XMI xmlns:xmi=\"http://schema.omg.org/spec/XMI/2.1\" xmi:version=\"2.1\" xmlns:uml=\"http://schema.omg.org/spec/UML/2.1\">\n")
+	fmt.Fprint(bw, "\t<xmi:Documentation exporter=\"Bausteinsicht synthetic generator\" exporterVersion=\"1.0\"/>\n")
+	fmt.Fprint(bw, "\t<uml:Model xmi:type=\"uml:Model\" name=\"EA_Model\" visibility=\"public\">\n")
+
+	generatedIDs := make([]string, 0, numElements)
+	elementsPerBranch := numElements / numBranches
+	elemIdx := 0
+
+	for b := 0; b < numBranches; b++ {
+		// Nested package chain down to `depth` for this branch — mirrors
+		// real-world EA/AUTOSAR export nesting (xmi.go's maxDepth comment
+		// cites depth 23 as observed) and gives multiple top-level packages,
+		// like a real export's AUTOSAR/ReadMe/ExportConfiguration/... roots.
+		indent := "\t\t"
+		for i := 0; i < depth; i++ {
+			fmt.Fprintf(bw, "%s<packagedElement xmi:type=\"uml:Package\" xmi:id=\"%s\" name=\"Branch%d_Package%d\" visibility=\"public\">\n",
+				indent, genID("EAPK"), b, i)
+			indent += "\t"
+		}
+
+		// Leaf elements at the deepest package level of this branch, plus
+		// relationships between them (referencing earlier-generated IDs,
+		// matching how EA exports interleave packagedElement and
+		// Dependency/Association entries).
+		limit := elemIdx + elementsPerBranch
+		if b == numBranches-1 {
+			limit = numElements // last branch absorbs any remainder
+		}
+		for ; elemIdx < limit; elemIdx++ {
+			kind := syntheticElementKinds[elemIdx%len(syntheticElementKinds)]
+			id := genID("EAID")
+			generatedIDs = append(generatedIDs, id)
+
+			fmt.Fprintf(bw, "%s<packagedElement xmi:type=\"uml:%s\" xmi:id=\"%s\" name=\"Element%d\" visibility=\"public\">\n",
+				indent, kind, id, elemIdx)
+
+			if elemIdx%3 == 0 {
+				fmt.Fprintf(bw, "%s\t<ownedAttribute xmi:type=\"uml:Property\" xmi:id=\"%s\" name=\"attr%d\" visibility=\"private\"/>\n",
+					indent, genID("EAID"), elemIdx)
+			}
+			if elemIdx%4 == 0 {
+				fmt.Fprintf(bw, "%s\t<ownedComment xmi:type=\"uml:Comment\" xmi:id=\"%s\" body=\"Synthetic comment for element %d, used for scale testing only.\"/>\n",
+					indent, genID("EAID"), elemIdx)
+			}
+			if stereo := syntheticStereotypes[elemIdx%len(syntheticStereotypes)]; stereo != "" {
+				fmt.Fprintf(bw, "%s\t<xmi:Extension extender=\"Bausteinsicht synthetic generator\">\n", indent)
+				fmt.Fprintf(bw, "%s\t\t<stereotype xmi:id=\"%s\" name=\"%s\"/>\n", indent, genID("EAID"), stereo)
+				fmt.Fprintf(bw, "%s\t</xmi:Extension>\n", indent)
+			}
+
+			// Every 5th element depends on an earlier one, once enough exist.
+			if elemIdx%5 == 0 && len(generatedIDs) > 1 {
+				target := generatedIDs[rng.Intn(len(generatedIDs)-1)]
+				fmt.Fprintf(bw, "%s\t<packagedElement xmi:type=\"uml:Dependency\" xmi:id=\"%s\" name=\"dep%d\" client=\"%s\" supplier=\"%s\"/>\n",
+					indent, genID("EAID"), elemIdx, id, target)
+			}
+
+			fmt.Fprintf(bw, "%s</packagedElement>\n", indent)
+		}
+
+		// Close this branch's package chain in reverse order.
+		for i := depth - 1; i >= 0; i-- {
+			indent = indent[:len(indent)-1]
+			fmt.Fprintf(bw, "%s</packagedElement>\n", indent)
+		}
+	}
+
+	fmt.Fprint(bw, "\t</uml:Model>\n")
+	fmt.Fprint(bw, "</xmi:XMI>\n")
+
+	return bw.Flush()
+}

--- a/internal/importer/xmi/synthetic_bigdata_test.go
+++ b/internal/importer/xmi/synthetic_bigdata_test.go
@@ -16,10 +16,20 @@ var syntheticElementKinds = []string{
 }
 
 // syntheticStereotypes mirrors common AUTOSAR/EA stereotype names — applied
-// to a fraction of generated elements to exercise the stereotype-as-kind path.
+// to a fraction of generated elements to exercise the stereotype-as-kind path
+// (xmi.go's resolveKind checks stereotype before the UML-type kindMap).
 var syntheticStereotypes = []string{
-	"SWComponent", "BSWModule", "PortInterface", "ECUAbstraction", "",
+	"SWComponent", "BSWModule", "PortInterface", "ECUAbstraction",
 }
+
+// stereotypeEvery gates how often a stereotype is attached, keyed off elemIdx
+// directly rather than off the same modulus as syntheticElementKinds'
+// len(10) cycle. 7 and 10 are coprime, so which of the 10 UML kinds gets a
+// stereotype varies across elements instead of always/never pairing the same
+// kind with the same stereotype-presence — every kind still gets exercised
+// via defaultKindMap's plain UML-type path (not just the stereotype path)
+// for most of its occurrences.
+const stereotypeEvery = 7
 
 // writeSyntheticXMI writes a synthetic XMI 2.1 / UML 2.1 document to w that
 // mirrors the shape of a real large Enterprise Architect / AUTOSAR export —
@@ -86,7 +96,8 @@ func writeSyntheticXMI(w io.Writer, numElements, depth, numBranches int) error {
 				fmt.Fprintf(bw, "%s\t<ownedComment xmi:type=\"uml:Comment\" xmi:id=\"%s\" body=\"Synthetic comment for element %d, used for scale testing only.\"/>\n",
 					indent, genID("EAID"), elemIdx)
 			}
-			if stereo := syntheticStereotypes[elemIdx%len(syntheticStereotypes)]; stereo != "" {
+			if elemIdx%stereotypeEvery == 0 {
+				stereo := syntheticStereotypes[(elemIdx/stereotypeEvery)%len(syntheticStereotypes)]
 				fmt.Fprintf(bw, "%s\t<xmi:Extension extender=\"Bausteinsicht synthetic generator\">\n", indent)
 				fmt.Fprintf(bw, "%s\t\t<stereotype xmi:id=\"%s\" name=\"%s\"/>\n", indent, genID("EAID"), stereo)
 				fmt.Fprintf(bw, "%s\t</xmi:Extension>\n", indent)

--- a/internal/importer/xmi/testdata/BigData.xmi
+++ b/internal/importer/xmi/testdata/BigData.xmi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b761872b0f773caac76446b857162986761500d625c9bd3514d55bd1f63f5b0
-size 118574881

--- a/internal/importer/xmi/xmi_test.go
+++ b/internal/importer/xmi/xmi_test.go
@@ -345,7 +345,7 @@ func TestImport_XXEDoctype(t *testing.T) {
 // (AUTOSAR model, windows-1252 encoding, ~114 MB, depth >20).
 // The fixture is gitignored (not committed, not Git-LFS-tracked, see #553) —
 // fetch it with `make fetch-testdata` (scripts/fetch-xmi-testdata.sh), which
-// pulls it from the separate docToolchain/bausteinsicht-testdata repo. This
+// pulls it from the separate docToolchain/Bausteinsicht-Testdata repo. This
 // test skips itself when the fixture is absent or too small (offline/local
 // dev without having fetched it); the xmi-bigdata-integration CI job in
 // go.yml fetches it explicitly and fails if the test unexpectedly skips.

--- a/internal/importer/xmi/xmi_test.go
+++ b/internal/importer/xmi/xmi_test.go
@@ -343,7 +343,12 @@ func TestImport_XXEDoctype(t *testing.T) {
 
 // TestImport_BigData runs against a real Enterprise Architect XMI export
 // (AUTOSAR model, windows-1252 encoding, ~114 MB, depth >20).
-// The fixture is gitignored due to its size; the test is skipped in CI when absent.
+// The fixture is gitignored (not committed, not Git-LFS-tracked, see #553) —
+// fetch it with `make fetch-testdata` (scripts/fetch-xmi-testdata.sh), which
+// pulls it from the separate docToolchain/bausteinsicht-testdata repo. This
+// test skips itself when the fixture is absent or too small (offline/local
+// dev without having fetched it); the xmi-bigdata-integration CI job in
+// go.yml fetches it explicitly and fails if the test unexpectedly skips.
 func TestImport_BigData(t *testing.T) {
 	const minSize = 1 * 1024 * 1024 // 1 MB — stub is only a few hundred bytes
 	path := td("BigData.xmi")

--- a/internal/importer/xmi/xmi_test.go
+++ b/internal/importer/xmi/xmi_test.go
@@ -377,6 +377,48 @@ func TestImport_BigData(t *testing.T) {
 		len(r.Model.Specification.Elements), len(r.Warnings))
 }
 
+// TestImport_SyntheticBigData exercises the importer at the same rough scale
+// as TestImport_BigData's real export (windows-1252 encoding, nesting depth
+// ~23, tens of thousands of elements), but via a generated fixture — so
+// every CI job gets scale/depth coverage unconditionally, without depending
+// on the real fixture having been fetched (#553). Complements, not replaces,
+// TestImport_BigData: this one is always-on/synthetic for baseline coverage
+// everywhere; that one is real-file/high-fidelity, but only in the dedicated
+// xmi-bigdata-integration CI job that fetches it.
+func TestImport_SyntheticBigData(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "synthetic_bigdata.xmi")
+	f, err := os.Create(path) // #nosec G304 -- path is our own t.TempDir() file
+	if err != nil {
+		t.Fatalf("create synthetic fixture: %v", err)
+	}
+	if err := writeSyntheticXMI(f, 20000, 23, 12); err != nil {
+		t.Fatalf("generate synthetic fixture: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close synthetic fixture: %v", err)
+	}
+	if fi, err := os.Stat(path); err == nil {
+		t.Logf("synthetic fixture size: %d bytes", fi.Size())
+	}
+
+	r, err := xmi.Import(path, nil)
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+	if len(r.Model.Model) == 0 {
+		t.Error("expected non-empty model")
+	}
+	if len(r.Model.Specification.Elements) == 0 {
+		t.Error("expected non-empty specification")
+	}
+	if len(r.Model.Relationships) == 0 {
+		t.Error("expected non-empty relationships")
+	}
+	t.Logf("synthetic BigData: %d top-level elements, %d relationships, %d spec kinds, %d warnings",
+		len(r.Model.Model), len(r.Model.Relationships),
+		len(r.Model.Specification.Elements), len(r.Warnings))
+}
+
 // ─── ParseKindMap ─────────────────────────────────────────────────────────────
 
 func TestParseKindMap(t *testing.T) {

--- a/internal/importer/xmi/xmi_test.go
+++ b/internal/importer/xmi/xmi_test.go
@@ -394,7 +394,7 @@ func TestImport_SyntheticBigData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create synthetic fixture: %v", err)
 	}
-	defer f.Close() // in addition to the explicit Close below, so t.Fatalf (Goexit) can't skip it
+	defer f.Close() //nolint:errcheck // in addition to the explicit Close below, so t.Fatalf (Goexit) can't skip it
 
 	if err := writeSyntheticXMI(f, 20000, 23, 12); err != nil {
 		t.Fatalf("generate synthetic fixture: %v", err)

--- a/internal/importer/xmi/xmi_test.go
+++ b/internal/importer/xmi/xmi_test.go
@@ -372,6 +372,9 @@ func TestImport_BigData(t *testing.T) {
 	if len(r.Model.Specification.Elements) == 0 {
 		t.Error("expected non-empty specification")
 	}
+	if len(r.Model.Relationships) == 0 {
+		t.Error("expected non-empty relationships")
+	}
 	t.Logf("BigData: %d top-level elements, %d relationships, %d spec kinds, %d warnings",
 		len(r.Model.Model), len(r.Model.Relationships),
 		len(r.Model.Specification.Elements), len(r.Warnings))
@@ -391,6 +394,8 @@ func TestImport_SyntheticBigData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create synthetic fixture: %v", err)
 	}
+	defer f.Close() // in addition to the explicit Close below, so t.Fatalf (Goexit) can't skip it
+
 	if err := writeSyntheticXMI(f, 20000, 23, 12); err != nil {
 		t.Fatalf("generate synthetic fixture: %v", err)
 	}

--- a/scripts/fetch-xmi-testdata.sh
+++ b/scripts/fetch-xmi-testdata.sh
@@ -34,11 +34,10 @@ if [ -f "$DEST" ] && [ "$(file_size "$DEST")" -gt "$MIN_SIZE" ]; then
 fi
 
 echo "Fetching BigData.xmi from docToolchain/bausteinsicht-testdata..."
-if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL"; then
-    mv "$DEST.tmp" "$DEST"
+if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL" && mv "$DEST.tmp" "$DEST"; then
     echo "Fetched BigData.xmi ($(file_size "$DEST") bytes)."
 else
-    echo "Warning: could not fetch BigData.xmi from $URL (network issue or fixture repo unavailable)." >&2
+    echo "Warning: could not fetch/place BigData.xmi from $URL (network issue, fixture repo unavailable, or move failed)." >&2
     echo "TestImport_BigData will skip itself; this is not treated as a hard failure here." >&2
     rm -f "$DEST.tmp"
 fi

--- a/scripts/fetch-xmi-testdata.sh
+++ b/scripts/fetch-xmi-testdata.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# scripts/fetch-xmi-testdata.sh — fetch the large XMI integration-test
+# fixture (internal/importer/xmi/testdata/BigData.xmi, a real ~118MB
+# Enterprise Architect/AUTOSAR export) from the separate, lightweight
+# docToolchain/bausteinsicht-testdata repo, instead of committing or
+# Git-LFS-tracking it in this repository (#553).
+#
+# Usage:
+#   scripts/fetch-xmi-testdata.sh
+#   make fetch-testdata
+#
+# Safe to run repeatedly: skips the download if a real (>1MB) file is
+# already present. Safe to fail: on any network/fetch error it prints a
+# warning and exits 0 rather than failing the caller — internal/importer/xmi's
+# TestImport_BigData already skips itself when the fixture is absent or too
+# small, so offline/local dev is never blocked by this script. CI jobs that
+# specifically need the fixture (see the xmi-bigdata-integration job in
+# go.yml) check the test actually ran, so a silent fetch failure there is
+# still caught — it just fails that one dedicated job, not the whole build.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEST="$ROOT/internal/importer/xmi/testdata/BigData.xmi"
+URL="https://raw.githubusercontent.com/docToolchain/bausteinsicht-testdata/main/BigData.xmi"
+MIN_SIZE=1048576 # 1 MiB — matches TestImport_BigData's own presence check
+
+file_size() {
+    stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0
+}
+
+if [ -f "$DEST" ] && [ "$(file_size "$DEST")" -gt "$MIN_SIZE" ]; then
+    echo "BigData.xmi already present ($(file_size "$DEST") bytes), skipping fetch."
+    exit 0
+fi
+
+echo "Fetching BigData.xmi from docToolchain/bausteinsicht-testdata..."
+if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL"; then
+    mv "$DEST.tmp" "$DEST"
+    echo "Fetched BigData.xmi ($(file_size "$DEST") bytes)."
+else
+    echo "Warning: could not fetch BigData.xmi from $URL (network issue or fixture repo unavailable)." >&2
+    echo "TestImport_BigData will skip itself; this is not treated as a hard failure here." >&2
+    rm -f "$DEST.tmp"
+fi

--- a/scripts/fetch-xmi-testdata.sh
+++ b/scripts/fetch-xmi-testdata.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # scripts/fetch-xmi-testdata.sh — fetch the large XMI integration-test
 # fixture (internal/importer/xmi/testdata/BigData.xmi, a real ~118MB
-# Enterprise Architect/AUTOSAR export) from the separate, lightweight
-# docToolchain/bausteinsicht-testdata repo, instead of committing or
-# Git-LFS-tracking it in this repository (#553).
+# Enterprise Architect/AUTOSAR export) from a GitHub Release asset on the
+# separate, lightweight docToolchain/Bausteinsicht-Testdata repo, instead of
+# committing or Git-LFS-tracking it in this repository (#553). A Release
+# asset (not a committed/raw file) because the fixture is ~118MB — over
+# GitHub's ~100MB per-file limit for a normal git blob.
 #
 # Usage:
 #   scripts/fetch-xmi-testdata.sh
@@ -21,7 +23,7 @@ set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/internal/importer/xmi/testdata/BigData.xmi"
-URL="https://raw.githubusercontent.com/docToolchain/bausteinsicht-testdata/main/BigData.xmi"
+URL="https://github.com/docToolchain/Bausteinsicht-Testdata/releases/download/testdata-v1/BigData.xmi"
 MIN_SIZE=1048576 # 1 MiB — matches TestImport_BigData's own presence check
 
 file_size() {
@@ -33,7 +35,7 @@ if [ -f "$DEST" ] && [ "$(file_size "$DEST")" -gt "$MIN_SIZE" ]; then
     exit 0
 fi
 
-echo "Fetching BigData.xmi from docToolchain/bausteinsicht-testdata..."
+echo "Fetching BigData.xmi from docToolchain/Bausteinsicht-Testdata (release testdata-v1)..."
 if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL" && mv "$DEST.tmp" "$DEST"; then
     echo "Fetched BigData.xmi ($(file_size "$DEST") bytes)."
 else


### PR DESCRIPTION
## Summary
`internal/importer/xmi/testdata/BigData.xmi` (~118MB, a real Enterprise Architect/AUTOSAR export) was Git-LFS-tracked, but no `actions/checkout` step anywhere set `lfs: true` — every CI checkout only ever saw the ~130-byte LFS pointer, not the real file. `TestImport_BigData`'s own >1MB presence check correctly (and silently) skipped the integration test as a result, in every CI run since LFS was introduced, unnoticed.

- Removed the LFS dependency entirely: untracked `BigData.xmi`, removed the `.gitattributes` LFS filter entry, gitignored the path.
- Added `scripts/fetch-xmi-testdata.sh` (+ `make fetch-testdata`) to fetch the real fixture on demand from a separate, lightweight repo (`docToolchain/bausteinsicht-testdata`) — plain HTTP fetch, no git submodule, no LFS, fails gracefully (exits 0 with a warning) when unreachable.
- Added a dedicated `xmi-bigdata-integration` CI job that fetches the fixture and explicitly fails if `TestImport_BigData` skips — so the "silently never actually running" failure mode can't recur unnoticed. Isolated from `build-and-test`/`test-race`/`coverage` so the ~118MB download happens once, not multiplied across every OS/test job.
- Added `TestImport_SyntheticBigData`: a deterministic generator (`writeSyntheticXMI`) producing a structurally equivalent XMI document (windows-1252, ~23 levels deep, ~20k elements, mixed types/stereotypes/relationships) at test time — no network dependency, ~11MB, race-safe. This means every CI job gets scale/depth coverage unconditionally, even if the fixture repo is ever unreachable; the real-file test provides additional high-fidelity coverage specifically in the dedicated job.
- Re-added a scoped `.gitleaks.toml` allowlist for the case where a contributor has fetched the real fixture locally and then runs `make gitleaks`/pre-commit (which scan the working directory regardless of `.gitignore`).

Closes #553.

**Action needed from a maintainer with org rights:** create `docToolchain/bausteinsicht-testdata` (public) and upload the real `BigData.xmi` there (available in this repo's `.git/lfs/objects` cache) — the fetch script expects it at `https://raw.githubusercontent.com/docToolchain/bausteinsicht-testdata/main/BigData.xmi`. Until then, `xmi-bigdata-integration` will fail (expected — the whole point is that it now fails loudly instead of silently skipping).

## Test plan
- [x] `go build ./...` / `go test ./...` / `gofmt -l .` all clean
- [x] `go test -race ./internal/importer/xmi/...` — both BigData tests pass, no OOM (~8s)
- [x] `TestImport_SyntheticBigData` verified: generates ~11MB, 12 top-level elements, 3999 relationships, non-empty spec
- [x] `TestImport_BigData` verified to skip gracefully when the fixture is absent (current state, until the new repo exists)
- [x] `scripts/fetch-xmi-testdata.sh` verified to fail gracefully (exit 0, warning) against a nonexistent URL
- [ ] Once `docToolchain/bausteinsicht-testdata` exists, confirm `xmi-bigdata-integration` actually fetches and passes (not skips) in a real Action run

🤖 Generated with [Claude Code](https://claude.com/claude-code)