### PR TITLE
fix: verify BigData.xmi fetch checksum against known LFS digest

### DIFF
--- a/scripts/fetch-xmi-testdata.sh
+++ b/scripts/fetch-xmi-testdata.sh
@@ -12,19 +12,27 @@
 #   make fetch-testdata
 #
 # Safe to run repeatedly: skips the download if a real (>1MB) file is
-# already present. Safe to fail: on any network/fetch error it prints a
-# warning and exits 0 rather than failing the caller — internal/importer/xmi's
-# TestImport_BigData already skips itself when the fixture is absent or too
-# small, so offline/local dev is never blocked by this script. CI jobs that
-# specifically need the fixture (see the xmi-bigdata-integration job in
-# go.yml) check the test actually ran, so a silent fetch failure there is
-# still caught — it just fails that one dedicated job, not the whole build.
+# already present. Safe to fail: on any network/fetch/checksum error it
+# prints a warning and exits 0 rather than failing the caller —
+# internal/importer/xmi's TestImport_BigData already skips itself when the
+# fixture is absent or too small, so offline/local dev is never blocked by
+# this script. CI jobs that specifically need the fixture (see the
+# xmi-bigdata-integration job in go.yml) check the test actually ran, so a
+# silent fetch/checksum failure there is still caught — it just fails that
+# one dedicated job, not the whole build.
+#
+# The downloaded bytes are verified against a pinned sha256 — Git LFS used to
+# guarantee this at smudge time via the pointer's own oid; a plain curl fetch
+# doesn't, so without this check a corrupted or unexpectedly replaced Release
+# asset (still >1MB) would silently pass the size-only check and
+# TestImport_BigData would run against the wrong fixture with no error.
 set -uo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DEST="$ROOT/internal/importer/xmi/testdata/BigData.xmi"
 URL="https://github.com/docToolchain/Bausteinsicht-Testdata/releases/download/testdata-v1/BigData.xmi"
 MIN_SIZE=1048576 # 1 MiB — matches TestImport_BigData's own presence check
+EXPECTED_SHA256="7b761872b0f773caac76446b857162986761500d625c9bd3514d55bd1f63f5b0"
 
 file_size() {
     stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0
@@ -36,10 +44,18 @@ if [ -f "$DEST" ] && [ "$(file_size "$DEST")" -gt "$MIN_SIZE" ]; then
 fi
 
 echo "Fetching BigData.xmi from docToolchain/Bausteinsicht-Testdata (release testdata-v1)..."
-if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL" && mv "$DEST.tmp" "$DEST"; then
-    echo "Fetched BigData.xmi ($(file_size "$DEST") bytes)."
+if curl -fsSL --retry 2 -o "$DEST.tmp" "$URL"; then
+    ACTUAL_SHA256="$(sha256sum "$DEST.tmp" | cut -d' ' -f1)"
+    if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+        echo "Warning: BigData.xmi checksum mismatch (expected $EXPECTED_SHA256, got $ACTUAL_SHA256) — discarding download." >&2
+        echo "TestImport_BigData will skip itself; this is not treated as a hard failure here." >&2
+        rm -f "$DEST.tmp"
+        exit 0
+    fi
+    mv "$DEST.tmp" "$DEST"
+    echo "Fetched and verified BigData.xmi ($(file_size "$DEST") bytes)."
 else
-    echo "Warning: could not fetch/place BigData.xmi from $URL (network issue, fixture repo unavailable, or move failed)." >&2
+    echo "Warning: could not fetch BigData.xmi from $URL (network issue or fixture repo unavailable)." >&2
     echo "TestImport_BigData will skip itself; this is not treated as a hard failure here." >&2
     rm -f "$DEST.tmp"
 fi

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -49,6 +49,12 @@
 
 | 2026-06-29 (XMI review fixes)
 | Reverted `MaxModelFileSize` in `loader.go` back to 10 MB (SEC-006). The XMI importer uses `os.ReadFile` directly and is not subject to the JSONC file size limit; the 100 MB bump was unnecessary and would have silently relaxed SEC-006 for all JSONC model loading.
+
+| 2026-07-14 (XMI fixture fetch)
+| #553/#554: removed Git-LFS tracking for the `BigData.xmi` test fixture (CI never actually pulled the real file — every checkout only saw the LFS pointer) in favor of a fetch script pulling a Release asset from the separate `docToolchain/Bausteinsicht-Testdata` repo. Added SEC-019: the replacement fetch initially checked size only, not content — fixed by pinning the original LFS `sha256` digest in the script (PR #561).
+
+| 2026-07-14 (history rewrite)
+| Purged the historical `BigData.xmi` Git-LFS pointer object from `main`'s history via `git filter-repo` (object was never reachable by CI anyway; this reclaims it from the object graph). Tags `v1.0.0`–`v1.2.0` preserved bit-identical (verified via hash comparison); `v1.2.1` (the only tag descending from the commit that introduced the fixture) was necessarily rewritten to a new commit hash as a result — `go install ...@v1.2.1` will now fail its `sum.golang.org` checksum. Older tags/releases are unaffected.
 |===
 
 === Scope
@@ -168,6 +174,11 @@ The primary risk scenario is a **malicious or crafted model/drawio file** shared
 | Medium
 | Typo-squatting risk: Go module path, README `go install`, and landing page all used misspelled `Bauteinsicht` or wrong owner `rdmueller`
 | Fixed
+
+| SEC-019
+| Low
+| `scripts/fetch-xmi-testdata.sh` fetched the `BigData.xmi` test fixture from a separate repo's Release asset with only a size check, no checksum — a corrupted/replaced asset would silently pass and the integration test would run against the wrong fixture
+| Fixed (pinned sha256, verified against known LFS digest; PR #561)
 |===
 
 === Findings
@@ -383,6 +394,19 @@ Medium. Users copying the `go install` command from the README would fetch from 
 **Fix:**
 Renamed the Go module to `github.com/docToolchain/Bausteinsicht` across the entire codebase (go.mod, all imports, schema URLs, documentation). Corrected landing page URLs to `docToolchain/Bausteinsicht`.
 
+==== SEC-019: Unverified Test Fixture Fetch (Low) — Fixed
+
+_Added 2026-07-14_
+
+**Description:**
+#553/#554 removed Git-LFS tracking for `internal/importer/xmi/testdata/BigData.xmi` (a ~118MB real Enterprise Architect/AUTOSAR export used only as a test fixture) and replaced it with `scripts/fetch-xmi-testdata.sh` downloading a GitHub Release asset from the separate `docToolchain/Bausteinsicht-Testdata` repo. Git LFS had guaranteed the exact content via a pinned `sha256` OID, verified at smudge time; the replacement script only checked the downloaded file's size (`>1MB`). A corrupted download, or the Release asset being unexpectedly replaced (accidental re-upload, or an unauthorized push to that repo), would silently pass the size check and `TestImport_BigData` would run against the wrong fixture with no error — the exact "silent drift" failure mode #553/#554 otherwise closed.
+
+**Risk:**
+Low. Test-fixture integrity only (Blast Radius 0 per the Risk Radar assessment) — no production code path is affected.
+
+**Fix:**
+Pinned the known digest (`sha256:7b761872b0f773caac76446b857162986761500d625c9bd3514d55bd1f63f5b0`, the same OID the original LFS pointer carried) in `scripts/fetch-xmi-testdata.sh`. On mismatch, the script discards the download and falls back to its existing "fetch failed" behavior (warn, exit 0, leave fixture absent) — `TestImport_BigData` skips itself and the dedicated `xmi-bigdata-integration` CI job still fails loudly if the test unexpectedly skips. PR #561.
+
 === Not Vulnerable
 
 The following attack vectors were explicitly tested and confirmed **not exploitable**:
@@ -479,6 +503,7 @@ All dependencies at latest versions. No known CVEs. `go mod verify` — **PASS**
 
 SEC-002 (PR #77), SEC-003 (PR #77), SEC-009 (PR #77), SEC-010 (PR #77), SEC-012 (#235).
 SEC-004, SEC-007, SEC-011 verified fixed 2026-03-30 (see individual findings above).
+SEC-019 (PR #561).
 
 ==== Remaining Open
 


### PR DESCRIPTION
## Summary
Fast-follow to #554 (removal of Git-LFS for `BigData.xmi`), flagged in that PR's review: `scripts/fetch-xmi-testdata.sh` only checked the downloaded file's size (>1MB) before placing it, unlike Git LFS which verified an exact `sha256` at smudge time. A corrupted or unexpectedly replaced Release asset in `docToolchain/Bausteinsicht-Testdata` that still happens to be >1MB would have silently passed, and `TestImport_BigData` would run against the wrong fixture with no error — the exact "silent drift" failure mode #553/#554 otherwise closed.

- Pins the known digest (`sha256:7b761872b0f773caac76446b857162986761500d625c9bd3514d55bd1f63f5b0`, the same OID the old LFS pointer carried) in the script.
- On mismatch: discards the download and backs off to the existing "fetch failed" behavior (warn, exit 0, leave fixture absent) — `TestImport_BigData` skips itself as before, and the dedicated `xmi-bigdata-integration` CI job still fails loudly if the test unexpectedly skips. No new failure mode introduced, just closes the integrity gap.

## Test plan
- [x] Real fetch + checksum match: `bash scripts/fetch-xmi-testdata.sh` — fetched and verified successfully
- [x] Re-run with file already present: skips fetch as before
- [x] Simulated checksum mismatch (temporarily wrong expected digest): warning printed, download discarded, exit 0
- [x] `go test -run 'TestImport_BigData|TestImport_SyntheticBigData' -v ./internal/importer/xmi/...` — both pass
- [x] `gofmt -l .` / `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)