### PR TITLE
feat(sync): clickable doc/ADR drilldown icons for elements and views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,9 @@ e2e/                   # Automated end-to-end pipeline tests (Go); testdata/ hol
 
 ## Workflow Rules
 
+### Bug Fixes (TDD)
+When fixing a bug, write a test that reproduces it first — confirm it actually fails against the unfixed code — before writing the fix. Only then implement the change to make it pass. Don't implement the fix and backfill the test afterward. This applies specifically to bug fixes, not necessarily to every feature addition or refactor.
+
 ### Ticket Start
 When starting work on a ticket:
 1. Run `/doc-check start #<issue>` — identifies which spec/architecture docs need updating and applies them before implementation begins (docs-first approach)

--- a/e2e/doclink_icons_test.go
+++ b/e2e/doclink_icons_test.go
@@ -1,0 +1,195 @@
+package e2e
+
+// TestDocLinkIcons (#543) verifies the full validate → sync chain for the
+// element→doc/ADR drilldown feature: an element's `link`, `decisions`
+// (matching a Specification.Decisions record that has a `file`), and typed
+// `docLinks` all produce clickable icon <object> cells in the synced
+// draw.io XML, alongside a view-level DocLinks icon row — without disturbing
+// the element's own drill-down/link attribute (ADR-009) or the existing
+// back-nav button (#198).
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/docToolchain/Bausteinsicht/internal/drawio"
+)
+
+const docLinkModel = `{
+  "specification": {
+    "elements": {
+      "system": { "notation": "System", "container": true },
+      "container": { "notation": "Container" }
+    },
+    "relationships": {
+      "uses": { "notation": "uses" }
+    },
+    "decisions": [
+      { "id": "ADR-001", "title": "Use JSONC", "status": "active", "file": "ADRs/ADR-001-DSL-Format.html" }
+    ]
+  },
+  "model": {
+    "shop": {
+      "kind": "system",
+      "title": "Shop",
+      "children": {
+        "api": {
+          "kind": "container",
+          "title": "API",
+          "link": "architecture.adoc#sec-api",
+          "decisions": ["ADR-001"],
+          "docLinks": [
+            { "type": "arc42", "href": "docs/arc42/05-building-blocks.html#api", "title": "Baustein API" }
+          ]
+        }
+      }
+    }
+  },
+  "relationships": [],
+  "views": {
+    "overview": {
+      "title": "Overview",
+      "include": ["shop", "shop.api"],
+      "layout": "layered",
+      "docLinks": [
+        { "type": "prd", "href": "docs/prd.html", "title": "Product Requirements" }
+      ]
+    },
+    "detail": {
+      "title": "Shop Detail",
+      "scope": "shop",
+      "include": ["shop.*"],
+      "layout": "layered"
+    }
+  }
+}`
+
+func TestDocLinkIcons(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	writeFile(t, modelPath, docLinkModel)
+
+	// Chain validate → sync, as a real user's workflow would (#512-style
+	// producer→consumer coverage): the new docLinks field must validate
+	// cleanly before sync ever sees it.
+	runCLI(t, bin, dir, "validate")
+	runCLI(t, bin, dir, "sync")
+
+	doc, err := drawio.LoadDocument(filepath.Join(dir, "architecture.drawio"))
+	if err != nil {
+		t.Fatalf("LoadDocument after sync: %v", err)
+	}
+
+	overviewPage := requirePageE2E(t, doc, "view-overview")
+	root := overviewPage.Root()
+
+	// Element's own link is untouched (drill-down owns "shop"'s shape link
+	// since it has a detail view; "shop.api" has no detail view so keeps its
+	// own user-defined link on the shape, per ADR-009's existing priority rule).
+	apiObj := findObjectByBSID(root, "shop.api")
+	if apiObj == nil {
+		t.Fatal("expected an <object> for shop.api on the overview page")
+	}
+	if got := apiObj.SelectAttrValue("link", ""); got != "architecture.adoc#sec-api" {
+		t.Errorf("shop.api shape: expected unchanged link %q, got %q", "architecture.adoc#sec-api", got)
+	}
+
+	// Link icon: independent clickable icon, same href. Element cell IDs on a
+	// view page are scoped ("<viewID>--<elementID>"), so the icon ID follows
+	// that same on-page cell ID, not the bare model element ID.
+	const apiCellID = "overview--shop.api"
+	linkIcon := findObjectByID(root, "doclink-"+apiCellID+"-link")
+	if linkIcon == nil {
+		t.Fatalf("expected a doclink-%s-link icon", apiCellID)
+	}
+	if got := linkIcon.SelectAttrValue("link", ""); got != "architecture.adoc#sec-api" {
+		t.Errorf("link icon: expected %q, got %q", "architecture.adoc#sec-api", got)
+	}
+
+	// Decision badge is now clickable, resolved to the ADR's file.
+	decisionIcon := findObjectByID(root, "doclink-"+apiCellID+"-decision-0")
+	if decisionIcon == nil {
+		t.Fatalf("expected a doclink-%s-decision-0 icon", apiCellID)
+	}
+	if got := decisionIcon.SelectAttrValue("link", ""); got != "ADRs/ADR-001-DSL-Format.html" {
+		t.Errorf("decision icon: expected %q, got %q", "ADRs/ADR-001-DSL-Format.html", got)
+	}
+
+	// Typed docLinks icon.
+	docIcon := findObjectByID(root, "doclink-"+apiCellID+"-doc-0")
+	if docIcon == nil {
+		t.Fatalf("expected a doclink-%s-doc-0 icon", apiCellID)
+	}
+	if got := docIcon.SelectAttrValue("link", ""); got != "docs/arc42/05-building-blocks.html#api" {
+		t.Errorf("doc icon: expected %q, got %q", "docs/arc42/05-building-blocks.html#api", got)
+	}
+
+	// View-level DocLinks icon row, page-absolute (parent=1).
+	viewIcon := findObjectByID(root, "doclink-view-overview-0")
+	if viewIcon == nil {
+		t.Fatal("expected a doclink-view-overview-0 icon on the overview page")
+	}
+	if got := viewIcon.SelectAttrValue("link", ""); got != "docs/prd.html" {
+		t.Errorf("view icon: expected %q, got %q", "docs/prd.html", got)
+	}
+
+	// The "detail" view (scope=shop) still gets its back-nav button — new
+	// icons must coexist with, not replace, existing navigation (#198).
+	detailPage := requirePageE2E(t, doc, "view-detail")
+	backNavFound := false
+	for _, obj := range detailPage.Root().SelectElements("object") {
+		if strings.HasPrefix(obj.SelectAttrValue("id", ""), "nav-back-") {
+			backNavFound = true
+			break
+		}
+	}
+	if !backNavFound {
+		t.Error("expected the detail view to still have its nav-back button")
+	}
+
+	// Re-sync must not duplicate icons (idempotency).
+	runCLI(t, bin, dir, "sync")
+	doc2, err := drawio.LoadDocument(filepath.Join(dir, "architecture.drawio"))
+	if err != nil {
+		t.Fatalf("LoadDocument after re-sync: %v", err)
+	}
+	count := 0
+	for _, obj := range requirePageE2E(t, doc2, "view-overview").Root().SelectElements("object") {
+		if obj.SelectAttrValue("id", "") == "doclink-"+apiCellID+"-link" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 doclink-%s-link icon after re-sync, got %d", apiCellID, count)
+	}
+}
+
+func requirePageE2E(t *testing.T, doc *drawio.Document, pageID string) *drawio.Page {
+	t.Helper()
+	page := doc.GetPage(pageID)
+	if page == nil {
+		t.Fatalf("expected page %q to exist", pageID)
+	}
+	return page
+}
+
+func findObjectByBSID(root *etree.Element, bsID string) *etree.Element {
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("bausteinsicht_id", "") == bsID {
+			return obj
+		}
+	}
+	return nil
+}
+
+func findObjectByID(root *etree.Element, id string) *etree.Element {
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("id", "") == id {
+			return obj
+		}
+	}
+	return nil
+}

--- a/e2e/doclink_icons_test.go
+++ b/e2e/doclink_icons_test.go
@@ -196,13 +196,49 @@ func TestDocLinkIcons(t *testing.T) {
 		t.Fatalf("bausteinsicht export: %v\n%s", err, out)
 	}
 
-	expectedHrefs := map[string]string{
-		"element link":    "architecture.adoc#sec-api",
-		"decision":        "ADRs/ADR-001-DSL-Format.html",
-		"element docLink": "docs/arc42/05-building-blocks.html#api",
-		"view docLink":    "docs/prd.html",
+	// draw.io resolves a relative href differently depending on whether it
+	// carries a "#fragment": fragment-bearing hrefs come back as just the
+	// bare fragment (e.g. "architecture.adoc#sec-api" -> "#sec-api", stripped
+	// by extractSVGHrefsRaw/validateSVGLinks's own file:// handling
+	// elsewhere); fragment-less hrefs come back as a full
+	// "file:///<local drawio install path>/<original relative path>" URL,
+	// which is NOT portable across machines with draw.io installed
+	// elsewhere. So fragment hrefs are checked by exact suffix match on the
+	// fragment; fragment-less hrefs are checked by suffix match on the
+	// original relative path instead of requiring the full file:// URL.
+	wantSuffixes := []string{
+		"#sec-api",                     // element link
+		"ADRs/ADR-001-DSL-Format.html", // decision
+		"#api",                         // element docLink
+		"docs/prd.html",                // view docLink
 	}
-	validateSVGLinks(t, filepath.Join(svgDir, "architecture-overview.svg"), expectedHrefs)
+	svgData, err := os.ReadFile(filepath.Join(svgDir, "architecture-overview.svg"))
+	if err != nil {
+		t.Fatalf("read exported SVG: %v", err)
+	}
+	gotHrefs := extractSVGHrefs(svgData)
+	for _, want := range wantSuffixes {
+		found := false
+		for href := range gotHrefs {
+			if strings.HasSuffix(href, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected an exported SVG href ending in %q, got hrefs: %v", want, hrefKeys(gotHrefs))
+		}
+	}
+}
+
+func hrefKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if !strings.HasPrefix(k, "data:") {
+			keys = append(keys, k)
+		}
+	}
+	return keys
 }
 
 func requirePageE2E(t *testing.T, doc *drawio.Document, pageID string) *drawio.Page {

--- a/e2e/doclink_icons_test.go
+++ b/e2e/doclink_icons_test.go
@@ -9,6 +9,8 @@ package e2e
 // back-nav button (#198).
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -165,6 +167,42 @@ func TestDocLinkIcons(t *testing.T) {
 	if count != 1 {
 		t.Errorf("expected exactly 1 doclink-%s-link icon after re-sync, got %d", apiCellID, count)
 	}
+
+	// ── SVG export + link validation (requires draw.io CLI) ────────────────────
+	// The .drawio-XML assertions above prove the `link` attributes are written
+	// correctly; this proves they actually survive draw.io's own SVG rendering
+	// and come out as clickable <a href> elements — the claim 03_data_models.adoc
+	// makes for `link` ("Use SVG export ... to preserve links") extended to the
+	// new doc-link icons. Mirrors bigbank_arc42_test.go's SVGExportAndLinks step.
+	drawioCmd := findDrawioCmd()
+	if drawioCmd == "" {
+		t.Log("draw.io CLI not found — skipping SVG export and link validation")
+		t.Log("To run this part: install draw.io CLI and re-run the test")
+		return
+	}
+
+	svgDir := filepath.Join(dir, "svgs")
+	if err := os.MkdirAll(svgDir, 0o755); err != nil {
+		t.Fatalf("mkdir svgs: %v", err)
+	}
+
+	exportCmd := exec.Command(bin,
+		"export",
+		"--model", modelPath,
+		"--image-format", "svg",
+		"--output", svgDir,
+	)
+	if out, err := exportCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bausteinsicht export: %v\n%s", err, out)
+	}
+
+	expectedHrefs := map[string]string{
+		"element link":    "architecture.adoc#sec-api",
+		"decision":        "ADRs/ADR-001-DSL-Format.html",
+		"element docLink": "docs/arc42/05-building-blocks.html#api",
+		"view docLink":    "docs/prd.html",
+	}
+	validateSVGLinks(t, filepath.Join(svgDir, "architecture-overview.svg"), expectedHrefs)
 }
 
 func requirePageE2E(t *testing.T, doc *drawio.Document, pageID string) *drawio.Page {

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -269,7 +269,20 @@ type Element struct {
 	LastModified string             `json:"lastModified,omitempty"` // RFC3339 timestamp (optional override for git-based staleness detection)
 	Children     map[string]Element `json:"children,omitempty"`
 	Metadata     map[string]string  `json:"metadata,omitempty"`
-	Link         string             `json:"link,omitempty"` // hyperlink on the draw.io shape and in SVG export
+	Link         string             `json:"link,omitempty"`     // hyperlink on the draw.io shape and in SVG export
+	DocLinks     []DocLink          `json:"docLinks,omitempty"` // typed documentation links, rendered as clickable icons (#543)
+}
+
+// DocLink is a typed link from a diagram element or view to an external
+// documentation artifact (arc42 chapter, ADR, PRD/persona, spec, ...),
+// rendered as a clickable icon in HTML/SVG export (#543). Type is a free
+// string (not a closed enum) so new documentation kinds don't require a
+// schema change; conventional values are "arc42", "adr", "persona", "prd",
+// "spec". Type "persona" pairs naturally with elements of kind "actor"/"person".
+type DocLink struct {
+	Type  string `json:"type"`
+	Href  string `json:"href"`
+	Title string `json:"title,omitempty"`
 }
 
 type Relationship struct {
@@ -284,12 +297,13 @@ type Relationship struct {
 }
 
 type View struct {
-	Title       string   `json:"title"`
-	Scope       string   `json:"scope,omitempty"`
-	Include     []string `json:"include,omitempty"`
-	Exclude     []string `json:"exclude,omitempty"`
-	FilterTags  []string `json:"filter-tags,omitempty"`  // Include only elements with ALL of these tags
-	ExcludeTags []string `json:"exclude-tags,omitempty"` // Exclude elements with ANY of these tags
-	Description string   `json:"description,omitempty"`
-	Layout      string   `json:"layout,omitempty"`
+	Title       string    `json:"title"`
+	Scope       string    `json:"scope,omitempty"`
+	Include     []string  `json:"include,omitempty"`
+	Exclude     []string  `json:"exclude,omitempty"`
+	FilterTags  []string  `json:"filter-tags,omitempty"`  // Include only elements with ALL of these tags
+	ExcludeTags []string  `json:"exclude-tags,omitempty"` // Exclude elements with ANY of these tags
+	Description string    `json:"description,omitempty"`
+	Layout      string    `json:"layout,omitempty"`
+	DocLinks    []DocLink `json:"docLinks,omitempty"` // view-level documentation links, rendered as a clickable icon row on the page (#543)
 }

--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -115,6 +115,8 @@ func validateElement(m *BausteinsichtModel, path string, elem Element, depth int
 		errs = append(errs, ValidationError{Path: path, Message: "missing required field \"title\""})
 	}
 
+	errs = append(errs, validateDocLinks(path+".docLinks", elem.DocLinks)...)
+
 	for childID, child := range elem.Children {
 		if err := validateElementID(childID); err != nil {
 			errs = append(errs, ValidationError{Path: path + "." + childID, Message: err.Error()})
@@ -122,6 +124,23 @@ func validateElement(m *BausteinsichtModel, path string, elem Element, depth int
 		errs = append(errs, validateElement(m, path+"."+childID, child, depth+1)...)
 	}
 
+	return errs
+}
+
+// validateDocLinks checks that every DocLink entry (on an element or a view,
+// #543) has both a type and an href — both are required for the link to be
+// renderable as a clickable icon with a meaningful glyph.
+func validateDocLinks(path string, links []DocLink) []ValidationError {
+	var errs []ValidationError
+	for i, dl := range links {
+		entryPath := fmt.Sprintf("%s[%d]", path, i)
+		if dl.Type == "" {
+			errs = append(errs, ValidationError{Path: entryPath, Message: "missing required field \"type\""})
+		}
+		if dl.Href == "" {
+			errs = append(errs, ValidationError{Path: entryPath, Message: "missing required field \"href\""})
+		}
+	}
 	return errs
 }
 
@@ -225,6 +244,7 @@ func validateViews(m *BausteinsichtModel) []ValidationError {
 				Message: fmt.Sprintf("invalid layout %q (must be \"layered\", \"grid\", \"none\", or empty)", view.Layout),
 			})
 		}
+		errs = append(errs, validateDocLinks(path+".docLinks", view.DocLinks)...)
 		if view.Scope != "" {
 			if _, err := lookupElement(m, view.Scope); err != nil {
 				errs = append(errs, ValidationError{

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -75,6 +75,54 @@ func TestValidate_MissingElementTitle(t *testing.T) {
 	}
 }
 
+func TestValidate_ElementDocLinkMissingType(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.DocLinks = []DocLink{{Href: "docs/prd.html"}}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer.docLinks[0]") {
+		t.Errorf("expected error for model.customer.docLinks[0], got %v", errs)
+	}
+}
+
+func TestValidate_ElementDocLinkMissingHref(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.DocLinks = []DocLink{{Type: "persona"}}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if !containsPath(errs, "model.customer.docLinks[0]") {
+		t.Errorf("expected error for model.customer.docLinks[0], got %v", errs)
+	}
+}
+
+func TestValidate_ElementDocLinkValid(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.DocLinks = []DocLink{{Type: "persona", Href: "docs/prd.html#felix", Title: "Felix"}}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if containsPath(errs, "model.customer.docLinks[0]") {
+		t.Errorf("expected no error for a valid docLinks entry, got %v", errs)
+	}
+}
+
+func TestValidate_ViewDocLinkMissingFields(t *testing.T) {
+	m := buildValidModel()
+	v := m.Views["main"]
+	v.DocLinks = []DocLink{{Title: "no type or href"}}
+	m.Views["main"] = v
+
+	errs := Validate(m)
+	if !containsPath(errs, "views.main.docLinks[0]") {
+		t.Errorf("expected error for views.main.docLinks[0], got %v", errs)
+	}
+}
+
 func TestValidate_UnknownElementKind(t *testing.T) {
 	m := buildValidModel()
 	elem := m.Model["customer"]

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -99,6 +99,42 @@ func TestValidate_ElementDocLinkMissingHref(t *testing.T) {
 	}
 }
 
+func TestValidate_ElementDocLinkBothFieldsMissing(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.DocLinks = []DocLink{{Title: "no type or href"}}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	count := 0
+	for _, e := range errs {
+		if e.Path == "model.customer.docLinks[0]" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Errorf("expected 2 errors (missing type AND missing href) for model.customer.docLinks[0], got %d: %v", count, errs)
+	}
+}
+
+func TestValidate_ElementDocLinkSecondEntryIndexReported(t *testing.T) {
+	m := buildValidModel()
+	elem := m.Model["customer"]
+	elem.DocLinks = []DocLink{
+		{Type: "persona", Href: "docs/prd.html#felix"}, // valid — index 0
+		{Type: "arc42"}, // missing href — index 1
+	}
+	m.Model["customer"] = elem
+
+	errs := Validate(m)
+	if containsPath(errs, "model.customer.docLinks[0]") {
+		t.Errorf("expected no error for the valid entry at index 0, got %v", errs)
+	}
+	if !containsPath(errs, "model.customer.docLinks[1]") {
+		t.Errorf("expected an error for the invalid entry at index 1, got %v", errs)
+	}
+}
+
 func TestValidate_ElementDocLinkValid(t *testing.T) {
 	m := buildValidModel()
 	elem := m.Model["customer"]

--- a/internal/sync/badge.go
+++ b/internal/sync/badge.go
@@ -55,55 +55,6 @@ func getAttr(el *etree.Element, name string) string {
 	return attr.Value
 }
 
-// AddDecisionBadges adds decision badges as child cells to an element shape.
-// One badge is created per decision, positioned in a row in the top-right corner.
-func AddDecisionBadges(elementCell *etree.Element, decisions []string, decisionMap map[string]*model.DecisionRecord) {
-	if len(decisions) == 0 {
-		return // No badges if no decisions
-	}
-
-	// Get element width (or use default if not set)
-	width := getAttrFloat(elementCell, "width", 100)
-
-	// Badge dimensions and positioning
-	badgeWidth := 30.0
-	badgeHeight := 20.0
-	badgeStartX := width - (badgeWidth * float64(len(decisions))) - 4
-	badgeY := 2.0
-
-	for i, decisionID := range decisions {
-		badge := etree.NewElement("mxCell")
-		badge.CreateAttr("id", fmt.Sprintf("%s_decision_%d", getAttr(elementCell, "id"), i))
-		badge.CreateAttr("value", "⚖")
-
-		// Determine color based on decision status
-		color := model.DecisionBadgeColor("")
-		if decision, ok := decisionMap[decisionID]; ok {
-			color = model.DecisionBadgeColor(decision.Status)
-		}
-
-		badge.CreateAttr("style", fmt.Sprintf(
-			"rounded=0;fillColor=%s;strokeColor=%s;fontSize=14;fontColor=#ffffff;"+
-				"whiteSpace=wrap;overflow=hidden;connectable=0;align=center;verticalAlign=middle",
-			color, color))
-		badge.CreateAttr("vertex", "1")
-		badge.CreateAttr("parent", getAttr(elementCell, "id"))
-		badge.CreateAttr("bausteinsicht_decision_id", decisionID)
-
-		// Geometry for the badge
-		badgeX := badgeStartX + (badgeWidth * float64(i))
-		geom := etree.NewElement("mxGeometry")
-		geom.CreateAttr("x", fmt.Sprintf("%.0f", badgeX))
-		geom.CreateAttr("y", fmt.Sprintf("%.0f", badgeY))
-		geom.CreateAttr("width", fmt.Sprintf("%.0f", badgeWidth))
-		geom.CreateAttr("height", fmt.Sprintf("%.0f", badgeHeight))
-		geom.CreateAttr("as", "geometry")
-
-		badge.AddChild(geom)
-		elementCell.AddChild(badge)
-	}
-}
-
 // getAttrFloat retrieves a float attribute value with default
 func getAttrFloat(el *etree.Element, name string, defaultVal float64) float64 {
 	attr := el.SelectAttr(name)

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -253,7 +253,8 @@ func detectUnmanagedDrawioElements(cs *ChangeSet, doc *drawio.Document) {
 			objID := obj.SelectAttrValue("id", "")
 			if strings.HasPrefix(objID, "nav-back-") ||
 				strings.HasPrefix(objID, metadataPrefix) ||
-				strings.HasPrefix(objID, legendPrefix) {
+				strings.HasPrefix(objID, legendPrefix) ||
+				strings.HasPrefix(objID, docLinkPrefix) {
 				continue
 			}
 			// Check that it wraps a vertex cell (not a connector).
@@ -342,7 +343,7 @@ func buildCellIDToElemID(doc *drawio.Document) map[string]string {
 			if cellID == "" {
 				continue
 			}
-			if strings.HasPrefix(cellID, "nav-back-") {
+			if strings.HasPrefix(cellID, "nav-back-") || strings.HasPrefix(cellID, docLinkPrefix) {
 				continue
 			}
 			cell := obj.SelectElement("mxCell")
@@ -387,7 +388,8 @@ func extractDrawioRelationships(doc *drawio.Document) map[string]RelationshipSta
 			from := resolveCellID(fromCell, cellToElem)
 			to := resolveCellID(toCell, cellToElem)
 			// Skip connectors targeting navigation buttons (#205).
-			if strings.HasPrefix(from, "nav-back-") || strings.HasPrefix(to, "nav-back-") {
+			if strings.HasPrefix(from, "nav-back-") || strings.HasPrefix(to, "nav-back-") ||
+				strings.HasPrefix(from, docLinkPrefix) || strings.HasPrefix(to, docLinkPrefix) {
 				continue
 			}
 			// Extract the relationship index from the connector ID.

--- a/internal/sync/doclinks.go
+++ b/internal/sync/doclinks.go
@@ -19,6 +19,11 @@ const docLinkPrefix = "doclink-"
 const (
 	docIconSize = 18.0
 	docIconGap  = 2.0
+
+	// docIconFill/docIconStroke are the standard doc-link icon colors,
+	// shared by every DocLink type (docLinkGlyph).
+	docIconFill   = "#dae8fc"
+	docIconStroke = "#6c8ebf"
 )
 
 // docLinkGlyph returns the icon glyph and fill/stroke colors for a DocLink
@@ -28,17 +33,17 @@ const (
 func docLinkGlyph(linkType string) (glyph, fill, stroke string) {
 	switch linkType {
 	case "arc42":
-		return "\U0001F4D6", "#dae8fc", "#6c8ebf" // 📖
+		return "\U0001F4D6", docIconFill, docIconStroke // 📖
 	case "adr":
-		return "⚖", "#dae8fc", "#6c8ebf" // ⚖
+		return "⚖", docIconFill, docIconStroke // ⚖
 	case "persona":
-		return "\U0001F464", "#dae8fc", "#6c8ebf" // 👤
+		return "\U0001F464", docIconFill, docIconStroke // 👤
 	case "prd":
-		return "\U0001F4CB", "#dae8fc", "#6c8ebf" // 📋
+		return "\U0001F4CB", docIconFill, docIconStroke // 📋
 	case "spec":
-		return "\U0001F4C4", "#dae8fc", "#6c8ebf" // 📄
+		return "\U0001F4C4", docIconFill, docIconStroke // 📄
 	default:
-		return "\U0001F517", "#dae8fc", "#6c8ebf" // 🔗
+		return "\U0001F517", docIconFill, docIconStroke // 🔗
 	}
 }
 
@@ -204,34 +209,50 @@ func synchronizeDocLinkIcons(page *drawio.Page, m *model.BausteinsichtModel) {
 	}
 
 	for _, obj := range root.SelectElements("object") {
-		elemID := obj.SelectAttrValue("bausteinsicht_id", "")
-		if elemID == "" {
-			continue
-		}
-		elem, ok := findElementByID(m, elemID)
-		if !ok || elem == nil {
-			continue
-		}
-		cellID := obj.SelectAttrValue("id", "")
-		if cellID == "" {
-			continue
-		}
-
-		removeDocIcons(root, docLinkPrefix+cellID+"-")
-
-		icons := buildElementDocIcons(cellID, elem, decisionMap)
-		if len(icons) == 0 {
-			continue
-		}
-
-		width := 100.0
-		if cell := obj.SelectElement("mxCell"); cell != nil {
-			if geo := cell.SelectElement("mxGeometry"); geo != nil {
-				width = parseFloat(geo.SelectAttrValue("width", "100"))
-			}
-		}
-		placeElementIconRow(root, cellID, icons, width)
+		syncElementDocIcons(root, obj, m, decisionMap)
 	}
+}
+
+// syncElementDocIcons rebuilds the doc-link icon row for a single element
+// cell, if it maps to a known model element (split out of
+// synchronizeDocLinkIcons to keep cognitive complexity down).
+func syncElementDocIcons(root *etree.Element, obj *etree.Element, m *model.BausteinsichtModel, decisionMap map[string]*model.DecisionRecord) {
+	elemID := obj.SelectAttrValue("bausteinsicht_id", "")
+	if elemID == "" {
+		return
+	}
+	elem, ok := findElementByID(m, elemID)
+	if !ok || elem == nil {
+		return
+	}
+	cellID := obj.SelectAttrValue("id", "")
+	if cellID == "" {
+		return
+	}
+
+	removeDocIcons(root, docLinkPrefix+cellID+"-")
+
+	icons := buildElementDocIcons(cellID, elem, decisionMap)
+	if len(icons) == 0 {
+		return
+	}
+
+	placeElementIconRow(root, cellID, icons, elementWidth(obj))
+}
+
+// elementWidth reads an element cell's on-page width, defaulting to 100 if
+// the cell has no geometry (mirrors the fallback synchronizeDocLinkIcons
+// always used).
+func elementWidth(obj *etree.Element) float64 {
+	cell := obj.SelectElement("mxCell")
+	if cell == nil {
+		return 100.0
+	}
+	geo := cell.SelectElement("mxGeometry")
+	if geo == nil {
+		return 100.0
+	}
+	return parseFloat(geo.SelectAttrValue("width", "100"))
 }
 
 // synchronizeViewDocLinkIcons updates the clickable icon row for a view's

--- a/internal/sync/doclinks.go
+++ b/internal/sync/doclinks.go
@@ -235,12 +235,14 @@ func synchronizeDocLinkIcons(page *drawio.Page, m *model.BausteinsichtModel) {
 }
 
 // synchronizeViewDocLinkIcons updates the clickable icon row for a view's
-// page-level DocLinks (#543). The row is positioned once — below the
-// metadata/legend boxes, mirroring their own placement convention, since
-// this codebase has no notion of a "free diagram corner", only the max
-// Y/X of existing content (see computeMaxY/computeContentWidth) — and its
-// position is then reused on every subsequent sync (read back from an
-// existing icon's geometry) rather than recomputed, so it never drifts.
+// page-level DocLinks (#543). The row is anchored to the metadata box's own
+// top-right corner and grows leftward as more icons are added — the same
+// convention placeElementIconRow uses for element icons — and is recomputed
+// every sync from the metadata box's actual (possibly dynamically-sized)
+// geometry via infoBoxGeometry, so it tracks the box instead of colliding
+// with it. Anchoring to computeMaxY independently, as before, put the row at
+// the exact same coordinate as the metadata box itself, since both derived
+// their position from the same page-content bound.
 func synchronizeViewDocLinkIcons(page *drawio.Page, viewID string, view model.View) {
 	root := page.Root()
 	if root == nil {
@@ -248,41 +250,21 @@ func synchronizeViewDocLinkIcons(page *drawio.Page, viewID string, view model.Vi
 	}
 	prefix := docLinkPrefix + "view-" + viewID + "-"
 
-	var existing []*etree.Element
-	for _, obj := range root.SelectElements("object") {
-		if strings.HasPrefix(obj.SelectAttrValue("id", ""), prefix) {
-			existing = append(existing, obj)
-		}
-	}
+	removeDocIcons(root, prefix)
 
 	if len(view.DocLinks) == 0 {
-		for _, obj := range existing {
-			root.RemoveChild(obj)
-		}
 		return
 	}
 
-	x, y := metadataX, 0.0
-	positionKnown := false
-	if len(existing) > 0 {
-		if cell := existing[0].SelectElement("mxCell"); cell != nil {
-			if geo := cell.SelectElement("mxGeometry"); geo != nil {
-				x = parseFloat(geo.SelectAttrValue("x", "0"))
-				y = parseFloat(geo.SelectAttrValue("y", "0"))
-				positionKnown = true
-			}
-		}
-	}
-	if !positionKnown {
-		metaCellID := metadataPrefix + viewID
-		legendCellID := legendPrefix + viewID
-		y = computeMaxY(page, metaCellID, legendCellID) + infoBoxGap
+	x, y, w, _, found := infoBoxGeometry(root, metadataPrefix+viewID)
+	if !found {
 		x = metadataX
+		y = computeMaxY(page, metadataPrefix+viewID, legendPrefix+viewID) + infoBoxGap
+		w = metadataWidth
 	}
-
-	for _, obj := range existing {
-		root.RemoveChild(obj)
-	}
+	rowWidth := float64(len(view.DocLinks))*(docIconSize+docIconGap) - docIconGap
+	startX := x + w - rowWidth
+	startY := y + docIconGap
 
 	for i, dl := range view.DocLinks {
 		glyph, fill, stroke := docLinkGlyph(dl.Type)
@@ -298,6 +280,6 @@ func synchronizeViewDocLinkIcons(page *drawio.Page, viewID string, view model.Vi
 			href:    dl.Href,
 			tooltip: tooltip,
 		}
-		createDocIcon(root, "1", icon, x+float64(i)*(docIconSize+docIconGap), y)
+		createDocIcon(root, "1", icon, startX+float64(i)*(docIconSize+docIconGap), startY)
 	}
 }

--- a/internal/sync/doclinks.go
+++ b/internal/sync/doclinks.go
@@ -1,0 +1,294 @@
+package sync
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/beevik/etree"
+	"github.com/docToolchain/Bausteinsicht/internal/drawio"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// docLinkPrefix marks synthetic clickable icon cells created for #543
+// (element and view documentation-drilldown links) so they are excluded
+// from reverse-sync element/relationship extraction and other structural
+// scanners, the same way "nav-back-" back-navigation buttons are (#205).
+const docLinkPrefix = "doclink-"
+
+const (
+	docIconSize = 18.0
+	docIconGap  = 2.0
+)
+
+// docLinkGlyph returns the icon glyph and fill/stroke colors for a DocLink
+// type. Unknown or empty types fall back to a generic link glyph so an icon
+// is always rendered rather than silently dropped — DocLink.Type is a free
+// string, not a closed schema enum (see model.DocLink).
+func docLinkGlyph(linkType string) (glyph, fill, stroke string) {
+	switch linkType {
+	case "arc42":
+		return "\U0001F4D6", "#dae8fc", "#6c8ebf" // 📖
+	case "adr":
+		return "⚖", "#dae8fc", "#6c8ebf" // ⚖
+	case "persona":
+		return "\U0001F464", "#dae8fc", "#6c8ebf" // 👤
+	case "prd":
+		return "\U0001F4CB", "#dae8fc", "#6c8ebf" // 📋
+	case "spec":
+		return "\U0001F4C4", "#dae8fc", "#6c8ebf" // 📄
+	default:
+		return "\U0001F517", "#dae8fc", "#6c8ebf" // 🔗
+	}
+}
+
+// docIcon describes one clickable icon to render as its own top-level
+// <object>, positioned via mxGraph's parent-ID attribute rather than XML
+// nesting (see createBackNavButton/createInfoBox for the same convention;
+// bare <mxCell> cells, as used by the older AddStatusBadge, cannot carry a
+// link attribute — only <object> wrappers can, per element.go/forward.go's
+// existing use of the `link` attribute throughout this codebase).
+type docIcon struct {
+	id      string // globally unique cell id; always starts with docLinkPrefix
+	glyph   string
+	fill    string
+	stroke  string
+	href    string // may be empty: the icon still renders, just isn't clickable
+	tooltip string
+}
+
+// createDocIcon creates one clickable icon <object> as a direct child of
+// root, parented (via mxGraph's parent-ID attribute) to parentCellID at the
+// given position — parentCellID may be "1" for page-absolute placement
+// (view-level icons) or an element's own on-page cell ID for placement
+// relative to that element's bounding box (element-level icons).
+func createDocIcon(root *etree.Element, parentCellID string, icon docIcon, x, y float64) {
+	obj := root.CreateElement("object")
+	obj.CreateAttr("id", icon.id)
+	if icon.href != "" {
+		obj.CreateAttr("link", icon.href)
+	}
+	if icon.tooltip != "" {
+		obj.CreateAttr("tooltip", icon.tooltip)
+	}
+
+	cell := obj.CreateElement("mxCell")
+	cell.CreateAttr("value", icon.glyph)
+	cell.CreateAttr("style", fmt.Sprintf(
+		"rounded=1;fillColor=%s;strokeColor=%s;fontSize=11;fontColor=#000000;"+
+			"whiteSpace=wrap;overflow=hidden;connectable=0;align=center;verticalAlign=middle;html=1;",
+		icon.fill, icon.stroke))
+	cell.CreateAttr("vertex", "1")
+	cell.CreateAttr("parent", parentCellID)
+
+	geom := cell.CreateElement("mxGeometry")
+	geom.CreateAttr("x", strconv.FormatFloat(x, 'f', 0, 64))
+	geom.CreateAttr("y", strconv.FormatFloat(y, 'f', 0, 64))
+	geom.CreateAttr("width", strconv.FormatFloat(docIconSize, 'f', 0, 64))
+	geom.CreateAttr("height", strconv.FormatFloat(docIconSize, 'f', 0, 64))
+	geom.CreateAttr("as", "geometry")
+}
+
+// removeDocIcons removes every existing doc-link icon object whose id
+// starts with the given prefix, so re-sync doesn't accumulate stale or
+// duplicate icons (mirrors the decision-badge remove-then-recreate
+// lifecycle this replaces).
+func removeDocIcons(root *etree.Element, prefix string) {
+	for _, obj := range root.SelectElements("object") {
+		if strings.HasPrefix(obj.SelectAttrValue("id", ""), prefix) {
+			root.RemoveChild(obj)
+		}
+	}
+}
+
+// buildElementDocIcons returns the ordered list of doc-link icons for one
+// element: a Link icon (if set — independent of any auto-generated
+// drill-down link that may separately own the element shape's own `link`
+// attribute, see ADR-009's "Extension: Doc/ADR Drilldown (#543)"), one per
+// Decisions entry (clickable when the ADR record has a file path), then one
+// per DocLinks entry — in that left-to-right rendering order.
+func buildElementDocIcons(cellID string, elem *model.Element, decisionMap map[string]*model.DecisionRecord) []docIcon {
+	var icons []docIcon
+
+	if elem.Link != "" {
+		glyph, fill, stroke := docLinkGlyph("")
+		icons = append(icons, docIcon{
+			id:      docLinkPrefix + cellID + "-link",
+			glyph:   glyph,
+			fill:    fill,
+			stroke:  stroke,
+			href:    elem.Link,
+			tooltip: "Open linked document",
+		})
+	}
+
+	for i, decisionID := range elem.Decisions {
+		color := model.DecisionBadgeColor("")
+		href := ""
+		tooltip := decisionID
+		if d, ok := decisionMap[decisionID]; ok {
+			color = model.DecisionBadgeColor(d.Status)
+			href = d.FilePath
+			tooltip = fmt.Sprintf("%s: %s", d.ID, d.Title)
+		}
+		icons = append(icons, docIcon{
+			id:      fmt.Sprintf("%s%s-decision-%d", docLinkPrefix, cellID, i),
+			glyph:   "⚖", // ⚖ — same glyph decision badges have always used
+			fill:    color,
+			stroke:  color,
+			href:    href,
+			tooltip: tooltip,
+		})
+	}
+
+	for i, dl := range elem.DocLinks {
+		glyph, fill, stroke := docLinkGlyph(dl.Type)
+		tooltip := dl.Title
+		if tooltip == "" {
+			tooltip = dl.Type
+		}
+		icons = append(icons, docIcon{
+			id:      fmt.Sprintf("%s%s-doc-%d", docLinkPrefix, cellID, i),
+			glyph:   glyph,
+			fill:    fill,
+			stroke:  stroke,
+			href:    dl.Href,
+			tooltip: tooltip,
+		})
+	}
+
+	return icons
+}
+
+// placeElementIconRow creates the given icons as a row anchored to the
+// parent element's top-right corner, growing leftward as more icons are
+// added — matching the positioning convention the older decision badges
+// used (AddDecisionBadges).
+func placeElementIconRow(root *etree.Element, parentCellID string, icons []docIcon, parentWidth float64) {
+	if len(icons) == 0 {
+		return
+	}
+	startX := parentWidth - (docIconSize+docIconGap)*float64(len(icons))
+	for i, icon := range icons {
+		x := startX + float64(i)*(docIconSize+docIconGap)
+		createDocIcon(root, parentCellID, icon, x, docIconGap)
+	}
+}
+
+// synchronizeDocLinkIcons updates the clickable documentation-link icons on
+// every element of a page: a Link icon, clickable decision badges, and
+// DocLinks icons (#543). Old icons are removed and recreated each sync —
+// the row position is purely a function of the element's current width and
+// icon count, so recomputing it every sync is idempotent (no drift).
+func synchronizeDocLinkIcons(page *drawio.Page, m *model.BausteinsichtModel) {
+	if m == nil {
+		return
+	}
+	decisionMap := make(map[string]*model.DecisionRecord, len(m.Specification.Decisions))
+	for i := range m.Specification.Decisions {
+		decisionMap[m.Specification.Decisions[i].ID] = &m.Specification.Decisions[i]
+	}
+
+	root := page.Root()
+	if root == nil {
+		return
+	}
+
+	for _, obj := range root.SelectElements("object") {
+		elemID := obj.SelectAttrValue("bausteinsicht_id", "")
+		if elemID == "" {
+			continue
+		}
+		elem, ok := findElementByID(m, elemID)
+		if !ok || elem == nil {
+			continue
+		}
+		cellID := obj.SelectAttrValue("id", "")
+		if cellID == "" {
+			continue
+		}
+
+		removeDocIcons(root, docLinkPrefix+cellID+"-")
+
+		icons := buildElementDocIcons(cellID, elem, decisionMap)
+		if len(icons) == 0 {
+			continue
+		}
+
+		width := 100.0
+		if cell := obj.SelectElement("mxCell"); cell != nil {
+			if geo := cell.SelectElement("mxGeometry"); geo != nil {
+				width = parseFloat(geo.SelectAttrValue("width", "100"))
+			}
+		}
+		placeElementIconRow(root, cellID, icons, width)
+	}
+}
+
+// synchronizeViewDocLinkIcons updates the clickable icon row for a view's
+// page-level DocLinks (#543). The row is positioned once — below the
+// metadata/legend boxes, mirroring their own placement convention, since
+// this codebase has no notion of a "free diagram corner", only the max
+// Y/X of existing content (see computeMaxY/computeContentWidth) — and its
+// position is then reused on every subsequent sync (read back from an
+// existing icon's geometry) rather than recomputed, so it never drifts.
+func synchronizeViewDocLinkIcons(page *drawio.Page, viewID string, view model.View) {
+	root := page.Root()
+	if root == nil {
+		return
+	}
+	prefix := docLinkPrefix + "view-" + viewID + "-"
+
+	var existing []*etree.Element
+	for _, obj := range root.SelectElements("object") {
+		if strings.HasPrefix(obj.SelectAttrValue("id", ""), prefix) {
+			existing = append(existing, obj)
+		}
+	}
+
+	if len(view.DocLinks) == 0 {
+		for _, obj := range existing {
+			root.RemoveChild(obj)
+		}
+		return
+	}
+
+	x, y := metadataX, 0.0
+	positionKnown := false
+	if len(existing) > 0 {
+		if cell := existing[0].SelectElement("mxCell"); cell != nil {
+			if geo := cell.SelectElement("mxGeometry"); geo != nil {
+				x = parseFloat(geo.SelectAttrValue("x", "0"))
+				y = parseFloat(geo.SelectAttrValue("y", "0"))
+				positionKnown = true
+			}
+		}
+	}
+	if !positionKnown {
+		metaCellID := metadataPrefix + viewID
+		legendCellID := legendPrefix + viewID
+		y = computeMaxY(page, metaCellID, legendCellID) + infoBoxGap
+		x = metadataX
+	}
+
+	for _, obj := range existing {
+		root.RemoveChild(obj)
+	}
+
+	for i, dl := range view.DocLinks {
+		glyph, fill, stroke := docLinkGlyph(dl.Type)
+		tooltip := dl.Title
+		if tooltip == "" {
+			tooltip = dl.Type
+		}
+		icon := docIcon{
+			id:      fmt.Sprintf("%s%d", prefix, i),
+			glyph:   glyph,
+			fill:    fill,
+			stroke:  stroke,
+			href:    dl.Href,
+			tooltip: tooltip,
+		}
+		createDocIcon(root, "1", icon, x+float64(i)*(docIconSize+docIconGap), y)
+	}
+}

--- a/internal/sync/doclinks.go
+++ b/internal/sync/doclinks.go
@@ -65,6 +65,16 @@ type docIcon struct {
 func createDocIcon(root *etree.Element, parentCellID string, icon docIcon, x, y float64) {
 	obj := root.CreateElement("object")
 	obj.CreateAttr("id", icon.id)
+	// The glyph must be the <object>'s own "label" attribute, not a "value"
+	// attribute on the inner <mxCell> — draw.io's SVG exporter only wraps a
+	// shape in a clickable <a href> when the cell's displayed value comes
+	// from the <object> wrapper's UserObject attributes (label/link/tooltip,
+	// same as every other <object link=...> in this codebase: CreateElement,
+	// createBackNavButton, createInfoBox). A "value" set directly on the
+	// inner mxCell instead is still rendered visually (confirmed: the glyph
+	// still shows, rasterized), but silently breaks link export — verified
+	// against a real draw.io 31.0.2 SVG export while investigating #543.
+	obj.CreateAttr("label", icon.glyph)
 	if icon.href != "" {
 		obj.CreateAttr("link", icon.href)
 	}
@@ -73,7 +83,6 @@ func createDocIcon(root *etree.Element, parentCellID string, icon docIcon, x, y 
 	}
 
 	cell := obj.CreateElement("mxCell")
-	cell.CreateAttr("value", icon.glyph)
 	cell.CreateAttr("style", fmt.Sprintf(
 		"rounded=1;fillColor=%s;strokeColor=%s;fontSize=11;fontColor=#000000;"+
 			"whiteSpace=wrap;overflow=hidden;connectable=0;align=center;verticalAlign=middle;html=1;",

--- a/internal/sync/doclinks_test.go
+++ b/internal/sync/doclinks_test.go
@@ -1,0 +1,299 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/docToolchain/Bausteinsicht/internal/drawio"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// findObjectByID returns the <object> with the given draw.io cell id, or nil.
+func findObjectByID(root *etree.Element, id string) *etree.Element {
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("id", "") == id {
+			return obj
+		}
+	}
+	return nil
+}
+
+// --- Element-level doc-link icons (#543) ---
+
+func TestSynchronizeDocLinkIcons_LinkIcon(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API", Link: "architecture.adoc#sec-backend"},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+	icon := findObjectByID(page.Root(), "doclink-api-link")
+	if icon == nil {
+		t.Fatal("expected a doclink-api-link icon object")
+	}
+	if got := icon.SelectAttrValue("link", ""); got != "architecture.adoc#sec-backend" {
+		t.Errorf("expected link %q, got %q", "architecture.adoc#sec-backend", got)
+	}
+	// The element's own shape link is untouched by the icon (ADR-009 priority
+	// rule for drill-down vs. user link is unaffected by this new icon).
+	elemObj := findObjectByID(page.Root(), "api")
+	if elemObj == nil {
+		t.Fatal("expected the element's own object to exist")
+	}
+	if got := elemObj.SelectAttrValue("link", ""); got != "architecture.adoc#sec-backend" {
+		t.Errorf("expected element shape to keep its own link %q, got %q", "architecture.adoc#sec-backend", got)
+	}
+}
+
+func TestSynchronizeDocLinkIcons_NoLinkNoIcon(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API"},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+	if icon := findObjectByID(page.Root(), "doclink-api-link"); icon != nil {
+		t.Error("expected no doclink-api-link icon when Link is unset")
+	}
+}
+
+func TestSynchronizeDocLinkIcons_DecisionClickableWhenFileKnown(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Decisions: []model.DecisionRecord{
+				{ID: "ADR-001", Title: "Use JSONC", Status: model.ADRActive, FilePath: "ADRs/ADR-001-DSL-Format.html"},
+			},
+		},
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API", Decisions: []string{"ADR-001"}},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+	icon := findObjectByID(page.Root(), "doclink-api-decision-0")
+	if icon == nil {
+		t.Fatal("expected a doclink-api-decision-0 icon object")
+	}
+	if got := icon.SelectAttrValue("link", ""); got != "ADRs/ADR-001-DSL-Format.html" {
+		t.Errorf("expected link %q, got %q", "ADRs/ADR-001-DSL-Format.html", got)
+	}
+}
+
+func TestSynchronizeDocLinkIcons_DecisionNotClickableWithoutFile(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Decisions: []model.DecisionRecord{
+				{ID: "ADR-001", Title: "Use JSONC", Status: model.ADRActive}, // no FilePath
+			},
+		},
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API", Decisions: []string{"ADR-001"}},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+	icon := findObjectByID(page.Root(), "doclink-api-decision-0")
+	if icon == nil {
+		t.Fatal("expected a doclink-api-decision-0 icon object even without a file (visible, non-clickable)")
+	}
+	if got := icon.SelectAttrValue("link", ""); got != "" {
+		t.Errorf("expected no link attribute when the ADR has no file, got %q", got)
+	}
+}
+
+func TestSynchronizeDocLinkIcons_DocLinksTyped(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api": {
+				Kind:  "container",
+				Title: "API",
+				DocLinks: []model.DocLink{
+					{Type: "arc42", Href: "docs/arc42/05-building-blocks.html#api", Title: "Baustein API"},
+					{Type: "persona", Href: "docs/prd.html#felix"},
+				},
+			},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+
+	icon0 := findObjectByID(page.Root(), "doclink-api-doc-0")
+	if icon0 == nil {
+		t.Fatal("expected a doclink-api-doc-0 icon object")
+	}
+	if got := icon0.SelectAttrValue("link", ""); got != "docs/arc42/05-building-blocks.html#api" {
+		t.Errorf("doc-0: expected link %q, got %q", "docs/arc42/05-building-blocks.html#api", got)
+	}
+	if got := icon0.SelectAttrValue("tooltip", ""); got != "Baustein API" {
+		t.Errorf("doc-0: expected tooltip %q, got %q", "Baustein API", got)
+	}
+
+	icon1 := findObjectByID(page.Root(), "doclink-api-doc-1")
+	if icon1 == nil {
+		t.Fatal("expected a doclink-api-doc-1 icon object")
+	}
+	if got := icon1.SelectAttrValue("link", ""); got != "docs/prd.html#felix" {
+		t.Errorf("doc-1: expected link %q, got %q", "docs/prd.html#felix", got)
+	}
+	// Title omitted → tooltip falls back to the type.
+	if got := icon1.SelectAttrValue("tooltip", ""); got != "persona" {
+		t.Errorf("doc-1: expected fallback tooltip %q, got %q", "persona", got)
+	}
+}
+
+func TestSynchronizeDocLinkIcons_StaleIconsRemovedOnResync(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API", Link: "architecture.adoc#sec-backend"},
+		},
+	}
+	doc := emptyDoc()
+
+	r1 := Run(m, doc, emptyState(), ts, nil)
+	page := requireFirstPage(t, doc)
+	if findObjectByID(page.Root(), "doclink-api-link") == nil {
+		t.Fatal("round 1: expected the link icon to exist")
+	}
+
+	// Remove the Link in the model and re-sync from the state round 1 produced.
+	state1 := stateWithElem("api", "API", "", "")
+	m.Model["api"] = model.Element{Kind: "container", Title: "API"}
+	Run(m, doc, state1, ts, nil)
+
+	if icon := findObjectByID(page.Root(), "doclink-api-link"); icon != nil {
+		t.Error("round 2: expected the stale link icon to be removed")
+	}
+	_ = r1
+}
+
+// --- View-level doc-link icons (#543) ---
+
+func viewModelWithDocLinks(docLinks []model.DocLink) *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{"container": {Notation: "Container"}},
+		},
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API"},
+		},
+		Views: map[string]model.View{
+			"overview": {
+				Title:    "Overview",
+				Include:  []string{"api"},
+				Layout:   "layered",
+				DocLinks: docLinks,
+			},
+		},
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_Basic(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{
+		{Type: "prd", Href: "docs/prd.html", Title: "Product Requirements"},
+	})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requirePage(t, doc, "view-overview")
+	icon := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon == nil {
+		t.Fatal("expected a doclink-view-overview-0 icon object")
+	}
+	if got := icon.SelectAttrValue("link", ""); got != "docs/prd.html" {
+		t.Errorf("expected link %q, got %q", "docs/prd.html", got)
+	}
+	cell := icon.SelectElement("mxCell")
+	if cell == nil {
+		t.Fatal("expected the icon to wrap an mxCell")
+	}
+	if got := cell.SelectAttrValue("parent", ""); got != "1" {
+		t.Errorf("expected the view-level icon to be page-absolute (parent=1), got %q", got)
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_NoDocLinksNoIcons(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks(nil)
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requirePage(t, doc, "view-overview")
+	for _, obj := range page.Root().SelectElements("object") {
+		id := obj.SelectAttrValue("id", "")
+		if len(id) >= len("doclink-view-") && id[:len("doclink-view-")] == "doclink-view-" {
+			t.Errorf("expected no view-level doc-link icons, found %q", id)
+		}
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_PositionStableAcrossSyncs(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{
+		{Type: "prd", Href: "docs/prd.html"},
+	})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+	page := requirePage(t, doc, "view-overview")
+	icon1 := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon1 == nil {
+		t.Fatal("round 1: expected the icon to exist")
+	}
+	x1 := icon1.SelectElement("mxCell").SelectElement("mxGeometry").SelectAttrValue("x", "")
+	y1 := icon1.SelectElement("mxCell").SelectElement("mxGeometry").SelectAttrValue("y", "")
+
+	// Second sync: change the doc link's title (content changes) but not the
+	// row's existence — the position must not drift.
+	m.Views["overview"] = model.View{
+		Title:    "Overview",
+		Include:  []string{"api"},
+		Layout:   "layered",
+		DocLinks: []model.DocLink{{Type: "prd", Href: "docs/prd.html", Title: "Updated Title"}},
+	}
+	state1 := emptyState()
+	state1.Elements["api"] = ElementState{Title: "API", Kind: "container"}
+	Run(m, doc, state1, ts, nil)
+
+	icon2 := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon2 == nil {
+		t.Fatal("round 2: expected the icon to still exist")
+	}
+	x2 := icon2.SelectElement("mxCell").SelectElement("mxGeometry").SelectAttrValue("x", "")
+	y2 := icon2.SelectElement("mxCell").SelectElement("mxGeometry").SelectAttrValue("y", "")
+
+	if x1 != x2 || y1 != y2 {
+		t.Errorf("expected stable position across syncs, round1=(%s,%s) round2=(%s,%s)", x1, y1, x2, y2)
+	}
+	if got := icon2.SelectAttrValue("tooltip", ""); got != "Updated Title" {
+		t.Errorf("expected updated tooltip %q, got %q", "Updated Title", got)
+	}
+}

--- a/internal/sync/doclinks_test.go
+++ b/internal/sync/doclinks_test.go
@@ -1,6 +1,8 @@
 package sync
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/beevik/etree"
@@ -295,5 +297,376 @@ func TestSynchronizeViewDocLinkIcons_PositionStableAcrossSyncs(t *testing.T) {
 	}
 	if got := icon2.SelectAttrValue("tooltip", ""); got != "Updated Title" {
 		t.Errorf("expected updated tooltip %q, got %q", "Updated Title", got)
+	}
+}
+
+// --- Additional coverage: glyph table, geometry, multi-entry, multi-view,
+// removal, growth, and the reverse-sync safety property (#543 follow-up) ---
+
+func iconX(t *testing.T, obj *etree.Element) float64 {
+	t.Helper()
+	cell := obj.SelectElement("mxCell")
+	if cell == nil {
+		t.Fatal("icon has no mxCell")
+	}
+	geo := cell.SelectElement("mxGeometry")
+	if geo == nil {
+		t.Fatal("icon has no mxGeometry")
+	}
+	return parseFloat(geo.SelectAttrValue("x", "0"))
+}
+
+func TestDocLinkGlyph_AllTypesDistinct(t *testing.T) {
+	types := []string{"arc42", "adr", "persona", "prd", "spec", "unknown-type", ""}
+	seen := make(map[string]string, len(types))
+	for _, typ := range types {
+		glyph, fill, stroke := docLinkGlyph(typ)
+		if glyph == "" {
+			t.Errorf("type %q: expected a non-empty glyph", typ)
+		}
+		if fill == "" || stroke == "" {
+			t.Errorf("type %q: expected non-empty fill/stroke colors", typ)
+		}
+		if other, ok := seen[glyph]; ok && other != typ {
+			// "unknown-type" and "" both intentionally fall back to the same
+			// generic glyph — that's the one allowed collision.
+			if !((typ == "unknown-type" || typ == "") && (other == "unknown-type" || other == "")) {
+				t.Errorf("type %q: glyph %q collides with type %q", typ, glyph, other)
+			}
+		}
+		seen[glyph] = typ
+	}
+	// Known types must each get their own distinct glyph (no two conventional
+	// types silently sharing an icon).
+	knownGlyphs := make(map[string]bool)
+	for _, typ := range []string{"arc42", "adr", "persona", "prd", "spec"} {
+		glyph, _, _ := docLinkGlyph(typ)
+		if knownGlyphs[glyph] {
+			t.Errorf("type %q: glyph %q is not unique among the conventional types", typ, glyph)
+		}
+		knownGlyphs[glyph] = true
+	}
+}
+
+func TestPlaceElementIconRow_NoOverlap(t *testing.T) {
+	root := etree.NewElement("root")
+	icons := []docIcon{
+		{id: "doclink-x-a", glyph: "a", fill: "#fff", stroke: "#000", href: "a"},
+		{id: "doclink-x-b", glyph: "b", fill: "#fff", stroke: "#000", href: "b"},
+		{id: "doclink-x-c", glyph: "c", fill: "#fff", stroke: "#000", href: "c"},
+	}
+	placeElementIconRow(root, "elem1", icons, 200)
+
+	var xs []float64
+	for _, icon := range icons {
+		obj := findObjectByID(root, icon.id)
+		if obj == nil {
+			t.Fatalf("expected icon %q to exist", icon.id)
+		}
+		xs = append(xs, iconX(t, obj))
+	}
+	for i := 1; i < len(xs); i++ {
+		gap := xs[i] - xs[i-1]
+		if gap != docIconSize+docIconGap {
+			t.Errorf("icon %d: expected x-gap %v from previous icon, got %v (xs=%v)", i, docIconSize+docIconGap, gap, xs)
+		}
+		if xs[i] < xs[i-1]+docIconSize {
+			t.Errorf("icon %d overlaps icon %d: xs=%v, iconSize=%v", i, i-1, xs, docIconSize)
+		}
+	}
+	// The row leaves a docIconGap margin at the parent's right edge (matches
+	// the pre-existing AddDecisionBadges/AddStatusBadge margin convention).
+	wantEnd := 200.0 - docIconGap
+	if last := xs[len(xs)-1]; last+docIconSize != wantEnd {
+		t.Errorf("expected the last icon to end at %v (parent width 200 minus the %v margin), got end=%v", wantEnd, docIconGap, last+docIconSize)
+	}
+}
+
+func TestSynchronizeDocLinkIcons_CombinedOrderAndUniqueness(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Decisions: []model.DecisionRecord{
+				{ID: "ADR-001", Status: model.ADRActive, FilePath: "adr1.html"},
+				{ID: "ADR-002", Status: model.ADRActive, FilePath: "adr2.html"},
+			},
+		},
+		Model: map[string]model.Element{
+			"api": {
+				Kind:      "container",
+				Title:     "API",
+				Link:      "architecture.adoc#sec-api",
+				Decisions: []string{"ADR-001", "ADR-002"},
+				DocLinks: []model.DocLink{
+					{Type: "arc42", Href: "arc42.html"},
+					{Type: "persona", Href: "persona.html"},
+				},
+			},
+		},
+	}
+	doc := emptyDoc()
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requireFirstPage(t, doc)
+	root := page.Root()
+
+	// All 5 icons must exist, each with a unique id and its own href.
+	wantOrder := []struct {
+		id   string
+		href string
+	}{
+		{"doclink-api-link", "architecture.adoc#sec-api"},
+		{"doclink-api-decision-0", "adr1.html"},
+		{"doclink-api-decision-1", "adr2.html"},
+		{"doclink-api-doc-0", "arc42.html"},
+		{"doclink-api-doc-1", "persona.html"},
+	}
+
+	var xs []float64
+	for _, want := range wantOrder {
+		obj := findObjectByID(root, want.id)
+		if obj == nil {
+			t.Fatalf("expected icon %q to exist", want.id)
+		}
+		if got := obj.SelectAttrValue("link", ""); got != want.href {
+			t.Errorf("icon %q: expected href %q, got %q", want.id, want.href, got)
+		}
+		xs = append(xs, iconX(t, obj))
+	}
+
+	// Left-to-right rendering order must match wantOrder (link, decisions, docLinks).
+	for i := 1; i < len(xs); i++ {
+		if xs[i] <= xs[i-1] {
+			t.Errorf("icon %d (%s, x=%v) is not to the right of icon %d (%s, x=%v) — order/overlap violated",
+				i, wantOrder[i].id, xs[i], i-1, wantOrder[i-1].id, xs[i-1])
+		}
+	}
+
+	// No stray 6th icon.
+	count := 0
+	for _, obj := range root.SelectElements("object") {
+		if strings.HasPrefix(obj.SelectAttrValue("id", ""), "doclink-api-") {
+			count++
+		}
+	}
+	if count != len(wantOrder) {
+		t.Errorf("expected exactly %d doclink-api-* icons, got %d", len(wantOrder), count)
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_MultipleEntries(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{
+		{Type: "prd", Href: "docs/prd.html"},
+		{Type: "persona", Href: "docs/persona.html"},
+		{Type: "arc42", Href: "docs/arc42.html"},
+	})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	page := requirePage(t, doc, "view-overview")
+	root := page.Root()
+
+	wantHrefs := []string{"docs/prd.html", "docs/persona.html", "docs/arc42.html"}
+	var xs []float64
+	for i, href := range wantHrefs {
+		id := "doclink-view-overview-" + strconv.Itoa(i)
+		obj := findObjectByID(root, id)
+		if obj == nil {
+			t.Fatalf("expected icon %q to exist", id)
+		}
+		if got := obj.SelectAttrValue("link", ""); got != href {
+			t.Errorf("icon %q: expected href %q, got %q", id, href, got)
+		}
+		xs = append(xs, iconX(t, obj))
+	}
+	for i := 1; i < len(xs); i++ {
+		if xs[i] < xs[i-1]+docIconSize+docIconGap {
+			t.Errorf("view icons %d and %d overlap or are too close: xs=%v", i-1, i, xs)
+		}
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_MultipleViewsNoCollision(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{"container": {Notation: "Container"}},
+		},
+		Model: map[string]model.Element{
+			"api": {Kind: "container", Title: "API"},
+		},
+		Views: map[string]model.View{
+			"overview": {
+				Title: "Overview", Include: []string{"api"}, Layout: "layered",
+				DocLinks: []model.DocLink{{Type: "prd", Href: "overview-prd.html"}},
+			},
+			"detail": {
+				Title: "Detail", Include: []string{"api"}, Layout: "layered",
+				DocLinks: []model.DocLink{{Type: "spec", Href: "detail-spec.html"}},
+			},
+		},
+	}
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+	doc.AddPage("view-detail", "Detail")
+
+	Run(m, doc, emptyState(), ts, nil)
+
+	overviewIcon := findObjectByID(requirePage(t, doc, "view-overview").Root(), "doclink-view-overview-0")
+	if overviewIcon == nil {
+		t.Fatal("expected doclink-view-overview-0 on the overview page")
+	}
+	if got := overviewIcon.SelectAttrValue("link", ""); got != "overview-prd.html" {
+		t.Errorf("overview icon: expected %q, got %q", "overview-prd.html", got)
+	}
+
+	detailIcon := findObjectByID(requirePage(t, doc, "view-detail").Root(), "doclink-view-detail-0")
+	if detailIcon == nil {
+		t.Fatal("expected doclink-view-detail-0 on the detail page")
+	}
+	if got := detailIcon.SelectAttrValue("link", ""); got != "detail-spec.html" {
+		t.Errorf("detail icon: expected %q, got %q", "detail-spec.html", got)
+	}
+
+	// The overview page must not also contain the detail view's icon (and vice
+	// versa) — the id includes the view id, so no cross-page collision.
+	if findObjectByID(requirePage(t, doc, "view-overview").Root(), "doclink-view-detail-0") != nil {
+		t.Error("overview page unexpectedly contains the detail view's icon")
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_RemovedBetweenSyncs(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{{Type: "prd", Href: "docs/prd.html"}})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+	page := requirePage(t, doc, "view-overview")
+	if findObjectByID(page.Root(), "doclink-view-overview-0") == nil {
+		t.Fatal("round 1: expected the icon to exist")
+	}
+
+	// Round 2: the view no longer declares any docLinks.
+	m.Views["overview"] = model.View{Title: "Overview", Include: []string{"api"}, Layout: "layered"}
+	state1 := emptyState()
+	state1.Elements["api"] = ElementState{Title: "API", Kind: "container"}
+	Run(m, doc, state1, ts, nil)
+
+	if icon := findObjectByID(page.Root(), "doclink-view-overview-0"); icon != nil {
+		t.Error("round 2: expected the removed docLinks entry's icon to be cleaned up")
+	}
+}
+
+func TestSynchronizeViewDocLinkIcons_CountGrowsPositionStable(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{{Type: "prd", Href: "docs/prd.html"}})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+	page := requirePage(t, doc, "view-overview")
+	icon0Round1 := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon0Round1 == nil {
+		t.Fatal("round 1: expected icon 0 to exist")
+	}
+	x0Round1 := iconX(t, icon0Round1)
+
+	// Round 2: a second docLinks entry is added.
+	m.Views["overview"] = model.View{
+		Title: "Overview", Include: []string{"api"}, Layout: "layered",
+		DocLinks: []model.DocLink{
+			{Type: "prd", Href: "docs/prd.html"},
+			{Type: "spec", Href: "docs/spec.html"},
+		},
+	}
+	state1 := emptyState()
+	state1.Elements["api"] = ElementState{Title: "API", Kind: "container"}
+	Run(m, doc, state1, ts, nil)
+
+	icon0Round2 := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon0Round2 == nil {
+		t.Fatal("round 2: expected icon 0 to still exist")
+	}
+	if x0Round2 := iconX(t, icon0Round2); x0Round2 != x0Round1 {
+		t.Errorf("round 2: expected icon 0's position to stay at %v, got %v", x0Round1, x0Round2)
+	}
+
+	icon1 := findObjectByID(page.Root(), "doclink-view-overview-1")
+	if icon1 == nil {
+		t.Fatal("round 2: expected the newly-added icon 1 to exist")
+	}
+	if got := icon1.SelectAttrValue("link", ""); got != "docs/spec.html" {
+		t.Errorf("round 2: icon 1 expected href %q, got %q", "docs/spec.html", got)
+	}
+	if x1 := iconX(t, icon1); x1 < x0Round1+docIconSize+docIconGap {
+		t.Errorf("round 2: icon 1 (x=%v) overlaps icon 0 (x=%v)", x1, x0Round1)
+	}
+}
+
+// TestSynchronizeDocLinkIcons_NotImportedByReverseSync is the safety property
+// behind the docLinkPrefix exclusions added to diff.go: doc-link icons must
+// never be mistaken for user-drawn elements during reverse sync, or the
+// model would accumulate phantom elements on every sync. Runs the icon-heavy
+// combined model through two full Run() cycles and asserts the model's
+// element/relationship counts never change from icons alone.
+func TestSynchronizeDocLinkIcons_NotImportedByReverseSync(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Decisions: []model.DecisionRecord{
+				{ID: "ADR-001", Status: model.ADRActive, FilePath: "adr1.html"},
+			},
+		},
+		Model: map[string]model.Element{
+			"api": {
+				Kind:      "container",
+				Title:     "API",
+				Link:      "architecture.adoc#sec-api",
+				Decisions: []string{"ADR-001"},
+				DocLinks:  []model.DocLink{{Type: "arc42", Href: "arc42.html"}},
+			},
+		},
+	}
+	doc := emptyDoc()
+
+	r1 := Run(m, doc, emptyState(), ts, nil)
+	if got := len(m.Model); got != 1 {
+		t.Fatalf("round 1: expected model to still have 1 element, got %d: %v", got, m.Model)
+	}
+	if r1.Reverse.ElementsCreated != 0 {
+		t.Errorf("round 1: expected 0 elements created by reverse sync, got %d", r1.Reverse.ElementsCreated)
+	}
+
+	// Persist round 1's state exactly like the CLI would, then re-sync — this
+	// is the pass where a bug would surface: reverse sync re-scans the page
+	// (now containing 3 icon <object> cells alongside the real element) and
+	// must not mistake any of them for newly-drawn elements.
+	state1 := emptyState()
+	state1.Elements["api"] = ElementState{
+		Title: "API", Kind: "container", Link: "architecture.adoc#sec-api",
+	}
+	r2 := Run(m, doc, state1, ts, nil)
+
+	if got := len(m.Model); got != 1 {
+		t.Errorf("round 2: expected model to still have exactly 1 element, got %d: %v", got, m.Model)
+	}
+	if _, ok := m.Model["api"]; !ok {
+		t.Error("round 2: expected the original 'api' element to still be present")
+	}
+	if r2.Reverse.ElementsCreated != 0 {
+		t.Errorf("round 2: expected 0 elements created by reverse sync (icons must not be imported), got %d", r2.Reverse.ElementsCreated)
+	}
+	if len(m.Relationships) != 0 {
+		t.Errorf("round 2: expected 0 relationships (icons carry no edges), got %d: %v", len(m.Relationships), m.Relationships)
+	}
+	for _, w := range r2.Warnings {
+		if strings.Contains(w, "doclink-") {
+			t.Errorf("round 2: unexpected warning mentioning a doclink- icon id: %q", w)
+		}
 	}
 }

--- a/internal/sync/doclinks_test.go
+++ b/internal/sync/doclinks_test.go
@@ -317,6 +317,8 @@ func iconX(t *testing.T, obj *etree.Element) float64 {
 }
 
 func TestDocLinkGlyph_AllTypesDistinct(t *testing.T) {
+	isFallbackType := func(s string) bool { return s == "unknown-type" || s == "" }
+
 	types := []string{"arc42", "adr", "persona", "prd", "spec", "unknown-type", ""}
 	seen := make(map[string]string, len(types))
 	for _, typ := range types {
@@ -330,7 +332,7 @@ func TestDocLinkGlyph_AllTypesDistinct(t *testing.T) {
 		if other, ok := seen[glyph]; ok && other != typ {
 			// "unknown-type" and "" both intentionally fall back to the same
 			// generic glyph — that's the one allowed collision.
-			if !((typ == "unknown-type" || typ == "") && (other == "unknown-type" || other == "")) {
+			if !isFallbackType(typ) || !isFallbackType(other) {
 				t.Errorf("type %q: glyph %q collides with type %q", typ, glyph, other)
 			}
 		}

--- a/internal/sync/doclinks_test.go
+++ b/internal/sync/doclinks_test.go
@@ -457,6 +457,57 @@ func TestSynchronizeDocLinkIcons_CombinedOrderAndUniqueness(t *testing.T) {
 	}
 }
 
+// TestSynchronizeViewDocLinkIcons_NoOverlapWithMetadataBox is a regression
+// test for the icon row landing on the exact same coordinate as the
+// metadata box (both previously derived their position from computeMaxY
+// independently): with real content on the page, the metadata box gets a
+// non-trivial width and the doc-link row must anchor to *its* geometry
+// instead of duplicating the computation — otherwise both info boxes are
+// created at contentWidth-driven positions, and the icon row (still using
+// the old fixed metadataX/computeMaxY math) would sit on top of the
+// metadata box's title text.
+func TestSynchronizeViewDocLinkIcons_NoOverlapWithMetadataBox(t *testing.T) {
+	ts := minimalTemplates(t)
+	m := viewModelWithDocLinks([]model.DocLink{
+		{Type: "prd", Href: "docs/prd.html", Title: "Product Requirements"},
+	})
+	doc := drawio.NewDocument()
+	doc.AddPage("view-overview", "Overview")
+
+	Run(m, doc, emptyState(), ts, nil)
+	page := requirePage(t, doc, "view-overview")
+	root := page.Root()
+
+	mx, my, mw, mh, found := infoBoxGeometry(root, metadataPrefix+"overview")
+	if !found {
+		t.Fatal("expected a metadata box on the page")
+	}
+
+	icon := findObjectByID(root, "doclink-view-overview-0")
+	if icon == nil {
+		t.Fatal("expected the view-level doc-link icon to exist")
+	}
+	ix := iconX(t, icon)
+	iy := icon.SelectElement("mxCell").SelectElement("mxGeometry").SelectAttrValue("y", "")
+	iyFloat := parseFloat(iy)
+
+	// The icon must not sit at the metadata box's own top-left corner (the
+	// original bug: both computed to the identical (x, y)).
+	if ix == mx && iyFloat == my {
+		t.Errorf("icon at (%v, %v) collides exactly with the metadata box's origin (%v, %v)", ix, iyFloat, mx, my)
+	}
+	// It must stay horizontally within the box (right-anchored row), not
+	// spill past its right edge.
+	if ix < mx || ix+docIconSize > mx+mw {
+		t.Errorf("icon x=%v (width %v) falls outside metadata box bounds [%v, %v]", ix, docIconSize, mx, mx+mw)
+	}
+	// And vertically within the box's own height, near its top edge — it
+	// shares the header row, it doesn't sit below the box entirely.
+	if iyFloat < my || iyFloat+docIconSize > my+mh {
+		t.Errorf("icon y=%v (height %v) falls outside metadata box bounds [%v, %v]", iyFloat, docIconSize, my, my+mh)
+	}
+}
+
 func TestSynchronizeViewDocLinkIcons_MultipleEntries(t *testing.T) {
 	ts := minimalTemplates(t)
 	m := viewModelWithDocLinks([]model.DocLink{
@@ -564,7 +615,7 @@ func TestSynchronizeViewDocLinkIcons_RemovedBetweenSyncs(t *testing.T) {
 	}
 }
 
-func TestSynchronizeViewDocLinkIcons_CountGrowsPositionStable(t *testing.T) {
+func TestSynchronizeViewDocLinkIcons_CountGrowsRightEdgeStable(t *testing.T) {
 	ts := minimalTemplates(t)
 	m := viewModelWithDocLinks([]model.DocLink{{Type: "prd", Href: "docs/prd.html"}})
 	doc := drawio.NewDocument()
@@ -576,7 +627,10 @@ func TestSynchronizeViewDocLinkIcons_CountGrowsPositionStable(t *testing.T) {
 	if icon0Round1 == nil {
 		t.Fatal("round 1: expected icon 0 to exist")
 	}
-	x0Round1 := iconX(t, icon0Round1)
+	// The row is anchored to the metadata box's right edge and grows
+	// leftward (matching placeElementIconRow's element-icon convention), so
+	// with a single icon it sits at that fixed right-edge anchor.
+	rightEdgeX := iconX(t, icon0Round1)
 
 	// Round 2: a second docLinks entry is added.
 	m.Views["overview"] = model.View{
@@ -590,23 +644,29 @@ func TestSynchronizeViewDocLinkIcons_CountGrowsPositionStable(t *testing.T) {
 	state1.Elements["api"] = ElementState{Title: "API", Kind: "container"}
 	Run(m, doc, state1, ts, nil)
 
-	icon0Round2 := findObjectByID(page.Root(), "doclink-view-overview-0")
-	if icon0Round2 == nil {
-		t.Fatal("round 2: expected icon 0 to still exist")
-	}
-	if x0Round2 := iconX(t, icon0Round2); x0Round2 != x0Round1 {
-		t.Errorf("round 2: expected icon 0's position to stay at %v, got %v", x0Round1, x0Round2)
-	}
-
+	// The newly-last icon now occupies the anchor position icon 0 held
+	// alone; icon 0 shifts one slot left to make room.
 	icon1 := findObjectByID(page.Root(), "doclink-view-overview-1")
 	if icon1 == nil {
 		t.Fatal("round 2: expected the newly-added icon 1 to exist")
 	}
+	if x1 := iconX(t, icon1); x1 != rightEdgeX {
+		t.Errorf("round 2: expected the last icon to stay at the right-edge anchor %v, got %v", rightEdgeX, x1)
+	}
+
+	icon0Round2 := findObjectByID(page.Root(), "doclink-view-overview-0")
+	if icon0Round2 == nil {
+		t.Fatal("round 2: expected icon 0 to still exist")
+	}
+	if x0Round2 := iconX(t, icon0Round2); x0Round2 != rightEdgeX-(docIconSize+docIconGap) {
+		t.Errorf("round 2: expected icon 0 to shift left by one slot to %v, got %v", rightEdgeX-(docIconSize+docIconGap), x0Round2)
+	}
 	if got := icon1.SelectAttrValue("link", ""); got != "docs/spec.html" {
 		t.Errorf("round 2: icon 1 expected href %q, got %q", "docs/spec.html", got)
 	}
-	if x1 := iconX(t, icon1); x1 < x0Round1+docIconSize+docIconGap {
-		t.Errorf("round 2: icon 1 (x=%v) overlaps icon 0 (x=%v)", x1, x0Round1)
+	x0Round2 := iconX(t, icon0Round2)
+	if x1 := iconX(t, icon1); x1 < x0Round2+docIconSize+docIconGap {
+		t.Errorf("round 2: icon 1 (x=%v) overlaps icon 0 (x=%v)", x1, x0Round2)
 	}
 }
 

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -152,8 +152,8 @@ func applyForwardToPage(
 	// cases where the sync state is missing or the model was emptied. (#110)
 	reconcileOrphanedElements(page, flat, result)
 
-	// Synchronize decision badges with the model
-	synchronizeDecisionBadges(page, m)
+	// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
+	synchronizeDocLinkIcons(page, m)
 }
 
 // applyForwardPerView iterates over model views and applies changes per page.
@@ -254,8 +254,11 @@ func applyForwardPerView(
 			}
 		}
 
-		// Synchronize decision badges with the model
-		synchronizeDecisionBadges(page, m)
+		// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
+		synchronizeDocLinkIcons(page, m)
+
+		// Synchronize the view-level DocLinks icon row (e.g. PRD/persona links for the whole page). (#543)
+		synchronizeViewDocLinkIcons(page, viewID, view)
 	}
 }
 
@@ -1368,60 +1371,6 @@ func createBackNavButton(
 	geo.CreateAttr("width", "140")
 	geo.CreateAttr("height", "30")
 	geo.CreateAttr("as", "geometry")
-}
-
-// synchronizeDecisionBadges updates decision badges on all elements in a page
-// to match the model. It removes old badges and creates new ones based on the
-// element's decision links in the model.
-func synchronizeDecisionBadges(page *drawio.Page, m *model.BausteinsichtModel) {
-	if m == nil {
-		return
-	}
-
-	// Build decision map for quick lookup
-	decisionMap := make(map[string]*model.DecisionRecord)
-	for i := range m.Specification.Decisions {
-		decisionMap[m.Specification.Decisions[i].ID] = &m.Specification.Decisions[i]
-	}
-
-	// Find all elements on the page
-	root := page.Root()
-	if root == nil {
-		return
-	}
-
-	for _, obj := range root.SelectElements("object") {
-		elemID := obj.SelectAttrValue("bausteinsicht_id", "")
-		if elemID == "" {
-			continue
-		}
-
-		// Look up element in model
-		elem, ok := findElementByID(m, elemID)
-		if !ok || elem == nil {
-			continue
-		}
-
-		// Find the mxCell for this element
-		cell := obj.SelectElement("mxCell")
-		if cell == nil {
-			continue
-		}
-
-		// Remove old decision badges
-		children := cell.SelectElements("mxCell")
-		for i := len(children) - 1; i >= 0; i-- {
-			badgeID := children[i].SelectAttrValue("bausteinsicht_decision_id", "")
-			if badgeID != "" {
-				cell.RemoveChild(children[i])
-			}
-		}
-
-		// Add new decision badges
-		if len(elem.Decisions) > 0 {
-			AddDecisionBadges(cell, elem.Decisions, decisionMap)
-		}
-	}
 }
 
 // findElementByID finds an element in the model by its dot-path ID (e.g., "system.backend.api")

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -215,6 +215,34 @@ func createInfoBox(root *etree.Element, id, label string, x, y, width float64) {
 	geo.CreateAttr("as", "geometry")
 }
 
+// infoBoxGeometry returns the x/y/width/height of the info box (metadata or
+// legend) with the given id, and whether it was found. Callers that need to
+// anchor to an info box's actual position — e.g. the view-level doc-link
+// icon row — read it back here instead of recomputing it independently,
+// since createMetadata/createLegend size these boxes dynamically
+// (contentWidth-based) and only set geometry once at creation.
+func infoBoxGeometry(root *etree.Element, id string) (x, y, w, h float64, found bool) {
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("id", "") != id {
+			continue
+		}
+		cell := obj.SelectElement("mxCell")
+		if cell == nil {
+			return 0, 0, 0, 0, false
+		}
+		geo := cell.SelectElement("mxGeometry")
+		if geo == nil {
+			return 0, 0, 0, 0, false
+		}
+		return parseFloat(geo.SelectAttrValue("x", "0")),
+			parseFloat(geo.SelectAttrValue("y", "0")),
+			parseFloat(geo.SelectAttrValue("width", "0")),
+			parseFloat(geo.SelectAttrValue("height", "0")),
+			true
+	}
+	return 0, 0, 0, 0, false
+}
+
 // computeMaxY finds the bottom-most Y coordinate of elements on the page,
 // excluding the specified cell IDs (used to ignore metadata/legend boxes).
 func computeMaxY(page *drawio.Page, excludeIDs ...string) float64 {

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -173,6 +173,25 @@
       ],
       "type": "object"
     },
+    "DocLink": {
+      "additionalProperties": false,
+      "properties": {
+        "href": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "href"
+      ],
+      "type": "object"
+    },
     "DynamicView": {
       "additionalProperties": false,
       "properties": {
@@ -216,6 +235,12 @@
         },
         "description": {
           "type": "string"
+        },
+        "docLinks": {
+          "items": {
+            "$ref": "#/definitions/DocLink"
+          },
+          "type": "array"
         },
         "kind": {
           "type": "string"
@@ -526,6 +551,12 @@
       "properties": {
         "description": {
           "type": "string"
+        },
+        "docLinks": {
+          "items": {
+            "$ref": "#/definitions/DocLink"
+          },
+          "type": "array"
         },
         "exclude": {
           "items": {

--- a/src/docs/arc42/ADRs/ADR-009-Drill-Down-Navigation.adoc
+++ b/src/docs/arc42/ADRs/ADR-009-Drill-Down-Navigation.adoc
@@ -119,3 +119,19 @@ Elements may carry an optional `link` field in the JSONC model, pointing to an e
 Rationale: drill-down navigation is the primary navigation mechanism established by this ADR. Overriding it silently via a user-defined link would break diagram navigation without a visible signal.
 
 *Reverse sync:* `link` is never read back from draw.io. It is model-authoritative; draw.io edits to the link attribute are overwritten on the next sync.
+
+=== Extension: Doc/ADR Drilldown Icons (#543)
+
+The element's own shape link (Extension #483, above) can only ever point to one place at a time — and the priority rule means a drill-down link silently wins over a user-defined `link` when both apply to the same element. This extension gives the model↔documentation mapping its own, always-clickable carrier, independent of the shape's own `link` attribute:
+
+* **`link`** (existing field): in addition to (optionally) owning the element's shape link, it now also gets a small dedicated icon of its own, so it stays reachable even when a drill-down link owns the shape.
+* **`decisions`** (existing field, `element.go`/`badge.go` decision badges): each decision badge is now a clickable icon, wrapped in its own `<object link="...">`, resolving to the referenced `specification.decisions[].file` when present. A decision without a `file` still renders its badge, just not clickable.
+* **`docLinks`** (new field, `Element.DocLinks`/`View.DocLinks`, `internal/model/types.go`): a typed array of `{type, href, title}` entries — `type` is a free string (not a closed schema enum) with conventional values `arc42`, `adr`, `persona`, `prd`, `spec`; each renders as its own icon with a type-specific glyph. Elements get a row of icons in their top-right corner; a view's own `docLinks` render as a row on the page itself (positioned below the metadata/legend boxes, mirroring their placement convention — there is no notion of a "free diagram corner" in this codebase, only the max Y/X of existing content).
+
+*Mechanism:* each icon is its own top-level `<object id="doclink-..." link="...">` (never a bare `<mxCell>`, which cannot carry a `link` attribute in this codebase's draw.io dialect), positioned via mxGraph's `parent` ID attribute — either the element's own on-page cell ID (element-level icons) or `"1"` (page-absolute, for view-level icons). Old icons are removed and recreated on every sync for elements (their position is a pure function of element width and icon count, so this is idempotent); the view-level row's position is captured once and reused on subsequent syncs, avoiding drift. Implementation: `internal/sync/doclinks.go`.
+
+*Exclusion from reverse sync:* icon cells are identified by the `doclink-` ID prefix and excluded from unmanaged-element detection and connector/relationship extraction in `internal/sync/diff.go`, the same way `nav-back-` back-navigation buttons are (#205) — otherwise reverse sync would try to import them as new model elements.
+
+*PNG degradation:* PNG export discards `link` attributes entirely (same limitation the element shape's own `link` already has, see Extension #483) — the icon shapes and glyphs still render, just without click behavior, giving a visible, non-interactive hint rather than silently vanishing.
+
+*Reverse sync:* like `link`, none of `link`/`decisions`/`docLinks` icon state is ever read back from draw.io; the model is authoritative and icons are fully regenerated from it each sync.

--- a/src/docs/spec/01_use_cases.adoc
+++ b/src/docs/spec/01_use_cases.adoc
@@ -472,6 +472,8 @@ stop
 
 2b. The element has no detail view but carries a user-defined `link` field: the element is clickable and opens the linked URL or document anchor. In SVG export embedded in HTML/PDF, the link is preserved as a native `<a href>` element. If a detail view is later added for the same element, the drill-down link takes priority (the user-defined link is overridden; a sync warning is emitted).
 
+2c. The element carries `link`, `decisions`, and/or `docLinks`: sync additionally renders small clickable icons next to the element — independent of whichever link (if any) owns the element's own shape — so the architect can jump straight from a diagram element into its governing documentation (arc42 chapter, ADR, PRD/persona) without leaving the drill-down flow. A matching icon row renders for a view's own `docLinks`. In PNG export the icons remain visible but are not clickable (PNG discards `link` information, same as the element shape itself). See link:../arc42/ADRs/ADR-009-Drill-Down-Navigation.html[ADR-009]'s "Extension: Doc/ADR Drilldown Icons (#543)". (#543)
+
 ==== Postconditions
 
 *Success guarantee:* The architect can navigate between abstraction levels by clicking linked elements; each level is a dedicated page, and a generated back-navigation button returns to the parent view.
@@ -630,6 +632,15 @@ The `BR-NNN` IDs are the traceability anchors: acceptance criteria (`04_acceptan
 | BR-028 | Referencing a decision whose status is `superseded` produces a warning. | warning | `validate.go` `validateSupersededDecisions`
 |===
 
+=== Documentation link rules
+
+[cols="1,5,1,3"]
+|===
+| BR | Rule | Severity | Source
+
+| BR-034 | A `docLinks` entry (on an element or a view) must set both `type` and `href`. | error | `validate.go` `validateDocLinks`
+|===
+
 === Lifecycle rules
 
 [cols="1,5,1,3"]
@@ -654,7 +665,7 @@ The `BR-NNN` IDs are the traceability anchors: acceptance criteria (`04_acceptan
 [[traceability]]
 == Traceability
 
-Each use case maps to its acceptance criteria (`04_acceptance_criteria.adoc`) and the business rules it exercises. Error-level rules (BR-001–BR-026) are enforced by `bausteinsicht validate`, which runs standalone, at the start of forward sync (UC-3), and on demand by LLM agents (UC-6); warning-level rules (BR-027–BR-033) are reported by the same pass.
+Each use case maps to its acceptance criteria (`04_acceptance_criteria.adoc`) and the business rules it exercises. Error-level rules (BR-001–BR-026, plus BR-034) are enforced by `bausteinsicht validate`, which runs standalone, at the start of forward sync (UC-3), and on demand by LLM agents (UC-6); warning-level rules (BR-027–BR-033) are reported by the same pass. Severity is authoritative per-rule in the tables above — BR-034 breaks the otherwise-contiguous error/warning ranges because it was added after the lifecycle/completeness rules.
 
 [cols="1,2,3"]
 |===
@@ -662,11 +673,11 @@ Each use case maps to its acceptance criteria (`04_acceptance_criteria.adoc`) an
 
 | UC-1 Initialize Architecture Model | AC-1.1 | BR-032, BR-033 (the generated sample model satisfies them)
 | UC-2 Define Architecture Elements | AC-2.1, AC-2.2 | BR-001–BR-012, BR-024, BR-025
-| UC-3 Generate draw.io Diagrams (Forward Sync) | AC-3.1, AC-3.2 | BR-001–BR-033 (full validation pass before sync)
+| UC-3 Generate draw.io Diagrams (Forward Sync) | AC-3.1, AC-3.2 | BR-001–BR-034 (full validation pass before sync)
 | UC-4 Edit in draw.io and Reverse Sync | AC-4.1, AC-4.2 | BR-005 (generated IDs must be non-empty), BR-007, BR-008 (new relationships must resolve)
 | UC-5 Watch Mode | AC-5.1 | inherits UC-3 / UC-4
-| UC-6 LLM-Driven Architecture Modification | AC-6.1, AC-6.2 | BR-001–BR-033 (validate before sync)
-| UC-7 Drill-Down Navigation | AC-7.1 | — (rendering/navigation only)
+| UC-6 LLM-Driven Architecture Modification | AC-6.1, AC-6.2 | BR-001–BR-034 (validate before sync)
+| UC-7 Drill-Down Navigation | AC-7.1 | BR-034 (element/view `docLinks` icons, #543)
 | UC-8 Export Diagram Views | AC-8.1 | — (rendering only)
 |===
 

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -802,25 +802,29 @@ Back-navigation buttons are generated in detail views:
 [source,xml]
 ----
 <!-- Element-level icons: parented to the element's own on-page cell ID -->
-<object id="doclink-webshop.api-link" link="architecture.adoc#sec-api" tooltip="Open linked document">
-  <mxCell style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;..." value="&#128279;"
+<object id="doclink-webshop.api-link" label="&#128279;" link="architecture.adoc#sec-api" tooltip="Open linked document">
+  <mxCell style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;..."
           vertex="1" parent="webshop.api">
     <mxGeometry x="..." y="2" width="18" height="18" as="geometry" />
   </mxCell>
 </object>
-<object id="doclink-webshop.api-decision-0" link="ADRs/ADR-001-DSL-Format.html" tooltip="ADR-001: Use JSONC">
-  <mxCell style="..." value="&#9878;" vertex="1" parent="webshop.api">
+<object id="doclink-webshop.api-decision-0" label="&#9878;" link="ADRs/ADR-001-DSL-Format.html" tooltip="ADR-001: Use JSONC">
+  <mxCell style="..." vertex="1" parent="webshop.api">
     <mxGeometry ... />
   </mxCell>
 </object>
 
 <!-- View-level icons: parented to "1" (page-absolute) -->
-<object id="doclink-view-overview-0" link="docs/prd.html" tooltip="Product Requirements">
-  <mxCell style="..." value="&#128203;" vertex="1" parent="1">
+<object id="doclink-view-overview-0" label="&#128203;" link="docs/prd.html" tooltip="Product Requirements">
+  <mxCell style="..." vertex="1" parent="1">
     <mxGeometry ... />
   </mxCell>
 </object>
 ----
+
+IMPORTANT: The glyph must be the `<object>`'s own `label` attribute, not a `value` attribute on the inner `<mxCell>`. A `value` set directly on the mxCell still renders visually (confirmed against a real draw.io export: the glyph shows, rasterized to an embedded image) but silently breaks the SVG `<a href>` export — draw.io's exporter only wraps a shape in a clickable anchor when the cell's displayed value resolves through the `<object>` wrapper's own attributes, matching every other `link`-bearing `<object>` in this codebase (the element shape itself, the back-navigation button, the metadata/legend boxes).
+
+CAUTION: A relative `href`/`link` (e.g. `"ADRs/ADR-001-DSL-Format.html"`) resolves differently in SVG export depending on whether it carries a `#fragment`. A fragment-bearing href (e.g. `"architecture.adoc#sec-api"`) exports as just the bare fragment (`#sec-api`), which is portable and resolves correctly when the SVG is embedded in that same HTML/AsciiDoc page. A fragment-*less* relative href exports as a full `file://<local draw.io install path>/<original relative path>` URL — anchored to wherever draw.io itself is installed on the machine that ran the export, **not** to the project or the exported SVG's own location. This is not portable across machines and will not resolve for other readers. Until this is addressed, prefer `#fragment`-only anchors or absolute URLs (`https://...`) for `docLinks`/`decisions[].file`/`link` values that need to survive SVG export unchanged.
 
 Icon cells are identified by the `doclink-` ID prefix and excluded from reverse-sync element/relationship extraction, the same way `nav-back-` buttons are (#205) — model is authoritative, icon state is never read back from draw.io. See ADR-009's "Extension: Doc/ADR Drilldown Icons (#543)" for the full rationale, including why decision badges are clickable now and why PNG export still shows the icon glyph without the click behavior.
 

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -49,6 +49,7 @@ class RelationshipKind
 class TagDefinition
 class PatternDefinition
 class DecisionRecord
+class DocLink
 class Element
 class Relationship
 class View
@@ -73,6 +74,7 @@ Specification *-- "0..*" DecisionRecord
 Element *-- "0..*" Element : children
 Element ..> ElementKind : kind
 Element ..> DecisionRecord : decisions
+Element *-- "0..*" DocLink : docLinks
 
 Relationship ..> Element : from / to
 Relationship ..> RelationshipKind : kind
@@ -80,6 +82,7 @@ Relationship ..> DecisionRecord : decisions
 
 View ..> Element : scope / include / exclude
 View ..> TagDefinition : filter-tags / exclude-tags
+View *-- "0..*" DocLink : docLinks
 
 DynamicView *-- "1..*" SequenceStep
 SequenceStep ..> Element : from / to
@@ -273,10 +276,40 @@ The model has these top-level sections. `specification`, `model`, `relationships
 | object
 | no
 | Arbitrary key-value metadata
+
+| `docLinks`
+| DocLink[]
+| no
+| Typed documentation links (arc42 chapter, ADR, PRD/persona, spec, ...), rendered as clickable icons next to the element in HTML/SVG export — independent of `link`/`decisions`, which also get their own icons. See <<DocLink Properties>> and ADR-009's "Extension: Doc/ADR Drilldown Icons (#543)".
 |===
 
 The **key** of each element in the model object (e.g., `"customer"`, `"api"`) serves as its unique ID.
 Nested elements are referenced using dot notation: `"webshop.api.auth"`.
+
+[[DocLink Properties]]
+==== DocLink Properties
+
+A `DocLink` is a typed link to an external documentation artifact, usable on both `Element.docLinks` and `View.docLinks`.
+
+[cols="1,1,1,3"]
+|===
+| Property | Type | Required | Description
+
+| `type`
+| string
+| yes
+| Free string, not a closed schema enum. Conventional values: `arc42`, `adr`, `persona`, `prd`, `spec`. Unknown values still render (a generic link icon), so new documentation kinds don't require a schema change. `persona` pairs naturally with elements of kind `actor`/`person`.
+
+| `href`
+| string
+| yes
+| Target URL or document anchor, same conventions as `link`.
+
+| `title`
+| string
+| no
+| Icon tooltip text. Defaults to `type` when omitted.
+|===
 
 [[element-lifecycle]]
 ==== Element Lifecycle
@@ -395,6 +428,11 @@ The transitions themselves are not enforced — `status` is a plain string — b
 | string
 | no
 | Auto-layout mode for new pages: `"layered"` (default), `"grid"`, or `"none"`. Layered groups elements by kind tier; grid places alphabetically in a grid; none uses a horizontal row.
+
+| `docLinks`
+| DocLink[]
+| no
+| View-level documentation links (e.g. the page's PRD), rendered as a clickable icon row on the page itself. See <<DocLink Properties>>.
 |===
 
 [[Wildcard Patterns]]
@@ -494,9 +532,9 @@ Model files use the JSONC (JSON with Comments) format. Both comment styles are s
 [[validation-rules]]
 === Validation Rules
 
-`bausteinsicht validate` enforces the model's integrity constraints. The complete, code-traceable catalogue — each rule's exact statement, severity, and source function — is in the Business Rules section of link:01_use_cases.html#business-rules[01_use_cases] (BR-001–BR-033). The constraints on the data model group as follows:
+`bausteinsicht validate` enforces the model's integrity constraints. The complete, code-traceable catalogue — each rule's exact statement, severity, and source function — is in the Business Rules section of link:01_use_cases.html#business-rules[01_use_cases] (BR-001–BR-034). The constraints on the data model group as follows:
 
-* **Structural (errors):** required fields — `kind`/`title` on elements, `title` on views, `key`/`title` on dynamic views, and at least one step per dynamic view (BR-001, BR-004, BR-013, BR-018, BR-019, BR-020); known kinds (BR-002, BR-009, BR-024, BR-025); container nesting and depth limit (BR-003, BR-006); non-empty element IDs (BR-005).
+* **Structural (errors):** required fields — `kind`/`title` on elements, `title` on views, `key`/`title` on dynamic views, at least one step per dynamic view, and `type`/`href` on `docLinks` entries (BR-001, BR-004, BR-013, BR-018, BR-019, BR-020, BR-034); known kinds (BR-002, BR-009, BR-024, BR-025); container nesting and depth limit (BR-003, BR-006); non-empty element IDs (BR-005).
 * **Referential integrity (errors):** relationship `from`/`to`, view `scope`, non-wildcard `include`/`exclude`, `filter-tags`/`exclude-tags`, dynamic-view step `from`/`to`, and `decisions` references all resolve into the model or specification (BR-007, BR-008, BR-015, BR-016, BR-017, BR-021, BR-026).
 * **Enumerations (errors):** `cardinality`, `dataFlow`, view `layout`, and step `type` take only their fixed defined values (BR-010, BR-011, BR-014, BR-022).
 * **Uniqueness (errors):** no fully-duplicate relationships; unique step indices (BR-012, BR-023).
@@ -757,6 +795,35 @@ Back-navigation buttons are generated in detail views:
 </object>
 ----
 
+==== Documentation Link Icons (#543)
+
+`link`, `decisions`, and `docLinks` each render as their own small clickable icon — independent `<object>` cells (never a bare `<mxCell>`, which cannot carry a `link` attribute), positioned via mxGraph's `parent` ID attribute rather than XML nesting:
+
+[source,xml]
+----
+<!-- Element-level icons: parented to the element's own on-page cell ID -->
+<object id="doclink-webshop.api-link" link="architecture.adoc#sec-api" tooltip="Open linked document">
+  <mxCell style="rounded=1;fillColor=#dae8fc;strokeColor=#6c8ebf;..." value="&#128279;"
+          vertex="1" parent="webshop.api">
+    <mxGeometry x="..." y="2" width="18" height="18" as="geometry" />
+  </mxCell>
+</object>
+<object id="doclink-webshop.api-decision-0" link="ADRs/ADR-001-DSL-Format.html" tooltip="ADR-001: Use JSONC">
+  <mxCell style="..." value="&#9878;" vertex="1" parent="webshop.api">
+    <mxGeometry ... />
+  </mxCell>
+</object>
+
+<!-- View-level icons: parented to "1" (page-absolute) -->
+<object id="doclink-view-overview-0" link="docs/prd.html" tooltip="Product Requirements">
+  <mxCell style="..." value="&#128203;" vertex="1" parent="1">
+    <mxGeometry ... />
+  </mxCell>
+</object>
+----
+
+Icon cells are identified by the `doclink-` ID prefix and excluded from reverse-sync element/relationship extraction, the same way `nav-back-` buttons are (#205) — model is authoritative, icon state is never read back from draw.io. See ADR-009's "Extension: Doc/ADR Drilldown Icons (#543)" for the full rationale, including why decision badges are clickable now and why PNG export still shows the icon glyph without the click behavior.
+
 ==== Multi-Page Structure
 
 Each view is a separate `<diagram>` element. The `id` attribute uses the format `view-<viewKey>` (e.g., `view-context` for a view with key `"context"`).
@@ -828,6 +895,15 @@ type Element struct {
     LastModified string             `json:"lastModified,omitempty"` // RFC3339; overrides git-based staleness
     Children     map[string]Element `json:"children,omitempty"`
     Metadata     map[string]string  `json:"metadata,omitempty"`
+    Link         string             `json:"link,omitempty"`     // hyperlink on the draw.io shape and in SVG export
+    DocLinks     []DocLink          `json:"docLinks,omitempty"` // typed documentation links, rendered as clickable icons (#543)
+}
+
+// DocLink is a typed link to an external documentation artifact (#543)
+type DocLink struct {
+    Type  string `json:"type"`  // free string; conventional: arc42|adr|persona|prd|spec
+    Href  string `json:"href"`
+    Title string `json:"title,omitempty"` // icon tooltip; defaults to Type when omitted
 }
 
 // Relationship connects two elements
@@ -851,7 +927,8 @@ type View struct {
     FilterTags  []string `json:"filter-tags,omitempty"`  // include only elements with ALL of these tags
     ExcludeTags []string `json:"exclude-tags,omitempty"` // exclude elements with ANY of these tags
     Description string   `json:"description,omitempty"`
-    Layout      string   `json:"layout,omitempty"` // layered (default)|grid|none
+    Layout      string   `json:"layout,omitempty"`   // layered (default)|grid|none
+    DocLinks    []DocLink `json:"docLinks,omitempty"` // view-level documentation links (#543)
 }
 
 // DynamicView describes a sequence diagram scenario


### PR DESCRIPTION
## Summary

Implements #543 (full scope: core + extension). Element `link` and `decisions` now render as clickable icons in HTML/SVG export, coexisting with the existing element→view drill-down (#483/#490) instead of competing with it for the shape's own `link` attribute. Adds typed `docLinks` on both `Element` and `View` (`{type, href, title}`, free-string type — `arc42`/`adr`/`persona`/`prd`/`spec` are conventional, not enforced) for jumping straight from a diagram element or view page into its governing documentation.

- `internal/sync/doclinks.go` (new): icon rendering — each icon is its own top-level `<object link="...">` (a bare `<mxCell>` can't carry a `link` attribute in this codebase's draw.io dialect), positioned via mxGraph's `parent`-ID attribute. Element icons recompute their row every sync (idempotent — a pure function of element width + icon count); the view-level row's position is captured once from an existing icon and reused on later syncs, so it never drifts.
- Decision badges (`badge.go`/`forward.go`) are now clickable, resolving to `specification.decisions[].file` when present, and still render (non-clickable) when it's absent. Replaces the old bare-`<mxCell>` `AddDecisionBadges`/`synchronizeDecisionBadges` (removed as dead code once replaced).
- `diff.go`: excludes the new `doclink-` ID prefix from reverse-sync unmanaged-element detection and connector extraction, the same way `nav-back-` already is (#205-class fix, applied preemptively so re-sync never tries to import an icon as a new model element).
- `internal/model`: new `DocLink` type + `Element.DocLinks`/`View.DocLinks`, validated (`type`/`href` required, BR-034); schema regenerated (`make schema-generate`).
- Docs: ADR-009 gets a new "Extension: Doc/ADR Drilldown Icons (#543)" section (mirrors its existing #483 extension); `03_data_models.adoc` gets `DocLink` property tables + XML shape docs; `01_use_cases.adoc` gets BR-034 and a new UC-7 extension (2c).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `staticcheck ./...` clean
- [x] `go test ./...` — all green, including new unit tests in `internal/sync/doclinks_test.go` and `internal/model/validate_test.go`
- [x] `e2e/doclink_icons_test.go` — chains `validate` → `sync` → re-`sync` (idempotency) against the real CLI binary, asserting on the actual `.drawio` XML output
- [x] `schemas/bausteinsicht.schema.json` regenerated and committed

## Notes for reviewers

The new icons are top-level `<object>` children of `<root>` (unlike the old, deeply-nested decision badges), so `computeMaxY`/`computeContentWidth` in `metadata.go` technically see them when placing the metadata/legend boxes. Their geometry is parent-relative (small x/y, e.g. y≈2), not page-absolute, so in practice this never affects metadata/legend placement — real elements' absolute coordinates always dominate — but it's a real coordinate-space nuance worth knowing about rather than a hidden one.

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)