### PR TITLE
ci: clear deferred workflow shellcheck backlog

### DIFF
--- a/.github/workflows/check-branch-freshness.yml
+++ b/.github/workflows/check-branch-freshness.yml
@@ -23,19 +23,22 @@ jobs:
 
           if [ "$BASE" != "$MAIN_HEAD" ]; then
             COMMITS_BEHIND=$(git rev-list --count HEAD..origin/main)
-            COMMITS_ON_BRANCH=$(git rev-list --count $BASE..HEAD)
+            COMMITS_ON_BRANCH=$(git rev-list --count "$BASE"..HEAD)
 
-            echo "## 📊 Branch Status" >> $GITHUB_STEP_SUMMARY
-            echo "- Commits on this branch: $COMMITS_ON_BRANCH" >> $GITHUB_STEP_SUMMARY
-            echo "- Commits main is ahead: $COMMITS_BEHIND" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "## 📊 Branch Status"
+              echo "- Commits on this branch: $COMMITS_ON_BRANCH"
+              echo "- Commits main is ahead: $COMMITS_BEHIND"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
 
             if [ "$COMMITS_BEHIND" -gt 0 ]; then
-              echo "- ⚠️ Branch is behind main" >> $GITHUB_STEP_SUMMARY
+              echo "- ⚠️ Branch is behind main" >> "$GITHUB_STEP_SUMMARY"
 
+              # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the PR comment body, not command substitution
               BODY=$(printf '⚠️ **Branch is behind main by %s commit(s)**\n\nThis may cause merge conflicts or miss recent bug fixes/improvements.\n\n**Recommended action:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nThis ensures compatibility with the latest main and prevents conflicts.' "$COMMITS_BEHIND")
               gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
             fi
           else
-            echo "✅ Branch is up-to-date with main" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Branch is up-to-date with main" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/check-branch-origin.yml
+++ b/.github/workflows/check-branch-origin.yml
@@ -40,6 +40,7 @@ jobs:
             echo "  git push --force-with-lease"
             echo ""
 
+            # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the PR comment body, not command substitution
             BODY=$(printf '⚠️ **Branch Behind Main**\n\nThis branch is based on an older commit from main and is behind by **%s commit(s)**.\n\nThis often happens when a feature branch is created from another feature branch instead of from main directly.\n\n**Recommendation:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nAfter rebasing, this warning will disappear.' "$COMMITS_BEHIND")
             gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
 

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -42,7 +42,7 @@ jobs:
             fi
           done
 
-          if [ ! -z "$DUPLICATES" ]; then
+          if [ -n "$DUPLICATES" ]; then
             echo "⚠️ Potential duplicates detected:"
             echo -e "$DUPLICATES"
             echo ""

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           # Get files changed in this PR
           BASE_COMMIT=$(git merge-base origin/main HEAD)
-          FILES=$(git diff --name-only $BASE_COMMIT HEAD)
+          FILES=$(git diff --name-only "$BASE_COMMIT" HEAD)
 
           echo "Files changed in this PR:"
           echo "$FILES"

--- a/.github/workflows/check-stale-branches.yml
+++ b/.github/workflows/check-stale-branches.yml
@@ -33,7 +33,7 @@ jobs:
           # weekly-maintenance.yml; not locally reproducible, so filtered
           # defensively here too since the pipeline is identical.
           for branch in $(git branch -r --format='%(refname:short)' | grep -vx 'origin/main' | grep -vx 'origin/HEAD' | sed 's|origin/||' | grep -vx '' | grep -vx origin); do
-            COMMIT_DATE=$(git log -1 --format=%ai origin/$branch 2>/dev/null | cut -d' ' -f1)
+            COMMIT_DATE=$(git log -1 --format=%ai "origin/$branch" 2>/dev/null | cut -d' ' -f1)
             if [ -z "$COMMIT_DATE" ]; then
               continue
             fi
@@ -41,11 +41,12 @@ jobs:
             DAYS_OLD=$(( ($(date +%s) - $(date -d "$COMMIT_DATE" +%s 2>/dev/null || echo 0)) / 86400 ))
 
             # Check if merged to main
-            if ! git merge-base --is-ancestor origin/$branch origin/main 2>/dev/null; then
+            if ! git merge-base --is-ancestor "origin/$branch" origin/main 2>/dev/null; then
               if [ "$DAYS_OLD" -gt 7 ]; then
                 # The trailing \n must be appended outside $(...): command
                 # substitution strips trailing newlines, which would run
                 # consecutive entries together on one line.
+                # shellcheck disable=SC2016  # backticks are literal markdown inline-code around the branch name, not command substitution
                 STALE_BRANCHES="${STALE_BRANCHES}$(printf -- '- `%s` (%s days old)' "$branch" "$DAYS_OLD")"$'\n'
                 BRANCH_COUNT=$((BRANCH_COUNT + 1))
               fi
@@ -53,13 +54,16 @@ jobs:
           done
 
           if [ "$BRANCH_COUNT" -gt 0 ]; then
-            echo "⚠️ **Stale Branches Found**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Found $BRANCH_COUNT stale branch(es) (unmerged, >7 days old):" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "$STALE_BRANCHES" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "⚠️ **Stale Branches Found**"
+              echo ""
+              echo "Found $BRANCH_COUNT stale branch(es) (unmerged, >7 days old):"
+              echo ""
+              echo "$STALE_BRANCHES"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
 
+            # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the issue body, not command substitution
             BODY=$(printf 'Found stale branches (not merged to main, >7 days old):\n\n%s\n\n**Recommendation:**\nReview if these branches should be:\n1. Merged (if still relevant work)\n2. Deleted (if work is abandoned or superseded)\n\nDelete with:\n```bash\ngit fetch origin\ngit branch -D <branch>\ngit push origin --delete <branch>\n```' "$STALE_BRANCHES")
             gh issue create \
               --title "🧹 Cleanup: Stale branches found" \
@@ -67,5 +71,5 @@ jobs:
               --label infrastructure \
               2>/dev/null || echo "Issue already exists or other error"
           else
-            echo "✅ No stale branches found" >> $GITHUB_STEP_SUMMARY
+            echo "✅ No stale branches found" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           GOEXE=$(go env GOEXE)
           cd scripts/test-report-generator
-          go build -o test-report-generator${GOEXE} .
+          go build -o "test-report-generator${GOEXE}" .
           cd ../..
 
           # Determine OS key from matrix.os
@@ -74,10 +74,10 @@ jobs:
             echo "Generating reports for ${OS_KEY} from test-results.json"
             # Only pass coverage.out if it exists (it may not exist on failed runs or Windows)
             if [ -f coverage.out ]; then
-              ./scripts/test-report-generator/test-report-generator${GOEXE} -coverage=coverage.out -format=json < test-results.json > test-report-${OS_KEY}.json
+              "./scripts/test-report-generator/test-report-generator${GOEXE}" -coverage=coverage.out -format=json < test-results.json > "test-report-${OS_KEY}.json"
             else
               echo "Warning: coverage.out not found, generating report without coverage data"
-              ./scripts/test-report-generator/test-report-generator${GOEXE} -format=json < test-results.json > test-report-${OS_KEY}.json
+              "./scripts/test-report-generator/test-report-generator${GOEXE}" -format=json < test-results.json > "test-report-${OS_KEY}.json"
             fi
           else
             echo "test-results.json not found!"
@@ -319,6 +319,7 @@ jobs:
             printf '\n'
             printf '%s\n' '</details>'
             printf '\n'
+            # shellcheck disable=SC2016  # backticks are literal markdown inline-code in the PR comment body, not command substitution
             printf '%s\n' '💡 `SKIP: not automated` means no `e2e/*_test.go` test is mapped to that line yet — see `internal/e2eplan` and `E2E-Test-Plan.adoc`'"'"'s "Generating a Line-Accurate Report Automatically" section.'
           } > pr-comment-body/e2e.md
       - name: Upload rendered comment body
@@ -349,7 +350,7 @@ jobs:
         run: |
           if [ -f coverage/coverage.out ]; then
             COVERAGE=$(go tool cover -func=coverage/coverage.out | grep total | awk '{print $NF}')
-            echo "percentage=${COVERAGE}" >> $GITHUB_OUTPUT
+            echo "percentage=${COVERAGE}" >> "$GITHUB_OUTPUT"
             echo "📊 Code Coverage: ${COVERAGE}"
           fi
       - name: Create coverage markdown summary
@@ -380,7 +381,7 @@ jobs:
           } > coverage/COVERAGE.md
 
           # Append to job summary for visibility in workflow run
-          cat coverage/COVERAGE.md >> $GITHUB_STEP_SUMMARY
+          cat coverage/COVERAGE.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
         if: always()

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -26,10 +26,3 @@ jobs:
 
       - name: Run actionlint
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
-        env:
-          # Gate on shellcheck error+warning only. The repo still carries ~40
-          # info/style shellcheck findings (mostly SC2086 "quote your
-          # variables") across the branch-management workflows; those are
-          # non-blocking here and left for a follow-up cleanup so this check is
-          # green on arrival. Raise to the default (info) once they are fixed.
-          SHELLCHECK_OPTS: --severity=warning

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -49,16 +49,20 @@ jobs:
           MERGED_REMOTE=$(git branch -r --format='%(refname:short)' --merged origin/main | grep -vx 'origin/main' | grep -vx 'origin/HEAD' | sed 's|origin/||' | grep -vx '' | grep -vx origin)
 
           if [ ! -z "$MERGED_REMOTE" ]; then
-            echo "## 🧹 Auto-Cleanup Summary" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Merged branches ready for deletion:**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "$MERGED_REMOTE" | sed 's/^/- /' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "## 🧹 Auto-Cleanup Summary"
+              echo ""
+              echo "**Merged branches ready for deletion:**"
+              echo ""
+              # shellcheck disable=SC2001  # per-line '^' prepend; ${var//search/replace} can't anchor per line
+              echo "$MERGED_REMOTE" | sed 's/^/- /'
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
 
             BRANCH_LIST=$(echo "$MERGED_REMOTE" | tr '\n' ' ')
 
             # Create issue for notification
+            # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the issue body, not command substitution
             BODY=$(printf 'Found branches merged to main. Safe to delete:\n\n%s\n\n**How to clean up:**\n```bash\ngit fetch origin\ngit branch -d %s\ngit push origin %s\n```\n\nOr delete individually in GitHub web UI: Settings → Branches' \
               "$(echo "$MERGED_REMOTE" | sed 's/^/- origin\//')" \
               "$BRANCH_LIST" \
@@ -69,5 +73,5 @@ jobs:
               --label infrastructure \
               2>/dev/null || echo "Issue creation skipped (may already exist)"
           else
-            echo "✅ No merged branches to clean up" >> $GITHUB_STEP_SUMMARY
+            echo "✅ No merged branches to clean up" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -48,7 +48,7 @@ jobs:
           # leaving a misleading branch name in the generated issue.
           MERGED_REMOTE=$(git branch -r --format='%(refname:short)' --merged origin/main | grep -vx 'origin/main' | grep -vx 'origin/HEAD' | sed 's|origin/||' | grep -vx '' | grep -vx origin)
 
-          if [ ! -z "$MERGED_REMOTE" ]; then
+          if [ -n "$MERGED_REMOTE" ]; then
             {
               echo "## 🧹 Auto-Cleanup Summary"
               echo ""


### PR DESCRIPTION
## Description
Clears the deferred info/style shellcheck backlog documented in #564 — the
follow-up to #565's actionlint introduction. Fixes all **41 findings** across 6
workflow files and removes the temporary `SHELLCHECK_OPTS=--severity=warning`
gate from `lint-workflows.yml`, so actionlint now lints the workflows (and
itself) at full default severity.

Breakdown:
- **SC2086 (31)** — double-quote variable expansions (`>> "$GITHUB_STEP_SUMMARY"`,
  `"origin/$branch"`, `"$BASE"..HEAD`, `"test-report-${OS_KEY}.json"`, …).
- **SC2129 (3)** — group consecutive summary redirects into `{ …; } >> "$file"`
  (identical output).
- **SC2016 (6)** — narrow `# shellcheck disable` with rationale: backticks are
  literal markdown (code fences / inline code) in `printf` comment/issue bodies,
  not command substitution.
- **SC2001 (1)** — narrow disable: `sed 's/^/- /'` prepends per line via the `^`
  anchor; `${var//search/replace}` can't anchor per-line.

Behavior-preserving only — no logic and no `${{ }}` expressions changed. The
intentional SC2046 word-split disables from #565 in `go.yml` are untouched.

## Related Issue
Follow-up to #564 (deferred backlog) / #565. #564 is already closed; this
completes its documented follow-up.

## Type of Change
- [x] Improvement/refactoring

## Pre-Merge Checklist (Developer)
- [x] **Branch is up-to-date with main** — branched from `origin/main`, no conflicts
- [x] **No duplicate work** — dedicated follow-up to #564/#565
- [x] **Tests passing** — unit/integration N/A (no Go changes); CI pipeline expected green
- [x] **Code quality** — `actionlint -no-color -oneline` → 0 findings at default severity; `make check` N/A (no Go code touched)
- [x] **Documentation** — N/A across the board: change is confined to `.github/workflows/` shell quoting; no CLI/flags, `types.go`/schema, `internal/sync/`, packages, or runtime paths changed.

## Testing
- `actionlint` v1.7.12 + `shellcheck` 0.11.0 locally: **0 findings at default
  severity** (was 41 info/style).
- Each `run:` block reviewed for behavior preservation (quoting, redirect
  grouping, per-line `sed` retained).
- This is itself a fork PR (`ascheman/Bausteinsicht` → `docToolchain`), so it
  re-exercises the fork-PR CI (#563/#567).

## Notes for Reviewers
7 narrow `# shellcheck disable` directives, each with a one-line inline rationale
(6× SC2016 literal-markdown, 1× SC2001 per-line anchor). Everything else is a
real quote/group fix.