### PR TITLE
ci: keep fork-PR comment workflows green (soft-warn)

### DIFF
--- a/.github/workflows/check-branch-freshness.yml
+++ b/.github/workflows/check-branch-freshness.yml
@@ -35,9 +35,13 @@ jobs:
             if [ "$COMMITS_BEHIND" -gt 0 ]; then
               echo "- ⚠️ Branch is behind main" >> "$GITHUB_STEP_SUMMARY"
 
+              echo "::warning title=Branch behind main::This branch is behind main by $COMMITS_BEHIND commit(s); rebase onto origin/main."
               # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the PR comment body, not command substitution
               BODY=$(printf '⚠️ **Branch is behind main by %s commit(s)**\n\nThis may cause merge conflicts or miss recent bug fixes/improvements.\n\n**Recommended action:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nThis ensures compatibility with the latest main and prevents conflicts.' "$COMMITS_BEHIND")
-              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
+              # Best-effort: posting a comment needs write access, which fork PRs
+              # lack. Never hard-fail here - the warning above already reports it.
+              gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" \
+                || echo "::notice::Could not post the branch-freshness comment (e.g. a fork PR's read-only token, rate limit, or API error); the warning above already reports it."
             fi
           else
             echo "✅ Branch is up-to-date with main" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-branch-origin.yml
+++ b/.github/workflows/check-branch-origin.yml
@@ -40,9 +40,13 @@ jobs:
             echo "  git push --force-with-lease"
             echo ""
 
+            echo "::warning title=Branch behind main::This branch is behind main by $COMMITS_BEHIND commit(s); rebase onto origin/main."
             # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the PR comment body, not command substitution
             BODY=$(printf '⚠️ **Branch Behind Main**\n\nThis branch is based on an older commit from main and is behind by **%s commit(s)**.\n\nThis often happens when a feature branch is created from another feature branch instead of from main directly.\n\n**Recommendation:**\n```bash\ngit fetch origin\ngit rebase origin/main\ngit push --force-with-lease\n```\n\nAfter rebasing, this warning will disappear.' "$COMMITS_BEHIND")
-            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY"
+            # Best-effort: posting a comment needs write access, which fork PRs
+            # lack. Never hard-fail here - the warning above already reports it.
+            gh pr comment ${{ github.event.pull_request.number }} --body "$BODY" \
+              || echo "::notice::Could not post the branch-origin comment (e.g. a fork PR's read-only token, rate limit, or API error); the warning above already reports it."
 
             # Don't fail - let it proceed with warning
           fi

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -57,7 +57,7 @@ jobs:
             # Best-effort: posting a comment needs write access, which fork PRs
             # lack. Never hard-fail here - the warning above already reports it.
             gh pr comment "$PR_NUMBER" --body "$BODY" \
-              || echo "::notice::Could not post the duplicate-work comment (fork PRs have a read-only token); see the warning above."
+              || echo "::notice::Could not post the duplicate-work comment (e.g. a fork PR's read-only token, rate limit, or API error); the overlap is reported in the warning above."
           else
             echo "✅ No overlapping work detected"
           fi

--- a/.github/workflows/check-duplicate-prs.yml
+++ b/.github/workflows/check-duplicate-prs.yml
@@ -47,8 +47,17 @@ jobs:
             echo -e "$DUPLICATES"
             echo ""
 
+            # Surface the overlap as a soft warning annotation so it is visible
+            # in the Checks UI without failing the job. Fork PRs get a read-only
+            # GITHUB_TOKEN, so the comment below cannot be posted there and the
+            # job must not hard-fail on that.
+            echo "::warning title=Potential duplicate work::This PR overlaps with other open PRs:$(echo -e "$DUPLICATES" | tr '\n' ' ')"
+
             BODY=$(printf '⚠️ **Potential Duplicate Work Detected**\n\nThis PR may overlap with other open PRs:%s\n\nPlease review and coordinate:\n1. Confirm this PR does not duplicate existing work\n2. If duplicate, consider closing this PR\n3. If improvements, consider cherry-picking into existing PR instead' "$(echo -e "$DUPLICATES")")
-            gh pr comment "$PR_NUMBER" --body "$BODY"
+            # Best-effort: posting a comment needs write access, which fork PRs
+            # lack. Never hard-fail here - the warning above already reports it.
+            gh pr comment "$PR_NUMBER" --body "$BODY" \
+              || echo "::notice::Could not post the duplicate-work comment (fork PRs have a read-only token); see the warning above."
           else
             echo "✅ No overlapping work detected"
           fi


### PR DESCRIPTION
## Description
Three `pull_request`-triggered workflows post a PR comment via `gh pr comment`
with no fallback, so they **hard-fail on fork PRs** (read-only `GITHUB_TOKEN`)
the moment their condition triggers. Same fork-PR-permission class as #563/#567,
but these workflows still comment directly in the untrusted PR context.

Observed live: #548 (a fork PR) went red on `check-duplicates` once #571 opened
touching `internal/sync`. The same latent gap exists in the two branch-status
workflows whenever a fork PR falls behind `main`.

Fix (same shape in all three): emit a GitHub `::warning::` annotation for the
condition (so the signal survives), and make `gh pr comment` **best-effort**
(`|| ::notice::`) so the job passes. No change on the no-overlap / up-to-date path.

Files:
- `check-duplicate-prs.yml` — overlap detection
- `check-branch-freshness.yml` — "branch behind main"
- `check-branch-origin.yml` — "branch behind main"

## Related Issue
Follow-up to the fork-PR CI hardening (#563 / #567); observed on #548 vs #571.

## Type of Change
- [x] Improvement/refactoring

## Testing
- `actionlint` v1.7.12 + `shellcheck` 0.11.0: 0 findings at full severity across all workflows.
- Itself a fork PR, so it exercises the fork-PR path; all three comment jobs now stay green.

## Notes for Reviewers
Behavior-preserving except the failure mode: the comment condition now yields a warning annotation + best-effort comment instead of a hard job failure. Expanded from the initial single-file version per @paulefl's review.