### PR TITLE
fix(ci): resolve fork PR by head ref, not commit association (#566)

### DIFF
--- a/.github/workflows/pr-comments.yml
+++ b/.github/workflows/pr-comments.yml
@@ -52,6 +52,7 @@ jobs:
           # populated by GitHub for workflow_run regardless of fork status.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           script: |
             const fs = require('fs');
@@ -66,19 +67,22 @@ jobs:
               return;
             }
 
-            // Resolve the real PR from the trusted head SHA, never the staged
-            // pr_number. listPullRequestsAssociatedWithCommit works for fork PRs
-            // because the base repo holds refs/pull/N/head at this commit.
-            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            const assoc = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              { owner: context.repo.owner, repo: context.repo.repo, commit_sha: process.env.HEAD_SHA },
-            );
-            const pr = assoc.find(p =>
-              p.head.repo && p.head.repo.full_name === process.env.HEAD_REPO &&
-              p.base.repo.full_name === baseRepo);
+            // Resolve the real PR from the trusted head repo + branch, never the
+            // staged pr_number. listPullRequestsAssociatedWithCommit does NOT
+            // return fork PRs when queried on the base repo (the fork-head commit
+            // is not associated there), so list open PRs by head "owner:branch" —
+            // every field comes from the trusted workflow_run event — and confirm
+            // the head SHA matches the commit that triggered this run.
+            const headOwner = process.env.HEAD_REPO.split('/')[0];
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${headOwner}:${process.env.HEAD_BRANCH}`,
+            });
+            const pr = prs.find(p => p.head.sha === process.env.HEAD_SHA);
             if (!pr) {
-              core.warning(`No PR found for ${process.env.HEAD_REPO}@${process.env.HEAD_SHA}; nothing to post.`);
+              core.warning(`No open PR found for ${headOwner}:${process.env.HEAD_BRANCH}@${process.env.HEAD_SHA}; nothing to post.`);
               return;
             }
             const issue_number = pr.number;

--- a/.github/workflows/sonarcloud-forks.yml
+++ b/.github/workflows/sonarcloud-forks.yml
@@ -53,18 +53,25 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           script: |
-            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
-            const assoc = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              { owner: context.repo.owner, repo: context.repo.repo, commit_sha: process.env.HEAD_SHA },
-            );
-            const pr = assoc.find(p =>
-              p.head.repo && p.head.repo.full_name === process.env.HEAD_REPO &&
-              p.base.repo.full_name === baseRepo);
+            // Resolve the PR from the trusted head repo + branch.
+            // listPullRequestsAssociatedWithCommit does NOT return fork PRs when
+            // queried on the base repo (the fork-head commit is not associated
+            // there), so list open PRs by head "owner:branch" — every field comes
+            // from the trusted workflow_run event — and confirm the head SHA
+            // matches the commit that triggered this run.
+            const headOwner = process.env.HEAD_REPO.split('/')[0];
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${headOwner}:${process.env.HEAD_BRANCH}`,
+            });
+            const pr = prs.find(p => p.head.sha === process.env.HEAD_SHA);
             if (!pr) {
-              core.warning(`No PR found for ${process.env.HEAD_REPO}@${process.env.HEAD_SHA}; skipping scan.`);
+              core.warning(`No open PR found for ${headOwner}:${process.env.HEAD_BRANCH}@${process.env.HEAD_SHA}; skipping scan.`);
               core.setOutput('found', 'false');
               return;
             }


### PR DESCRIPTION
## Description
Fixes fork-PR identity resolution in the `workflow_run` workflows added in #563.
They resolve the PR via `listPullRequestsAssociatedWithCommit`, which returns
**empty for a fork-head commit** queried on the base repo — so both workflows
silently no-op on real fork PRs (observed on #565: `No PR found …; nothing to
post / skipping scan`).

Resolve the PR by head ref instead —
`pulls.list({ state: 'open', head: '<fork-owner>:<head-branch>' })` — and match
`head.sha === github.event.workflow_run.head_sha`. Applies to both
`pr-comments.yml` and `sonarcloud-forks.yml`.

## Related Issue
Closes #566

## Type of Change
- [x] Bug fix

## Root cause (verified on the live fork PR #565)
- `GET /repos/docToolchain/Bausteinsicht/commits/ef583f4/pulls` → `[]` (broken)
- `GET /repos/docToolchain/Bausteinsicht/pulls?head=ascheman:feature/gh-workflow-linter&state=open` → `#565` (the fix)

The original (pre-hardening) #563 version read the PR number from the staged
artifact and was verified on `BS-test-549`; the security fix that replaced it
was never exercised on a real fork PR, so the regression shipped.

## Security
PR identity is still taken **only** from trusted `workflow_run` fields
(`head_repository`, `head_branch`, `head_sha`); the `head.sha` match binds the
result to the commit that triggered the run, so a fork cannot redirect the
privileged job to another PR. #563's security property is preserved.

## Testing
- Root cause and fix mechanism proven at the API level on the **live fork PR #565** (above).
- `actionlint` + YAML clean on both files.
- Edited workflows parse and run in real GitHub: after deploying them to the
  `BS-test-549` default branch, the push-triggered `workflow_run` runs skipped
  correctly (`if: event == 'pull_request'`).
- ⚠️ **Verification gap:** a full live end-to-end re-run on `BS-test-549` could
  not be completed — GitHub no longer schedules fork-PR CI on that throwaway repo
  (empty commit, real change, and close/reopen all produced zero runs; no pending
  approvals). The change is confined to the identity-resolution step; the rest of
  each pipeline is unchanged and was validated end-to-end during #563.
- **Authoritative confirmation** will come from **#565** after this merges:
  re-trigger its Go CI and the poster/scan should resolve the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
