### PR TITLE
fix(chaos): tighten world-accessible test-file permissions (SEC-020)

### DIFF
--- a/internal/chaos/chaos.go
+++ b/internal/chaos/chaos.go
@@ -49,16 +49,16 @@ func (tc *TestChaos) CorruptFilePartial(path string, content string) {
 	}
 }
 
-// MakeReadOnly sets file permissions to read-only.
+// MakeReadOnly sets file permissions to read-only for the owner only.
 func (tc *TestChaos) MakeReadOnly(path string) {
-	if err := os.Chmod(path, 0444); err != nil {
+	if err := os.Chmod(path, 0400); err != nil {
 		tc.t.Fatalf("MakeReadOnly: %v", err)
 	}
 }
 
-// MakeWritable sets file permissions to writable.
+// MakeWritable sets file permissions to read-write for the owner only.
 func (tc *TestChaos) MakeWritable(path string) {
-	if err := os.Chmod(path, 0644); err != nil {
+	if err := os.Chmod(path, 0600); err != nil {
 		tc.t.Fatalf("MakeWritable: %v", err)
 	}
 }

--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -1,0 +1,63 @@
+package chaos
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMakeReadOnly_NotWorldAccessible is a regression test for SonarCloud
+// go:S2612 ("File permissions should not be set to world-accessible
+// values"): MakeReadOnly used to chmod to 0444, which — while it does block
+// the owner from writing — also grants read access to group and other. The
+// chaos helper only needs to affect the owning test process, so group/other
+// bits must be cleared entirely (#585).
+func TestMakeReadOnly_NotWorldAccessible(t *testing.T) {
+	tc := NewTestChaos(t)
+	path := tc.CreateEmptyFile("readonly.txt")
+
+	tc.MakeReadOnly(path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0077 != 0 {
+		t.Errorf("MakeReadOnly left group/other-accessible bits set: mode=%#o", perm)
+	}
+	if perm&0200 != 0 {
+		t.Errorf("MakeReadOnly left the file owner-writable: mode=%#o", perm)
+	}
+
+	// The permission change must still do its actual job: writes fail.
+	if err := os.WriteFile(path, []byte("x"), 0644); err == nil {
+		t.Error("expected write to a read-only file to fail")
+	}
+}
+
+// TestMakeWritable_NotWorldAccessible is the MakeWritable counterpart of
+// TestMakeReadOnly_NotWorldAccessible (#585, go:S2612).
+func TestMakeWritable_NotWorldAccessible(t *testing.T) {
+	tc := NewTestChaos(t)
+	path := tc.CreateEmptyFile("writable.txt")
+	tc.MakeReadOnly(path)
+
+	tc.MakeWritable(path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0077 != 0 {
+		t.Errorf("MakeWritable left group/other-accessible bits set: mode=%#o", perm)
+	}
+	if perm&0200 == 0 {
+		t.Errorf("MakeWritable left the file owner-unwritable: mode=%#o", perm)
+	}
+
+	// The permission change must still do its actual job: writes succeed.
+	if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+		t.Errorf("expected write to a writable file to succeed, got: %v", err)
+	}
+}

--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -2,6 +2,7 @@ package chaos
 
 import (
 	"os"
+	"runtime"
 	"testing"
 )
 
@@ -11,6 +12,12 @@ import (
 // the owner from writing — also grants read access to group and other. The
 // chaos helper only needs to affect the owning test process, so group/other
 // bits must be cleared entirely (#585).
+//
+// The group/other-bits assertions are POSIX-only: os.Chmod on Windows only
+// ever toggles the read-only attribute via the 0200 bit, and os.Stat
+// synthesizes a FileMode that mirrors that single attribute across all
+// three permission classes (0444 read-only / 0666 writable) — there is no
+// Windows equivalent of "owner-only" access to assert on.
 func TestMakeReadOnly_NotWorldAccessible(t *testing.T) {
 	tc := NewTestChaos(t)
 	path := tc.CreateEmptyFile("readonly.txt")
@@ -22,11 +29,13 @@ func TestMakeReadOnly_NotWorldAccessible(t *testing.T) {
 		t.Fatalf("Stat: %v", err)
 	}
 	perm := info.Mode().Perm()
-	if perm&0077 != 0 {
-		t.Errorf("MakeReadOnly left group/other-accessible bits set: mode=%#o", perm)
-	}
-	if perm&0200 != 0 {
-		t.Errorf("MakeReadOnly left the file owner-writable: mode=%#o", perm)
+	if runtime.GOOS != "windows" {
+		if perm&0077 != 0 {
+			t.Errorf("MakeReadOnly left group/other-accessible bits set: mode=%#o", perm)
+		}
+		if perm&0200 != 0 {
+			t.Errorf("MakeReadOnly left the file owner-writable: mode=%#o", perm)
+		}
 	}
 
 	// The permission change must still do its actual job: writes fail.
@@ -36,7 +45,8 @@ func TestMakeReadOnly_NotWorldAccessible(t *testing.T) {
 }
 
 // TestMakeWritable_NotWorldAccessible is the MakeWritable counterpart of
-// TestMakeReadOnly_NotWorldAccessible (#585, go:S2612).
+// TestMakeReadOnly_NotWorldAccessible (#585, go:S2612). See that test's
+// comment for why the group/other-bits assertions are POSIX-only.
 func TestMakeWritable_NotWorldAccessible(t *testing.T) {
 	tc := NewTestChaos(t)
 	path := tc.CreateEmptyFile("writable.txt")
@@ -49,11 +59,13 @@ func TestMakeWritable_NotWorldAccessible(t *testing.T) {
 		t.Fatalf("Stat: %v", err)
 	}
 	perm := info.Mode().Perm()
-	if perm&0077 != 0 {
-		t.Errorf("MakeWritable left group/other-accessible bits set: mode=%#o", perm)
-	}
-	if perm&0200 == 0 {
-		t.Errorf("MakeWritable left the file owner-unwritable: mode=%#o", perm)
+	if runtime.GOOS != "windows" {
+		if perm&0077 != 0 {
+			t.Errorf("MakeWritable left group/other-accessible bits set: mode=%#o", perm)
+		}
+		if perm&0200 == 0 {
+			t.Errorf("MakeWritable left the file owner-unwritable: mode=%#o", perm)
+		}
 	}
 
 	// The permission change must still do its actual job: writes succeed.

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -55,6 +55,9 @@
 
 | 2026-07-14 (history rewrite)
 | Purged the historical `BigData.xmi` Git-LFS pointer object from `main`'s history via `git filter-repo` (object was never reachable by CI anyway; this reclaims it from the object graph). Tags `v1.0.0`–`v1.2.0` preserved bit-identical (verified via hash comparison); `v1.2.1` (the only tag descending from the commit that introduced the fixture) was necessarily rewritten to a new commit hash as a result — `go install ...@v1.2.1` will now fail its `sum.golang.org` checksum. Older tags/releases are unaffected.
+
+| 2026-08-13 (chaos permissions)
+| Fixed SEC-020 (#585): `internal/chaos.TestChaos.MakeReadOnly`/`MakeWritable` chmod'd to `0444`/`0644`, granting group/other read access on test-only files. Tightened to `0400`/`0600` (owner-only). TDD: regression test added first (commit `12c942e`), then the fix.
 |===
 
 === Scope
@@ -407,6 +410,21 @@ Low. Test-fixture integrity only (Blast Radius 0 per the Risk Radar assessment) 
 **Fix:**
 Pinned the known digest (`sha256:7b761872b0f773caac76446b857162986761500d625c9bd3514d55bd1f63f5b0`, the same OID the original LFS pointer carried) in `scripts/fetch-xmi-testdata.sh`. On mismatch, the script discards the download and falls back to its existing "fetch failed" behavior (warn, exit 0, leave fixture absent) — `TestImport_BigData` skips itself and the dedicated `xmi-bigdata-integration` CI job still fails loudly if the test unexpectedly skips. PR #561.
 
+==== SEC-020: World-Accessible File Permissions in Chaos Test Helper (Low) — Fixed
+
+_Added 2026-08-13_
+
+**Affected file:** `internal/chaos/chaos.go` (`MakeReadOnly`, `MakeWritable`)
+
+**Description:**
+The chaos-testing helper's `MakeReadOnly`/`MakeWritable` methods chmod'd files to `0444`/`0644`, granting group and other read access. Flagged by SonarCloud (`go:S2612`). These files only ever live under `t.TempDir()` and are only ever touched by the owning test process, so the group/other bits serve no purpose.
+
+**Risk:**
+Low (Blast Radius 0 per the Risk Radar assessment) — test-only helper, no production code path, files are ephemeral per-test temp files.
+
+**Fix:**
+Tightened to `0400`/`0600` (owner-only). Regression test added first per the TDD workflow rule, confirmed failing against the unfixed `0444`/`0644` modes, then the fix applied (#585).
+
 === Not Vulnerable
 
 The following attack vectors were explicitly tested and confirmed **not exploitable**:
@@ -504,6 +522,7 @@ All dependencies at latest versions. No known CVEs. `go mod verify` — **PASS**
 SEC-002 (PR #77), SEC-003 (PR #77), SEC-009 (PR #77), SEC-010 (PR #77), SEC-012 (#235).
 SEC-004, SEC-007, SEC-011 verified fixed 2026-03-30 (see individual findings above).
 SEC-019 (PR #561).
+SEC-020 (#585).
 
 ==== Remaining Open
 

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -425,6 +425,8 @@ Low (Blast Radius 0 per the Risk Radar assessment) — test-only helper, no prod
 **Fix:**
 Tightened to `0400`/`0600` (owner-only). Regression test added first per the TDD workflow rule, confirmed failing against the unfixed `0444`/`0644` modes, then the fix applied (#585).
 
+**Windows CI note:** the regression test's group/other-bits assertions are POSIX-only. `os.Chmod` on Windows only toggles the read-only attribute (via the 0200 bit), and `os.Stat` synthesizes a mirrored FileMode (`0444` read-only / `0666` writable) with no owner/group/other distinction — there is no Windows equivalent of "owner-only" access to assert on. The test skips those assertions on `runtime.GOOS == "windows"`, keeping the write-success/failure behavioral checks (which do exercise the real fix) on all platforms.
+
 === Not Vulnerable
 
 The following attack vectors were explicitly tested and confirmed **not exploitable**:


### PR DESCRIPTION
## Summary
- First batch of #585 (SonarCloud cleanup): fixes the `go:S2612` vulnerability in `internal/chaos/chaos.go` — `MakeReadOnly`/`MakeWritable` chmod'd to `0444`/`0644`, granting group/other read access on files that only ever live under `t.TempDir()` and are only touched by the owning test process.
- Tightened to `0400`/`0600` (owner-only).
- Regression test (already merged to `main` in `12c942e`, part of this PR's history) confirmed failing against the old modes before this fix, per the repo's TDD workflow rule.
- Updated the living security report (`src/docs/security/2026-03-01-security-review.adoc`) with SEC-020 and a changelog entry, per the Security Report policy.

## Test plan
- [x] `go test ./internal/chaos/...` — regression test passes
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — full suite green
- [x] `gofmt` clean