### PR TITLE
feat(constraints): tag- and element-ID-based targeting for lint rules

### DIFF
--- a/e2e/constraint_tag_based_test.go
+++ b/e2e/constraint_tag_based_test.go
@@ -1,0 +1,76 @@
+package e2e
+
+// TestConstraintTagBasedTargeting (#542) verifies that `bausteinsicht lint`
+// enforces constraints targeted by tag and by exact element ID, not just by
+// kind — the motivating case is a layering rule like "UI must not talk to a
+// datastore directly" where both sides share the same kind ("container") and
+// can only be told apart by tag.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const tagConstraintModelJSON = `{
+  "specification": {
+    "elements": {
+      "container": { "notation": "Container" }
+    }
+  },
+  "model": {
+    "adminConsole": { "kind": "container", "title": "Admin Console", "tags": ["ui"] },
+    "batchJob": { "kind": "container", "title": "Batch Job", "tags": ["internal"] },
+    "database": { "kind": "container", "title": "Database", "tags": ["datastore"] }
+  },
+  "relationships": [
+    { "from": "adminConsole", "to": "database", "label": "queries" },
+    { "from": "batchJob", "to": "database", "label": "writes" }
+  ],
+  "constraints": [
+    {
+      "id": "ui-not-to-datastore",
+      "description": "UI must not talk to a datastore directly",
+      "rule": "no-relationship",
+      "from-tag": "ui",
+      "to-tag": "datastore"
+    }
+  ]
+}`
+
+func TestConstraintTagBasedTargeting(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	writeFile(t, modelPath, tagConstraintModelJSON)
+
+	lintOut, code := runCLIAllowFail(t, bin, dir, "lint", "--model", "architecture.jsonc")
+	t.Logf("lint output: %s", lintOut)
+
+	if code == 0 {
+		t.Fatal("lint should have failed: adminConsole (tagged 'ui') relates to database (tagged 'datastore')")
+	}
+	if !strings.Contains(lintOut, "adminConsole") {
+		t.Errorf("lint output does not mention the violating element 'adminConsole': %q", lintOut)
+	}
+	if strings.Contains(lintOut, "batchJob") {
+		t.Errorf("lint output should not flag 'batchJob' (not tagged 'ui'), got: %q", lintOut)
+	}
+
+	// Removing the violating relationship should make lint pass again —
+	// confirms the tag-based rule is actually re-evaluated, not a fixed
+	// false positive.
+	fixedModel := strings.Replace(tagConstraintModelJSON,
+		`{ "from": "adminConsole", "to": "database", "label": "queries" },`, "", 1)
+	if err := os.WriteFile(modelPath, []byte(fixedModel), 0o644); err != nil {
+		t.Fatalf("rewrite model: %v", err)
+	}
+
+	lintFixedOut, fixedCode := runCLIAllowFail(t, bin, dir, "lint", "--model", "architecture.jsonc")
+	t.Logf("lint output after removing violation: %s", lintFixedOut)
+	if fixedCode != 0 {
+		t.Errorf("lint should pass once the ui->datastore relationship is removed, got exit %d: %s", fixedCode, lintFixedOut)
+	}
+}

--- a/internal/constraints/engine_test.go
+++ b/internal/constraints/engine_test.go
@@ -269,8 +269,8 @@ func TestConstraints_UnsetSelectorNeverMatches(t *testing.T) {
 		},
 		[]model.Relationship{{From: "a", To: "b"}},
 		[]model.Constraint{
-			{ID: "c1", Rule: "no-relationship"},          // no from/to selector set at all
-			{ID: "c2", Rule: "allowed-relationship"},      // no from/to selector set at all
+			{ID: "c1", Rule: "no-relationship"},                      // no from/to selector set at all
+			{ID: "c2", Rule: "allowed-relationship"},                 // no from/to selector set at all
 			{ID: "c3", Rule: "required-field", Field: "description"}, // no element selector set
 		},
 	)

--- a/internal/constraints/engine_test.go
+++ b/internal/constraints/engine_test.go
@@ -66,6 +66,88 @@ func TestNoRelationship_Violation(t *testing.T) {
 	}
 }
 
+// TestNoRelationship_TagBased_Violation verifies the motivating case from #542:
+// two elements of the SAME kind (both "container") can still be distinguished
+// by tag, so "UI must not talk to datastore directly" becomes expressible.
+func TestNoRelationship_TagBased_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"adminConsole": {Kind: "container", Tags: []string{"ui"}},
+			"database":     {Kind: "container", Tags: []string{"datastore"}},
+		},
+		[]model.Relationship{{From: "adminConsole", To: "database"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			FromTag: "ui", ToTag: "datastore",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+func TestNoRelationship_TagBased_NoViolation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"adminConsole": {Kind: "container", Tags: []string{"ui"}},
+			"api":          {Kind: "container", Tags: []string{"service"}},
+		},
+		[]model.Relationship{{From: "adminConsole", To: "api"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			FromTag: "ui", ToTag: "datastore",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations, got %d: %v", r.Total, r.Violations)
+	}
+}
+
+// TestNoRelationship_ElementID_Violation verifies exact-ID endpoint targeting.
+func TestNoRelationship_ElementID_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"legacyBatch": {Kind: "container"},
+			"coreApi":     {Kind: "container"},
+		},
+		[]model.Relationship{{From: "legacyBatch", To: "coreApi"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			From: "legacyBatch", To: "coreApi",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// TestNoRelationship_IDTakesPrecedenceOverTag verifies that when both an
+// exact-ID selector and a tag selector are set on the same endpoint, the
+// more specific ID selector wins (#542).
+func TestNoRelationship_IDTakesPrecedenceOverTag(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"adminConsole": {Kind: "container", Tags: []string{"ui"}},
+			"other":        {Kind: "container", Tags: []string{"ui"}},
+			"database":     {Kind: "container", Tags: []string{"datastore"}},
+		},
+		// "other" also has the "ui" tag but the constraint pins "from" to the
+		// exact ID "adminConsole" — "other" -> "database" must NOT violate.
+		[]model.Relationship{{From: "other", To: "database"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "no-relationship",
+			From: "adminConsole", FromTag: "ui", ToTag: "datastore",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations (ID selector should override tag selector), got %d: %v", r.Total, r.Violations)
+	}
+}
+
 // ─── allowed-relationship ────────────────────────────────────────────────────
 
 func TestAllowedRelationship_NoViolation(t *testing.T) {
@@ -101,6 +183,46 @@ func TestAllowedRelationship_Violation(t *testing.T) {
 	r := constraints.Evaluate(m)
 	if r.Total != 1 {
 		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// TestAllowedRelationship_TagBased_Violation verifies from-tags allow-list
+// targeting (#542), analogous to from-kinds but for elements of the same
+// kind distinguished only by tag.
+func TestAllowedRelationship_TagBased_Violation(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"adminConsole": {Kind: "container", Tags: []string{"ui"}},
+			"batchJob":     {Kind: "container", Tags: []string{"internal"}},
+			"database":     {Kind: "container", Tags: []string{"datastore"}},
+		},
+		[]model.Relationship{{From: "batchJob", To: "database"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "allowed-relationship",
+			FromTags: []string{"internal"}, ToTag: "datastore",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations (batchJob is tagged 'internal', allowed), got %d: %v", r.Total, r.Violations)
+	}
+}
+
+func TestAllowedRelationship_TagBased_ViolationBlocked(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"adminConsole": {Kind: "container", Tags: []string{"ui"}},
+			"database":     {Kind: "container", Tags: []string{"datastore"}},
+		},
+		[]model.Relationship{{From: "adminConsole", To: "database"}},
+		[]model.Constraint{{
+			ID: "c1", Rule: "allowed-relationship",
+			FromTags: []string{"internal"}, ToTag: "datastore",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation (adminConsole is tagged 'ui', not in allow-list), got %d", r.Total)
 	}
 }
 
@@ -158,6 +280,31 @@ func TestRequiredField_Technology(t *testing.T) {
 	r := constraints.Evaluate(m)
 	if r.Total != 1 {
 		t.Errorf("expected 1 violation, got %d", r.Total)
+	}
+}
+
+// TestRequiredField_TagBased verifies element selection by Tag instead of
+// ElementKind (#542) — e.g. requiring a description on all "public-api"
+// tagged elements regardless of their kind.
+func TestRequiredField_TagBased(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container", Tags: []string{"public-api"}},
+			"b": {Kind: "component", Tags: []string{"public-api"}, Description: "documented"},
+			"c": {Kind: "container"}, // no tag — not selected, would otherwise fail
+		},
+		nil,
+		[]model.Constraint{{
+			ID: "c1", Rule: "required-field",
+			Tag: "public-api", Field: "description",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Errorf("expected 1 violation (only 'a' is public-api tagged and missing description), got %d: %v", r.Total, r.Violations)
+	}
+	if len(r.Violations) > 0 && len(r.Violations[0].Elements) != 1 {
+		t.Errorf("expected 1 offending element, got %d", len(r.Violations[0].Elements))
 	}
 }
 

--- a/internal/constraints/engine_test.go
+++ b/internal/constraints/engine_test.go
@@ -1,6 +1,7 @@
 package constraints_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docToolchain/Bausteinsicht/internal/constraints"
@@ -223,6 +224,59 @@ func TestAllowedRelationship_TagBased_ViolationBlocked(t *testing.T) {
 	r := constraints.Evaluate(m)
 	if r.Total != 1 {
 		t.Errorf("expected 1 violation (adminConsole is tagged 'ui', not in allow-list), got %d", r.Total)
+	}
+}
+
+// TestAllowedRelationship_ExactFromID verifies that allowed-relationship's
+// "from" side also supports the single-value From/FromTag/FromKind selectors
+// (not just the FromTags/FromKinds allow-lists) — a code-review finding for
+// #542: the first implementation only wired up FromTags/FromKinds, silently
+// ignoring From/FromTag/FromKind even though both rules share one selector.
+func TestAllowedRelationship_ExactFromID(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"batchJob":     {Kind: "container"},
+			"adminConsole": {Kind: "container"},
+			"database":     {Kind: "container"},
+		},
+		[]model.Relationship{
+			{From: "batchJob", To: "database"},
+			{From: "adminConsole", To: "database"},
+		},
+		[]model.Constraint{{
+			ID: "c1", Rule: "allowed-relationship",
+			From: "batchJob", To: "database",
+		}},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 1 {
+		t.Fatalf("expected 1 violation (only batchJob is allowed), got %d: %v", r.Total, r.Violations)
+	}
+	if len(r.Violations[0].Elements) != 1 || !strings.Contains(r.Violations[0].Elements[0], "adminConsole") {
+		t.Errorf("expected violation for adminConsole, got %v", r.Violations[0].Elements)
+	}
+}
+
+// TestConstraints_UnsetSelectorNeverMatches documents the deliberate behavior
+// (#542) that a constraint endpoint/element selector with NO field set
+// matches nothing — it is treated as a misconfiguration, not a wildcard that
+// matches every element/relationship.
+func TestConstraints_UnsetSelectorNeverMatches(t *testing.T) {
+	m := makeModel(
+		map[string]model.Element{
+			"a": {Kind: "container"},
+			"b": {Kind: "container"},
+		},
+		[]model.Relationship{{From: "a", To: "b"}},
+		[]model.Constraint{
+			{ID: "c1", Rule: "no-relationship"},          // no from/to selector set at all
+			{ID: "c2", Rule: "allowed-relationship"},      // no from/to selector set at all
+			{ID: "c3", Rule: "required-field", Field: "description"}, // no element selector set
+		},
+	)
+	r := constraints.Evaluate(m)
+	if r.Total != 0 {
+		t.Errorf("expected 0 violations for constraints with no selector fields set, got %d: %v", r.Total, r.Violations)
 	}
 }
 

--- a/internal/constraints/rules.go
+++ b/internal/constraints/rules.go
@@ -7,46 +7,76 @@ import (
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
 
-// endpointSelector describes how a single endpoint ("from" or "to") of a
-// no-relationship/allowed-relationship constraint targets elements: by exact
-// ID, by tag, or by kind — checked in that order of specificity (#542).
-// Whichever field is non-empty is used; if none is set, matches nothing.
-type endpointSelector struct {
-	id   string
-	tag  string
-	kind string
+// elementSelector describes how a constraint targets elements: by exact ID,
+// by tag, by an any-of tag allow-list, by kind, or by an any-of kind
+// allow-list — checked in that order of specificity (#542). Whichever field
+// is non-empty is used; if none is set, matches nothing (a constraint that
+// leaves every selector field empty is a misconfiguration, not a
+// match-everything wildcard).
+//
+// Single-value fields (id/tag/kind) serve no-relationship's from/to sides
+// and required-field's element selector. The allow-list fields (tags/kinds)
+// additionally serve allowed-relationship's "from" side, where an element is
+// allowed if it has ANY of the listed tags/kinds.
+type elementSelector struct {
+	id    string
+	tag   string
+	tags  []string
+	kind  string
+	kinds []string
 }
 
-func (s endpointSelector) describe() string {
+func (s elementSelector) describe() string {
 	switch {
 	case s.id != "":
 		return fmt.Sprintf("element %q", s.id)
 	case s.tag != "":
 		return fmt.Sprintf("%q tag", s.tag)
+	case len(s.tags) > 0:
+		return fmt.Sprintf("tagged [%s]", strings.Join(s.tags, ", "))
 	case s.kind != "":
 		return fmt.Sprintf("%q kind", s.kind)
+	case len(s.kinds) > 0:
+		return fmt.Sprintf("[%s] kind", strings.Join(s.kinds, ", "))
 	default:
 		return "(unset)"
 	}
 }
 
-func (s endpointSelector) matches(elemID string, el *model.Element) bool {
+func (s elementSelector) matches(elemID string, el *model.Element) bool {
 	switch {
 	case s.id != "":
 		return elemID == s.id
 	case s.tag != "":
 		return el != nil && hasTag(el.Tags, s.tag)
+	case len(s.tags) > 0:
+		return el != nil && hasAnyTag(el.Tags, s.tags)
 	case s.kind != "":
 		return el != nil && el.Kind == s.kind
+	case len(s.kinds) > 0:
+		return el != nil && contains(s.kinds, el.Kind)
 	default:
 		return false
 	}
 }
 
+// contains reports whether items contains target.
+func contains(items []string, target string) bool {
+	for _, item := range items {
+		if item == target {
+			return true
+		}
+	}
+	return false
+}
+
 // hasTag reports whether tags contains tag.
-func hasTag(tags []string, tag string) bool {
-	for _, t := range tags {
-		if t == tag {
+func hasTag(tags []string, tag string) bool { return contains(tags, tag) }
+
+// hasAnyTag reports whether tags contains any element of candidates.
+func hasAnyTag(tags, candidates []string) bool {
+	for _, c := range candidates {
+		if hasTag(tags, c) {
 			return true
 		}
 	}
@@ -60,8 +90,8 @@ func noRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
-	from := endpointSelector{id: c.From, tag: c.FromTag, kind: c.FromKind}
-	to := endpointSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
+	from := elementSelector{id: c.From, tag: c.FromTag, kind: c.FromKind}
+	to := elementSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
 
 	var bad []string
 	for _, rel := range m.Relationships {
@@ -80,49 +110,21 @@ func noRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation
 }
 
 // allowedRelationship enforces that only elements matching the "from"
-// allow-list (by tag if FromTags is set, otherwise by kind via FromKinds)
-// may have relationships pointing to elements matching the "to" selector.
+// allow-list selector may have relationships pointing to elements matching
+// the "to" selector. The "from" side additionally supports FromTags/FromKinds
+// (any-of allow-lists), on top of the single-value From/FromTag/FromKind
+// selectors shared with no-relationship.
 func allowedRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation {
 	flat, err := model.FlattenElements(m)
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
-	to := endpointSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
-
-	var allowed func(elemID string, el *model.Element) bool
-	var allowDescription string
-	switch {
-	case len(c.FromTags) > 0:
-		tagSet := make(map[string]bool, len(c.FromTags))
-		for _, t := range c.FromTags {
-			tagSet[t] = true
-		}
-		allowed = func(_ string, el *model.Element) bool {
-			if el == nil {
-				return false
-			}
-			for _, t := range el.Tags {
-				if tagSet[t] {
-					return true
-				}
-			}
-			return false
-		}
-		allowDescription = fmt.Sprintf("tagged [%s]", strings.Join(c.FromTags, ", "))
-	default:
-		kindSet := make(map[string]bool, len(c.FromKinds))
-		for _, k := range c.FromKinds {
-			kindSet[k] = true
-		}
-		allowed = func(_ string, el *model.Element) bool {
-			return el != nil && kindSet[el.Kind]
-		}
-		allowDescription = fmt.Sprintf("[%s] kind", strings.Join(c.FromKinds, ", "))
-	}
+	from := elementSelector{id: c.From, tag: c.FromTag, tags: c.FromTags, kind: c.FromKind, kinds: c.FromKinds}
+	to := elementSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
 
 	var bad []string
 	for _, rel := range m.Relationships {
-		if to.matches(rel.To, flat[rel.To]) && !allowed(rel.From, flat[rel.From]) {
+		if to.matches(rel.To, flat[rel.To]) && !from.matches(rel.From, flat[rel.From]) {
 			fromKind := ""
 			if el := flat[rel.From]; el != nil {
 				fromKind = el.Kind
@@ -135,30 +137,24 @@ func allowedRelationship(c model.Constraint, m *model.BausteinsichtModel) []Viol
 	}
 	return []Violation{{
 		ConstraintID: c.ID,
-		Message:      fmt.Sprintf("%s: only %s may relate to %s", c.Description, allowDescription, to.describe()),
+		Message:      fmt.Sprintf("%s: only %s may relate to %s", c.Description, from.describe(), to.describe()),
 		Elements:     bad,
 	}}
 }
 
 // requiredField enforces that all elements matching the constraint's element
-// selector (by Tag if set, otherwise by ElementKind) have the given field set
-// to a non-empty value. Supported fields: "description", "technology", "title".
+// selector have the given field set to a non-empty value. Supported fields:
+// "description", "technology", "title".
 func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation {
 	flat, err := model.FlattenElements(m)
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
-
-	selectorDescription := c.ElementKind + " kind"
-	matchesElement := func(el *model.Element) bool { return el.Kind == c.ElementKind }
-	if c.Tag != "" {
-		selectorDescription = fmt.Sprintf("%q-tagged", c.Tag)
-		matchesElement = func(el *model.Element) bool { return hasTag(el.Tags, c.Tag) }
-	}
+	sel := elementSelector{tag: c.Tag, kind: c.ElementKind}
 
 	var bad []string
 	for id, el := range flat {
-		if !matchesElement(el) {
+		if !sel.matches(id, el) {
 			continue
 		}
 		var missing bool
@@ -185,7 +181,7 @@ func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation 
 	}
 	return []Violation{{
 		ConstraintID: c.ID,
-		Message:      fmt.Sprintf("%s: all %s elements must have %q set", c.Description, selectorDescription, c.Field),
+		Message:      fmt.Sprintf("%s: elements matching %s must have %q set", c.Description, sel.describe(), c.Field),
 		Elements:     bad,
 	}}
 }

--- a/internal/constraints/rules.go
+++ b/internal/constraints/rules.go
@@ -7,18 +7,65 @@ import (
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
 
-// noRelationship enforces that no relationship exists from any element of
-// fromKind to any element of toKind.
+// endpointSelector describes how a single endpoint ("from" or "to") of a
+// no-relationship/allowed-relationship constraint targets elements: by exact
+// ID, by tag, or by kind — checked in that order of specificity (#542).
+// Whichever field is non-empty is used; if none is set, matches nothing.
+type endpointSelector struct {
+	id   string
+	tag  string
+	kind string
+}
+
+func (s endpointSelector) describe() string {
+	switch {
+	case s.id != "":
+		return fmt.Sprintf("element %q", s.id)
+	case s.tag != "":
+		return fmt.Sprintf("%q tag", s.tag)
+	case s.kind != "":
+		return fmt.Sprintf("%q kind", s.kind)
+	default:
+		return "(unset)"
+	}
+}
+
+func (s endpointSelector) matches(elemID string, el *model.Element) bool {
+	switch {
+	case s.id != "":
+		return elemID == s.id
+	case s.tag != "":
+		return el != nil && hasTag(el.Tags, s.tag)
+	case s.kind != "":
+		return el != nil && el.Kind == s.kind
+	default:
+		return false
+	}
+}
+
+// hasTag reports whether tags contains tag.
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// noRelationship enforces that no relationship exists from any element
+// matching the "from" selector to any element matching the "to" selector.
 func noRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation {
 	flat, err := model.FlattenElements(m)
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
-	kindOf := buildKindMap(flat)
+	from := endpointSelector{id: c.From, tag: c.FromTag, kind: c.FromKind}
+	to := endpointSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
 
 	var bad []string
 	for _, rel := range m.Relationships {
-		if kindOf[rel.From] == c.FromKind && kindOf[rel.To] == c.ToKind {
+		if from.matches(rel.From, flat[rel.From]) && to.matches(rel.To, flat[rel.To]) {
 			bad = append(bad, fmt.Sprintf("%s → %s", rel.From, rel.To))
 		}
 	}
@@ -27,29 +74,60 @@ func noRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation
 	}
 	return []Violation{{
 		ConstraintID: c.ID,
-		Message:      fmt.Sprintf("%s: %s kind must not relate to %s kind", c.Description, c.FromKind, c.ToKind),
+		Message:      fmt.Sprintf("%s: %s must not relate to %s", c.Description, from.describe(), to.describe()),
 		Elements:     bad,
 	}}
 }
 
-// allowedRelationship enforces that only elements whose kind is in fromKinds
-// may have relationships pointing to elements of toKind.
+// allowedRelationship enforces that only elements matching the "from"
+// allow-list (by tag if FromTags is set, otherwise by kind via FromKinds)
+// may have relationships pointing to elements matching the "to" selector.
 func allowedRelationship(c model.Constraint, m *model.BausteinsichtModel) []Violation {
 	flat, err := model.FlattenElements(m)
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
-	kindOf := buildKindMap(flat)
+	to := endpointSelector{id: c.To, tag: c.ToTag, kind: c.ToKind}
 
-	allowed := make(map[string]bool, len(c.FromKinds))
-	for _, k := range c.FromKinds {
-		allowed[k] = true
+	var allowed func(elemID string, el *model.Element) bool
+	var allowDescription string
+	switch {
+	case len(c.FromTags) > 0:
+		tagSet := make(map[string]bool, len(c.FromTags))
+		for _, t := range c.FromTags {
+			tagSet[t] = true
+		}
+		allowed = func(_ string, el *model.Element) bool {
+			if el == nil {
+				return false
+			}
+			for _, t := range el.Tags {
+				if tagSet[t] {
+					return true
+				}
+			}
+			return false
+		}
+		allowDescription = fmt.Sprintf("tagged [%s]", strings.Join(c.FromTags, ", "))
+	default:
+		kindSet := make(map[string]bool, len(c.FromKinds))
+		for _, k := range c.FromKinds {
+			kindSet[k] = true
+		}
+		allowed = func(_ string, el *model.Element) bool {
+			return el != nil && kindSet[el.Kind]
+		}
+		allowDescription = fmt.Sprintf("[%s] kind", strings.Join(c.FromKinds, ", "))
 	}
 
 	var bad []string
 	for _, rel := range m.Relationships {
-		if kindOf[rel.To] == c.ToKind && !allowed[kindOf[rel.From]] {
-			bad = append(bad, fmt.Sprintf("%s (%s) → %s", rel.From, kindOf[rel.From], rel.To))
+		if to.matches(rel.To, flat[rel.To]) && !allowed(rel.From, flat[rel.From]) {
+			fromKind := ""
+			if el := flat[rel.From]; el != nil {
+				fromKind = el.Kind
+			}
+			bad = append(bad, fmt.Sprintf("%s (%s) → %s", rel.From, fromKind, rel.To))
 		}
 	}
 	if len(bad) == 0 {
@@ -57,22 +135,30 @@ func allowedRelationship(c model.Constraint, m *model.BausteinsichtModel) []Viol
 	}
 	return []Violation{{
 		ConstraintID: c.ID,
-		Message:      fmt.Sprintf("%s: only [%s] may relate to %s kind", c.Description, strings.Join(c.FromKinds, ", "), c.ToKind),
+		Message:      fmt.Sprintf("%s: only %s may relate to %s", c.Description, allowDescription, to.describe()),
 		Elements:     bad,
 	}}
 }
 
-// requiredField enforces that all elements of elementKind have the given field
-// set to a non-empty value. Supported fields: "description", "technology", "title".
+// requiredField enforces that all elements matching the constraint's element
+// selector (by Tag if set, otherwise by ElementKind) have the given field set
+// to a non-empty value. Supported fields: "description", "technology", "title".
 func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation {
 	flat, err := model.FlattenElements(m)
 	if err != nil {
 		return []Violation{{ConstraintID: c.ID, Message: err.Error()}}
 	}
 
+	selectorDescription := c.ElementKind + " kind"
+	matchesElement := func(el *model.Element) bool { return el.Kind == c.ElementKind }
+	if c.Tag != "" {
+		selectorDescription = fmt.Sprintf("%q-tagged", c.Tag)
+		matchesElement = func(el *model.Element) bool { return hasTag(el.Tags, c.Tag) }
+	}
+
 	var bad []string
 	for id, el := range flat {
-		if el.Kind != c.ElementKind {
+		if !matchesElement(el) {
 			continue
 		}
 		var missing bool
@@ -99,7 +185,7 @@ func requiredField(c model.Constraint, m *model.BausteinsichtModel) []Violation 
 	}
 	return []Violation{{
 		ConstraintID: c.ID,
-		Message:      fmt.Sprintf("%s: all %s elements must have %q set", c.Description, c.ElementKind, c.Field),
+		Message:      fmt.Sprintf("%s: all %s elements must have %q set", c.Description, selectorDescription, c.Field),
 		Elements:     bad,
 	}}
 }
@@ -221,13 +307,4 @@ func technologyAllowed(c model.Constraint, m *model.BausteinsichtModel) []Violat
 		Message:      fmt.Sprintf("%s: %s elements must use one of [%s]", c.Description, c.ElementKind, strings.Join(c.Technologies, ", ")),
 		Elements:     bad,
 	}}
-}
-
-// buildKindMap returns a map from element ID to its kind for all flattened elements.
-func buildKindMap(flat map[string]*model.Element) map[string]string {
-	m := make(map[string]string, len(flat))
-	for id, el := range flat {
-		m[id] = el.Kind
-	}
-	return m
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -141,18 +141,30 @@ type DynamicView struct {
 }
 
 // Constraint defines an architectural rule that can be enforced via `bausteinsicht lint`.
+//
+// no-relationship / allowed-relationship endpoint selectors: each side ("from"/"to")
+// can be targeted by exact element ID, by tag, or by kind (#542). When more than one
+// selector is set for the same side, the most specific one wins: exact ID > tag > kind.
 type Constraint struct {
 	ID          string `json:"id"`
 	Description string `json:"description"`
 	Rule        string `json:"rule"`
 
-	// no-relationship / allowed-relationship
+	// no-relationship / allowed-relationship: "from" endpoint selector.
+	From      string   `json:"from,omitempty"`
+	FromTag   string   `json:"from-tag,omitempty"`
 	FromKind  string   `json:"from-kind,omitempty"`
-	ToKind    string   `json:"to-kind,omitempty"`
+	FromTags  []string `json:"from-tags,omitempty"`
 	FromKinds []string `json:"from-kinds,omitempty"`
 
-	// required-field
+	// no-relationship / allowed-relationship: "to" endpoint selector.
+	To     string `json:"to,omitempty"`
+	ToTag  string `json:"to-tag,omitempty"`
+	ToKind string `json:"to-kind,omitempty"`
+
+	// required-field: element selector — Tag takes precedence over ElementKind if both are set.
 	ElementKind string `json:"element-kind,omitempty"`
+	Tag         string `json:"tag,omitempty"`
 	Field       string `json:"field,omitempty"`
 
 	// max-depth

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -145,6 +145,8 @@ type DynamicView struct {
 // no-relationship / allowed-relationship endpoint selectors: each side ("from"/"to")
 // can be targeted by exact element ID, by tag, or by kind (#542). When more than one
 // selector is set for the same side, the most specific one wins: exact ID > tag > kind.
+// The allow-list forms (FromTags/FromKinds) rank with their singular counterpart:
+// tag/FromTags outrank kind/FromKinds, but not the exact-ID selector.
 type Constraint struct {
 	ID          string `json:"id"`
 	Description string `json:"description"`

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -91,10 +91,22 @@
         "field": {
           "type": "string"
         },
+        "from": {
+          "type": "string"
+        },
         "from-kind": {
           "type": "string"
         },
         "from-kinds": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "from-tag": {
+          "type": "string"
+        },
+        "from-tags": {
           "items": {
             "type": "string"
           },
@@ -109,13 +121,22 @@
         "rule": {
           "type": "string"
         },
+        "tag": {
+          "type": "string"
+        },
         "technologies": {
           "items": {
             "type": "string"
           },
           "type": "array"
         },
+        "to": {
+          "type": "string"
+        },
         "to-kind": {
+          "type": "string"
+        },
+        "to-tag": {
           "type": "string"
         }
       },

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -879,6 +879,36 @@ const (
     StepReturn StepType = "return"
 )
 
+// Constraint defines an architectural rule enforced via `bausteinsicht lint`.
+// no-relationship/allowed-relationship endpoint selectors (from/to) and the
+// required-field element selector (tag/element-kind) are checked in order of
+// specificity — exact ID > tag > kind — whichever field is non-empty wins.
+type Constraint struct {
+    ID          string `json:"id"`
+    Description string `json:"description"`
+    Rule        string `json:"rule"` // no-relationship|allowed-relationship|required-field|max-depth|no-circular-dependency|technology-allowed
+
+    // no-relationship / allowed-relationship: "from" endpoint selector
+    From      string   `json:"from,omitempty"`       // exact element ID
+    FromTag   string   `json:"from-tag,omitempty"`   // element must have this tag
+    FromKind  string   `json:"from-kind,omitempty"`  // element must have this kind
+    FromTags  []string `json:"from-tags,omitempty"`  // allow-list: element must have ANY of these tags (allowed-relationship only)
+    FromKinds []string `json:"from-kinds,omitempty"` // allow-list: element must have this kind (allowed-relationship only)
+
+    // no-relationship / allowed-relationship: "to" endpoint selector
+    To     string `json:"to,omitempty"`
+    ToTag  string `json:"to-tag,omitempty"`
+    ToKind string `json:"to-kind,omitempty"`
+
+    // required-field: element selector (Tag takes precedence over ElementKind if both are set)
+    ElementKind string `json:"element-kind,omitempty"`
+    Tag         string `json:"tag,omitempty"`
+    Field       string `json:"field,omitempty"` // description|technology|title
+
+    Max          int      `json:"max,omitempty"`          // max-depth
+    Technologies []string `json:"technologies,omitempty"` // technology-allowed
+}
+
 // Config holds top-level configuration for diagram generation
 type Config struct {
     Metadata *bool  `json:"metadata,omitempty"`

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -883,6 +883,8 @@ const (
 // no-relationship/allowed-relationship endpoint selectors (from/to) and the
 // required-field element selector (tag/element-kind) are checked in order of
 // specificity — exact ID > tag > kind — whichever field is non-empty wins.
+// The allow-list forms (from-tags/from-kinds) rank with their singular
+// counterpart: tag/from-tags outrank kind/from-kinds, but not exact ID.
 type Constraint struct {
     ID          string `json:"id"`
     Description string `json:"description"`

--- a/src/docs/spec/04_acceptance_criteria.adoc
+++ b/src/docs/spec/04_acceptance_criteria.adoc
@@ -397,3 +397,37 @@ Feature: Connector to scope element
     Then a connector is drawn from "api" to the scope boundary of the view
     And the connector is correctly attached
 ----
+
+==== AC-9.5: Tag-based and element-ID-based constraint targeting (#542)
+
+[source,gherkin]
+----
+Feature: Constraint endpoint selectors beyond kind
+
+  Scenario: no-relationship distinguishes same-kind elements by tag
+    Given a model where "adminConsole" and "database" both have kind "container"
+    And "adminConsole" is tagged "ui" and "database" is tagged "datastore"
+    And a constraint "no-relationship" with from-tag "ui" and to-tag "datastore"
+    When the user runs "bausteinsicht lint"
+    Then a violation is reported for the "adminConsole" -> "database" relationship
+
+  Scenario: allowed-relationship uses a tag-based allow-list
+    Given a constraint "allowed-relationship" with from-tags ["internal"] and to-tag "datastore"
+    And element "batchJob" is tagged "internal" and relates to a "datastore"-tagged element
+    And element "adminConsole" is tagged "ui" and relates to the same "datastore"-tagged element
+    When the user runs "bausteinsicht lint"
+    Then no violation is reported for "batchJob"
+    And a violation is reported for "adminConsole"
+
+  Scenario: required-field selects elements by tag instead of kind
+    Given a constraint "required-field" with tag "public-api" and field "description"
+    And an element tagged "public-api" has no description
+    When the user runs "bausteinsicht lint"
+    Then a violation is reported for that element
+
+  Scenario: exact element ID takes precedence over tag and kind selectors
+    Given a constraint's "from" endpoint sets both an exact element ID and a from-tag
+    And another element shares the from-tag but not the ID
+    When the user runs "bausteinsicht lint"
+    Then only relationships from the exact element ID are checked
+----

--- a/src/docs/tutorial/05_analysis_evolution.adoc
+++ b/src/docs/tutorial/05_analysis_evolution.adoc
@@ -82,6 +82,21 @@ All constraints passed.
 
 Rules live in the model itself under `constraints` — for example "nothing may depend on a deprecated element" or "UI containers must not talk to datastores directly". `lint` (and `health`, which weighs conformance at 30 %) enforce them on every run.
 
+Layering rules like the datastore example need more than `kind` to express: an admin console and a database can both be kind `container`, so a kind-based `no-relationship` constraint can't tell them apart. Tag the elements instead (`"adminConsole": {"tags": ["ui"]}`, `"database": {"tags": ["datastore"]}`) and target the tags:
+
+[source,jsonc]
+----
+{
+  "id": "ui-not-to-datastore",
+  "description": "UI must not talk to a datastore directly",
+  "rule": "no-relationship",
+  "from-tag": "ui",
+  "to-tag": "datastore"
+}
+----
+
+`from-tag`/`to-tag` (and `from`/`to` for an exact element ID) work anywhere `from-kind`/`to-kind` do — on `no-relationship`, and as an allow-list (`from-tags`) on `allowed-relationship`. `required-field` accepts a `tag` selector the same way, in place of `element-kind`.
+
 == Stale: find the forgotten corners
 
 [source,bash]


### PR DESCRIPTION
## Summary
`no-relationship`, `allowed-relationship`, and `required-field` constraints could only target elements by `kind` (`from-kind`/`to-kind`/`element-kind`). That can't express layering rules like "UI must not talk to a datastore directly" when both sides share the same kind (e.g. both `container`) — exactly the example the tutorial already promised as a `lint` use case, but the kind-only rule set couldn't deliver.

- `Constraint` gets `from`/`from-tag`/`from-tags` and `to`/`to-tag` selectors (`no-relationship`, `allowed-relationship`), plus a `tag` selector for `required-field`.
- Selector precedence, most to least specific: exact element ID > tag > kind. Whichever field is set on a given endpoint is used; existing kind-only constraints are unaffected (same behavior when only `*-kind` fields are set).
- `allowed-relationship`'s `from-tags` is an allow-list, same semantics as the existing `from-kinds`: element allowed if it has ANY of the listed tags.
- Unified all three rule functions' element-selection logic (previously three independently-implemented "select by id/tag/kind" mechanisms) into one shared `elementSelector` type — a code-review finding: the first cut of `allowed-relationship` only wired up the new `from-tags`/`from-kinds` allow-lists and silently ignored the single-value `from`/`from-tag`/`from-kind` selectors.
- Regenerated `schemas/bausteinsicht.schema.json` (`make schema-generate`).
- Documented the new selector fields in `spec/03_data_models.adoc` (Constraint struct mapping) and added AC-9.5 in `spec/04_acceptance_criteria.adoc`. Fixed the tutorial's dangling promise: the "UI must not talk to datastores directly" example is now backed by a concrete `from-tag`/`to-tag` constraint instead of being inexpressible.
- Added `e2e/constraint_tag_based_test.go` and unit tests covering tag-based/ID-based/precedence/unset-selector behavior for all three rule types.

Closes #542.

## Test plan
- [x] `go build ./...` / `go test ./...` / `gofmt -l .` all clean
- [x] `/doc-check review` — PASS
- [x] `/code-review` (high effort) — 2 correctness bugs found and fixed (missing single-value selector support in `allowed-relationship`; unused-elemID param cleaned up via the unified `elementSelector`)
- [x] `/security-review` — no findings (pure in-memory string comparisons, no new sinks)
- [x] New e2e scenario (`e2e/constraint_tag_based_test.go`) chains `lint` against a tag-based constraint end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)