### PR TITLE
fix(cli): allow camelCase specification and view keys

### DIFF
--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -3,21 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
-
-// validIDPattern matches element IDs: letters, digits, hyphens, underscores.
-// Dots are NOT allowed since they serve as hierarchy separators.
-var validIDPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
-
-// isValidID checks if the given ID is a valid element identifier.
-func isValidID(id string) bool {
-	return validIDPattern.MatchString(id)
-}
 
 func newAddElementCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -52,7 +42,7 @@ func runAddElement(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 
 	// Validate ID format. (#123)
-	if !isValidID(id) {
+	if !isValidKey(id) {
 		return exitWithCode(
 			fmt.Errorf("invalid element ID %q: must contain only letters, digits, hyphens, or underscores", id),
 			1,

--- a/cmd/bausteinsicht/add_element.go
+++ b/cmd/bausteinsicht/add_element.go
@@ -44,7 +44,7 @@ func runAddElement(cmd *cobra.Command, args []string) error {
 	// Validate ID format. (#123)
 	if !isValidKey(id) {
 		return exitWithCode(
-			fmt.Errorf("invalid element ID %q: must contain only letters, digits, hyphens, or underscores", id),
+			fmt.Errorf("invalid element ID %q: must start with a letter and contain only letters, digits, hyphens, or underscores", id),
 			1,
 		)
 	}

--- a/cmd/bausteinsicht/add_specification.go
+++ b/cmd/bausteinsicht/add_specification.go
@@ -49,7 +49,7 @@ func runAddSpecificationElement(cmd *cobra.Command, args []string) error {
 	// Validate key format
 	if !isValidKey(key) {
 		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must contain only letters, digits, hyphens, or underscores", key),
+			fmt.Errorf("invalid specification key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", key),
 			1,
 		)
 	}
@@ -141,7 +141,7 @@ func runAddSpecificationRelationship(cmd *cobra.Command, args []string) error {
 	// Validate key format
 	if !isValidKey(key) {
 		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must contain only letters, digits, hyphens, or underscores", key),
+			fmt.Errorf("invalid specification key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", key),
 			1,
 		)
 	}

--- a/cmd/bausteinsicht/add_specification.go
+++ b/cmd/bausteinsicht/add_specification.go
@@ -3,19 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
-
-// validSpecKeyPattern matches specification keys: lowercase letters, digits, underscores, hyphens.
-var validSpecKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-
-// isValidSpecKey checks if the given spec key is valid.
-func isValidSpecKey(key string) bool {
-	return validSpecKeyPattern.MatchString(key)
-}
 
 func newAddSpecificationCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -56,9 +47,9 @@ func runAddSpecificationElement(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 
 	// Validate key format
-	if !isValidSpecKey(key) {
+	if !isValidKey(key) {
 		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must contain only lowercase letters, digits, hyphens, or underscores", key),
+			fmt.Errorf("invalid specification key %q: must contain only letters, digits, hyphens, or underscores", key),
 			1,
 		)
 	}
@@ -148,9 +139,9 @@ func runAddSpecificationRelationship(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 
 	// Validate key format
-	if !isValidSpecKey(key) {
+	if !isValidKey(key) {
 		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must contain only lowercase letters, digits, hyphens, or underscores", key),
+			fmt.Errorf("invalid specification key %q: must contain only letters, digits, hyphens, or underscores", key),
 			1,
 		)
 	}

--- a/cmd/bausteinsicht/add_specification_test.go
+++ b/cmd/bausteinsicht/add_specification_test.go
@@ -8,30 +8,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestIsValidSpecKey(t *testing.T) {
-	tests := []struct {
-		key   string
-		valid bool
-	}{
-		{"system", true},
-		{"my_component", true},
-		{"my-component", true},
-		{"custom123", true},
-		{"_invalid", false},     // starts with underscore
-		{"123invalid", false},   // starts with digit
-		{"Component", false},    // uppercase
-		{"my component", false}, // space
-		{"", false},             // empty
-	}
-
-	for _, tt := range tests {
-		got := isValidSpecKey(tt.key)
-		if got != tt.valid {
-			t.Errorf("isValidSpecKey(%q) = %v, want %v", tt.key, got, tt.valid)
-		}
-	}
-}
-
 func TestAddSpecificationElementCmd_MissingNotationFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.AddCommand(newAddCmd())

--- a/cmd/bausteinsicht/add_view.go
+++ b/cmd/bausteinsicht/add_view.go
@@ -3,19 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
-
-// validViewKeyPattern matches view keys: lowercase letters, digits, hyphens.
-var validViewKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
-
-// isValidViewKey checks if the given view key is valid.
-func isValidViewKey(key string) bool {
-	return validViewKeyPattern.MatchString(key)
-}
 
 func newAddViewCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -44,9 +35,9 @@ func runAddView(cmd *cobra.Command, args []string) error {
 	format, _ := cmd.Flags().GetString("format")
 
 	// Validate view key format
-	if !isValidViewKey(viewKey) {
+	if !isValidKey(viewKey) {
 		return exitWithCode(
-			fmt.Errorf("invalid view key %q: must contain only lowercase letters, digits, hyphens, or underscores", viewKey),
+			fmt.Errorf("invalid view key %q: must contain only letters, digits, hyphens, or underscores", viewKey),
 			1,
 		)
 	}

--- a/cmd/bausteinsicht/add_view.go
+++ b/cmd/bausteinsicht/add_view.go
@@ -37,7 +37,7 @@ func runAddView(cmd *cobra.Command, args []string) error {
 	// Validate view key format
 	if !isValidKey(viewKey) {
 		return exitWithCode(
-			fmt.Errorf("invalid view key %q: must contain only letters, digits, hyphens, or underscores", viewKey),
+			fmt.Errorf("invalid view key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", viewKey),
 			1,
 		)
 	}

--- a/cmd/bausteinsicht/identifier.go
+++ b/cmd/bausteinsicht/identifier.go
@@ -1,0 +1,16 @@
+package main
+
+import "regexp"
+
+// validKeyPattern is the shared identifier form for element IDs, specification
+// keys, and view keys: a letter followed by letters, digits, hyphens, or
+// underscores. Dots are NOT allowed - they serve as element-hierarchy
+// separators. Defined once so the callers cannot drift apart again: they did,
+// which is how specification and view keys ended up lowercase-only while
+// element IDs allowed camelCase (#582).
+var validKeyPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
+
+// isValidKey reports whether s is a valid element ID, specification key, or view key.
+func isValidKey(s string) bool {
+	return validKeyPattern.MatchString(s)
+}

--- a/cmd/bausteinsicht/identifier_test.go
+++ b/cmd/bausteinsicht/identifier_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+// TestIsValidKey covers the shared identifier rule used for element IDs,
+// specification keys, and view keys (consolidated in #582).
+func TestIsValidKey(t *testing.T) {
+	tests := []struct {
+		key   string
+		valid bool
+	}{
+		{"system", true},
+		{"my_component", true},
+		{"my-component", true},
+		{"custom123", true},
+		{"orderRecord", true},        // camelCase element ID
+		{"boundaryObject", true},     // camelCase specification kind (#582)
+		{"applicationService", true}, // camelCase specification kind (#582)
+		{"systemContext", true},      // camelCase view key (#582)
+		{"Component", true},          // leading uppercase allowed
+		{"_invalid", false},          // starts with underscore
+		{"123invalid", false},        // starts with digit
+		{"has.dot", false},           // dots reserved for hierarchy separators
+		{"my component", false},      // space
+		{"", false},                  // empty
+	}
+
+	for _, tt := range tests {
+		if got := isValidKey(tt.key); got != tt.valid {
+			t.Errorf("isValidKey(%q) = %v, want %v", tt.key, got, tt.valid)
+		}
+	}
+}

--- a/cmd/bausteinsicht/repl.go
+++ b/cmd/bausteinsicht/repl.go
@@ -248,7 +248,7 @@ func (s *replState) addElementInteractive() {
 		return
 	}
 	if !isValidKey(id) {
-		fmt.Printf("Invalid ID %q: must contain only letters, digits, hyphens, or underscores\n", id)
+		fmt.Printf("Invalid ID %q: must start with a letter and contain only letters, digits, hyphens, or underscores\n", id)
 		return
 	}
 

--- a/cmd/bausteinsicht/repl.go
+++ b/cmd/bausteinsicht/repl.go
@@ -247,7 +247,7 @@ func (s *replState) addElementInteractive() {
 		fmt.Println("Aborted (empty ID)")
 		return
 	}
-	if !isValidID(id) {
+	if !isValidKey(id) {
 		fmt.Printf("Invalid ID %q: must contain only letters, digits, hyphens, or underscores\n", id)
 		return
 	}

--- a/e2e/authoring_workflow_test.go
+++ b/e2e/authoring_workflow_test.go
@@ -94,7 +94,7 @@ func TestAuthoringWorkflow_CamelCaseKinds(t *testing.T) {
 
 	// The resulting model must still validate.
 	validateOut := runCLI(t, bin, dir, "validate")
-	if !strings.Contains(validateOut, "valid") {
+	if !strings.Contains(validateOut, "Model is valid.") {
 		t.Errorf("expected model to validate after camelCase authoring, got: %q", validateOut)
 	}
 

--- a/e2e/authoring_workflow_test.go
+++ b/e2e/authoring_workflow_test.go
@@ -63,3 +63,40 @@ func TestAuthoringWorkflow(t *testing.T) {
 
 	t.Log("authoring workflow OK: init → validate → lint (pass) → add element → lint (fail) verified")
 }
+
+// TestAuthoringWorkflow_CamelCaseKinds (#582) verifies the CLI can author a
+// model whose specification kinds and view key are camelCase. The model,
+// schema, `validate`, and `add element --kind` already accept camelCase kinds
+// (e.g. the hexagonal/DDD example), so `add specification` and `add view` must
+// be able to create them too.
+func TestAuthoringWorkflow_CamelCaseKinds(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	runCLI(t, bin, dir, "init")
+
+	// Define camelCase specification kinds (hexagonal/DDD style).
+	runCLI(t, bin, dir, "add", "specification", "element", "boundaryObject",
+		"--notation", "Boundary Object", "--container")
+	runCLI(t, bin, dir, "add", "specification", "element", "applicationService",
+		"--notation", "Application Service")
+	runCLI(t, bin, dir, "add", "specification", "relationship", "dependsOn",
+		"--notation", "depends on")
+
+	// A camelCase view key.
+	runCLI(t, bin, dir, "add", "view", "systemContext", "--title", "System Context")
+
+	// Use the camelCase kinds when adding elements.
+	runCLI(t, bin, dir, "add", "element",
+		"--id", "orderRecord", "--kind", "boundaryObject", "--title", "Order Record")
+	runCLI(t, bin, dir, "add", "element",
+		"--id", "orderService", "--kind", "applicationService", "--title", "Order Service")
+
+	// The resulting model must still validate.
+	validateOut := runCLI(t, bin, dir, "validate")
+	if !strings.Contains(validateOut, "valid") {
+		t.Errorf("expected model to validate after camelCase authoring, got: %q", validateOut)
+	}
+
+	t.Log("camelCase authoring OK: add specification/view/element with camelCase kinds → validate")
+}

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -525,6 +525,8 @@ $ bausteinsicht add relationship --from webshop.api --to webshop.db --format jso
 
 Creates a new view or modifies an existing view's include list. Designed for LLM-driven workflows to dynamically filter architecture diagrams.
 
+The `<view-key>` argument must match `[a-zA-Z][a-zA-Z0-9_-]*` (the same identifier form as element IDs and specification keys).
+
 **Flags:**
 
 [cols="2,3,1,1"]
@@ -612,6 +614,9 @@ $ bausteinsicht add view context --title "System Context" --format json
 ==== `bausteinsicht add specification`
 
 Adds new element or relationship types to the model's specification. Enables definition of custom architecture notations.
+
+The `<key>` names the kind and must match `[a-zA-Z][a-zA-Z0-9_-]*` (letters, digits, hyphens, underscores -- the same identifier form as element IDs).
+camelCase kinds such as `boundaryObject` or `applicationService` are supported.
 
 ===== Add Element Type
 

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -526,6 +526,7 @@ $ bausteinsicht add relationship --from webshop.api --to webshop.db --format jso
 Creates a new view or modifies an existing view's include list. Designed for LLM-driven workflows to dynamically filter architecture diagrams.
 
 The `<view-key>` argument must match `[a-zA-Z][a-zA-Z0-9_-]*` (the same identifier form as element IDs and specification keys).
+Dots are not allowed -- they are reserved as element-hierarchy separators.
 
 **Flags:**
 
@@ -616,6 +617,7 @@ $ bausteinsicht add view context --title "System Context" --format json
 Adds new element or relationship types to the model's specification. Enables definition of custom architecture notations.
 
 The `<key>` names the kind and must match `[a-zA-Z][a-zA-Z0-9_-]*` (letters, digits, hyphens, underscores -- the same identifier form as element IDs).
+Dots are not allowed -- they are reserved as element-hierarchy separators.
 camelCase kinds such as `boundaryObject` or `applicationService` are supported.
 
 ===== Add Element Type


### PR DESCRIPTION
## Description
`add specification element|relationship` and `add view` rejected **camelCase** keys, even though the model, JSON schema, `validate`, and `add element --kind` all accept camelCase kinds (e.g. the hexagonal/DDD example). The CLI could not create the kinds used by its own examples.

**Root cause:** the identifier validator was duplicated three times and drifted — `validSpecKeyPattern` / `validViewKeyPattern` stayed lowercase-only (`^[a-z]…`) while `validIDPattern` allowed camelCase (`^[a-zA-Z]…`).

**Fix:** consolidate the three into a single `validKeyPattern` / `isValidKey` (`cmd/bausteinsicht/identifier.go`), used by `add element`, `add specification`, `add view`, and `repl`, so they cannot diverge again. camelCase kinds like `boundaryObject` and view keys like `systemContext` are now accepted; leading digit / underscore / dot / space are still rejected.

## Related Issue
Fixes #582.

## Type of Change
- [x] Bug fix
- [x] Improvement/refactoring (DRY consolidation of the identifier validator)

## Reproduction (before)
```console
$ bausteinsicht add specification element boundaryObject --notation "Boundary Object"
invalid specification key "boundaryObject": must contain only lowercase letters, digits, hyphens, or underscores   # exit 1
```
After this PR the same command succeeds, and `validate` still passes on the resulting model.

## Pre-Merge Checklist (Developer)
- [x] **Branch up-to-date with main** — branched from `origin/main` (`2e2467e`)
- [x] **Tests passing** — `go test ./...` green
- [x] **Code quality** — build, `go vet`, `gofmt` clean; three duplicated validators + their `regexp` imports removed
- [x] **Documentation** — `spec/02_cli_specification.adoc` documents the key format for `add specification` and `add view`

## Testing
- Unit: single `TestIsValidKey` (replaces the two per-command validator tests) covers camelCase, leading uppercase, and the rejected forms (digit/underscore/dot/space start).
- E2E: `TestAuthoringWorkflow_CamelCaseKinds` — `add specification element|relationship` + `add view` + `add element --kind` with camelCase, then `validate` passes.
- Reproduced the fix live against a freshly `init`-ed project.

## Notes for Reviewers
The consolidation touches `repl.go` (also used `isValidID`) and merges the two validator tests into one. Behavior change is limited to accepting the additional character set (uppercase letters) for spec/view keys — aligning them with element IDs, which already allowed it.
