### PR TITLE
ci: lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/workflows/check-branch-origin.yml
+++ b/.github/workflows/check-branch-origin.yml
@@ -29,8 +29,7 @@ jobs:
             exit 0
           fi
 
-          # Check if branch has diverged (contains commits not in main)
-          COMMITS_AHEAD=$(git rev-list --count origin/main..HEAD)
+          # Check if branch has diverged (is behind main)
           COMMITS_BEHIND=$(git rev-list --count HEAD..origin/main)
 
           if [ "$COMMITS_BEHIND" -gt 0 ]; then

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Detect duplicate functionality
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Get files changed in this PR
           BASE_COMMIT=$(git merge-base origin/main HEAD)
@@ -27,7 +28,7 @@ jobs:
           # Check for similar changes in other open PRs
           DUPLICATES=""
           for pr in $(gh pr list --state open --json number -q '.[].number'); do
-            if [ "$pr" -ne "${{ github.event.pull_request.number }}" ]; then
+            if [ "$pr" != "$PR_NUMBER" ]; then
               PR_FILES=$(gh pr view "$pr" --json files -q '.files[].path' | tr '\n' ' ')
 
               # Check for overlapping packages/modules
@@ -47,7 +48,7 @@ jobs:
             echo ""
 
             BODY=$(printf '⚠️ **Potential Duplicate Work Detected**\n\nThis PR may overlap with other open PRs:%s\n\nPlease review and coordinate:\n1. Confirm this PR does not duplicate existing work\n2. If duplicate, consider closing this PR\n3. If improvements, consider cherry-picking into existing PR instead' "$(echo -e "$DUPLICATES")")
-            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
+            gh pr comment "$PR_NUMBER" --body "$BODY"
           else
             echo "✅ No overlapping work detected"
           fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -486,7 +486,11 @@ jobs:
         # parsing it exhausts memory well before the package's own (fast,
         # non-race) tests would ever suggest a problem. The other 33
         # packages are raced normally.
-        run: go test -race $(go list ./... | grep -v '/internal/importer/xmi$')
+        run: |
+          # The package list from $() is intentionally word-split into one
+          # argument per package for `go test`.
+          # shellcheck disable=SC2046
+          go test -race $(go list ./... | grep -v '/internal/importer/xmi$')
 
   govulncheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,35 @@
+name: Lint Workflows
+
+# Lints the GitHub Actions workflows themselves with actionlint (structure,
+# expressions, action references) plus its embedded shellcheck on `run:`
+# scripts. Runs only when a workflow file changes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    name: actionlint
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
+        env:
+          # Gate on shellcheck error+warning only. The repo still carries ~40
+          # info/style shellcheck findings (mostly SC2086 "quote your
+          # variables") across the branch-management workflows; those are
+          # non-blocking here and left for a follow-up cleanup so this check is
+          # green on arrival. Raise to the default (info) once they are fixed.
+          SHELLCHECK_OPTS: --severity=warning

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -29,7 +29,12 @@ jobs:
           # grep -x (exact-line) instead of substring match: a hypothetical
           # branch that merely *contains* "main" (e.g. "maintenance-fix")
           # must not be silently dropped.
-          DELETED_LOCAL=$(git branch -d $(git branch --format='%(refname:short)' --merged origin/main | grep -vx main | tr '\n' ' ') 2>&1 || echo "")
+          # The inner $() is intentionally word-split into one argument per
+          # merged branch for `git branch -d`; output is discarded (the point is
+          # the deletion side effect, and on a fresh runner there is usually
+          # nothing to delete).
+          # shellcheck disable=SC2046
+          git branch -d $(git branch --format='%(refname:short)' --merged origin/main | grep -vx main | tr '\n' ' ') >/dev/null 2>&1 || true
 
           # List remote branches that should be deleted (already merged to main)
           # grep -vx origin (post-strip): a run on 2026-07-03 produced one


### PR DESCRIPTION
## Description
Adds a `Lint Workflows` job (`raven-actions/actionlint`, SHA-pinned) that lints
the repo's GitHub Actions workflows whenever a file under `.github/workflows/**`
changes — validating structure / expressions / action references plus the
embedded shellcheck on `run:` scripts.

## Related Issue
Closes #564

## Type of Change
- [x] Improvement/refactoring

## How it lands green
actionlint surfaces 45 findings on the current workflows (1 error, 3 warning, 41
info/style). This PR:
- gates the embedded shellcheck on **error + warning**
  (`SHELLCHECK_OPTS=--severity=warning`);
- fixes the 4 blocking findings, including a **real bug** — `SC2170`
  (`[ "$pr" -ne "<number>" ]`, invalid numeric comparison) in
  `check-duplicate-prs.yml`;
- defers the 41 info/style findings (mostly SC2086 "quote your variables") to a
  follow-up documented in #564.

## Fixes
- `check-duplicate-prs.yml` — bind PR number via env, compare with `!=` (SC2170)
- `check-branch-origin.yml` — drop unused `COMMITS_AHEAD` (SC2034)
- `weekly-maintenance.yml` — drop unused capture, document intentional word-split (SC2034/SC2046)
- `go.yml` — document intentional package-list word-split in the `test-race` step (SC2046)

## Testing
- `actionlint` locally (with shellcheck 0.11.0): `--severity=warning` → clean;
  default severity → only the 41 deferred info/style findings.
- `act workflow_dispatch -W .github/workflows/lint-workflows.yml` → job
  succeeded. (The `act` image ships no shellcheck, so this exercised the
  workflow wiring / action reference; real `ubuntu-latest` runners have
  shellcheck pre-installed and match the host run.)
- This is itself a fork PR (`ascheman/Bausteinsicht` → `docToolchain`), so it
  also exercises the fork-PR CI added in #563.

## Notes for Reviewers
Behavior-preserving changes only — no logic changes to the branch-management
workflows beyond removing dead code and documenting intentional word-splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
