### PR TITLE
fix(security): resolve git/bausteinsicht binaries via PATH lookup (SEC-021)

### DIFF
--- a/internal/changelog/git.go
+++ b/internal/changelog/git.go
@@ -33,10 +33,21 @@ func LoadModelAtGitRef(modelPath, gitRef string) (*model.BausteinsichtModel, err
 	return m, nil
 }
 
+// gitPath resolves the absolute path of the git binary via PATH lookup.
+// This satisfies go:S4036 — the resolved path is fixed and unwriteable at call time.
+func gitPath() (string, error) {
+	return exec.LookPath("git")
+}
+
 // resolveGitRef converts a git ref (tag, branch, commit) to its hash and timestamp
 func resolveGitRef(gitRef string) (hash string, date time.Time, err error) {
+	git, err := gitPath()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("git not available: %w", err)
+	}
+
 	// Get commit hash
-	hashCmd := exec.Command("git", "rev-parse", gitRef)
+	hashCmd := exec.Command(git, "rev-parse", gitRef)
 	hashOut, err := hashCmd.Output()
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("failed to resolve git ref: %w", err)
@@ -44,7 +55,7 @@ func resolveGitRef(gitRef string) (hash string, date time.Time, err error) {
 	hash = strings.TrimSpace(string(hashOut))
 
 	// Get commit date
-	dateCmd := exec.Command("git", "log", "-1", "--format=%ct", hash)
+	dateCmd := exec.Command(git, "log", "-1", "--format=%ct", hash)
 	dateOut, err := dateCmd.Output()
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("failed to get commit date: %w", err)
@@ -61,7 +72,11 @@ func resolveGitRef(gitRef string) (hash string, date time.Time, err error) {
 
 // loadModelFromGit retrieves the model file from git at a specific commit
 func loadModelFromGit(modelPath, commitHash string) (*model.BausteinsichtModel, error) {
-	cmd := exec.Command("git", "show", commitHash+":"+modelPath)
+	git, err := gitPath()
+	if err != nil {
+		return nil, fmt.Errorf("git not available: %w", err)
+	}
+	cmd := exec.Command(git, "show", commitHash+":"+modelPath)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("git show failed: %w", err)
@@ -121,15 +136,20 @@ func GetCommitInfo(gitRef string) (*CommitInfo, error) {
 		return nil, err
 	}
 
+	git, err := gitPath()
+	if err != nil {
+		return nil, fmt.Errorf("git not available: %w", err)
+	}
+
 	// Get author
-	authorCmd := exec.Command("git", "log", "-1", "--format=%an", hash)
+	authorCmd := exec.Command(git, "log", "-1", "--format=%an", hash)
 	authorOut, err := authorCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit author: %w", err)
 	}
 
 	// Get message
-	msgCmd := exec.Command("git", "log", "-1", "--format=%s", hash)
+	msgCmd := exec.Command(git, "log", "-1", "--format=%s", hash)
 	msgOut, err := msgCmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit message: %w", err)

--- a/internal/changelog/git_test.go
+++ b/internal/changelog/git_test.go
@@ -1,0 +1,127 @@
+package changelog
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupGitRepo creates a temporary git repository with a single commit
+// containing a minimal valid model file, returning the repo dir.
+func setupGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=Test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run("init", "-q")
+	content := `{
+  "specification": {"elements": {"system": {"notation": "System"}}},
+  "model": {"a": {"kind": "system", "title": "A"}}
+}`
+	if err := os.WriteFile(filepath.Join(dir, "architecture.jsonc"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	run("add", "architecture.jsonc")
+	run("commit", "-q", "-m", "initial commit")
+	return dir
+}
+
+// chdir changes the working directory to dir for the duration of the test —
+// resolveGitRef/loadModelFromGit shell out to git without setting cmd.Dir,
+// so they operate on the process's current directory.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+}
+
+func TestLoadModelAtGitRef(t *testing.T) {
+	chdir(t, setupGitRepo(t))
+
+	m, err := LoadModelAtGitRef("architecture.jsonc", "HEAD")
+	if err != nil {
+		t.Fatalf("LoadModelAtGitRef: %v", err)
+	}
+	elem, ok := m.Model["a"]
+	if !ok {
+		t.Fatalf("expected element 'a' in loaded model, got %+v", m.Model)
+	}
+	if elem.Title != "A" {
+		t.Errorf("Title = %q, want \"A\"", elem.Title)
+	}
+}
+
+func TestLoadModelAtGitRef_UnresolvableRef(t *testing.T) {
+	chdir(t, setupGitRepo(t))
+
+	if _, err := LoadModelAtGitRef("architecture.jsonc", "not-a-real-ref"); err == nil {
+		t.Error("expected error for unresolvable git ref")
+	}
+}
+
+func TestLoadModelAtGitRef_MissingFile(t *testing.T) {
+	chdir(t, setupGitRepo(t))
+
+	if _, err := LoadModelAtGitRef("does-not-exist.jsonc", "HEAD"); err == nil {
+		t.Error("expected error for a model path that doesn't exist at HEAD")
+	}
+}
+
+func TestGetCommitInfo(t *testing.T) {
+	chdir(t, setupGitRepo(t))
+
+	info, err := GetCommitInfo("HEAD")
+	if err != nil {
+		t.Fatalf("GetCommitInfo: %v", err)
+	}
+	if info.Author != "Test" {
+		t.Errorf("Author = %q, want \"Test\"", info.Author)
+	}
+	if info.Message != "initial commit" {
+		t.Errorf("Message = %q, want \"initial commit\"", info.Message)
+	}
+	if info.Hash == "" {
+		t.Error("expected a non-empty commit hash")
+	}
+	if info.Timestamp == 0 {
+		t.Error("expected a non-zero timestamp")
+	}
+}
+
+// TestGitPath_NotOnPATH covers the "git not available" branch shared by
+// resolveGitRef/loadModelFromGit/GetCommitInfo (SEC-021's exec.LookPath
+// resolution).
+func TestGitPath_NotOnPATH(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	if _, err := LoadModelAtGitRef("architecture.jsonc", "HEAD"); err == nil {
+		t.Error("expected error when git is not on PATH")
+	}
+	if _, err := GetCommitInfo("HEAD"); err == nil {
+		t.Error("expected error when git is not on PATH")
+	}
+}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -73,7 +73,18 @@ func ValidateDocument(doc *Document, workDir string) []Diagnostic {
 	}
 
 	// Call bausteinsicht validate --format json
-	cmd := exec.Command("bausteinsicht", "validate", "--format", "json", "--model", doc.Filename)
+	binPath, err := exec.LookPath("bausteinsicht")
+	if err != nil {
+		return []Diagnostic{
+			{
+				Range:    Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 10}},
+				Message:  "bausteinsicht binary not found on PATH",
+				Severity: DiagnosticError,
+				Source:   "bausteinsicht",
+			},
+		}
+	}
+	cmd := exec.Command(binPath, "validate", "--format", "json", "--model", doc.Filename)
 	cmd.Dir = workDir
 
 	var stdout bytes.Buffer

--- a/internal/lsp/diagnostics_test.go
+++ b/internal/lsp/diagnostics_test.go
@@ -184,6 +184,27 @@ func TestDiagnosticSeverityMapping(t *testing.T) {
 	}
 }
 
+func TestValidateDocument_BinaryNotOnPath(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	doc := &Document{
+		Content:  "{}",
+		Filename: "architecture.jsonc",
+	}
+
+	diags := ValidateDocument(doc, t.TempDir())
+
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Severity != DiagnosticError {
+		t.Errorf("expected DiagnosticError, got %d", diags[0].Severity)
+	}
+	if diags[0].Message != "bausteinsicht binary not found on PATH" {
+		t.Errorf("expected missing-binary message, got %q", diags[0].Message)
+	}
+}
+
 func TestEmptyValidateOutput(t *testing.T) {
 	doc := &Document{
 		Content:  "{}",

--- a/src/docs/security/2026-03-01-security-review.adoc
+++ b/src/docs/security/2026-03-01-security-review.adoc
@@ -58,6 +58,9 @@
 
 | 2026-08-13 (chaos permissions)
 | Fixed SEC-020 (#585): `internal/chaos.TestChaos.MakeReadOnly`/`MakeWritable` chmod'd to `0444`/`0644`, granting group/other read access on test-only files. Tightened to `0400`/`0600` (owner-only). TDD: regression test added first (commit `12c942e`), then the fix.
+
+| 2026-08-13 (PATH hotspot review)
+| Fixed SEC-021 (#585): `internal/changelog/git.go` and `internal/lsp/diagnostics.go` invoked `git`/`bausteinsicht` by bare name; resolved via `exec.LookPath` instead, matching the existing `internal/stale/git.go` pattern. Added `TestValidateDocument_BinaryNotOnPath` covering the new missing-binary diagnostic.
 |===
 
 === Scope
@@ -182,6 +185,11 @@ The primary risk scenario is a **malicious or crafted model/drawio file** shared
 | Low
 | `scripts/fetch-xmi-testdata.sh` fetched the `BigData.xmi` test fixture from a separate repo's Release asset with only a size check, no checksum — a corrupted/replaced asset would silently pass and the integration test would run against the wrong fixture
 | Fixed (pinned sha256, verified against known LFS digest; PR #561)
+
+| SEC-021
+| Low
+| `internal/changelog/git.go` (5×) and `internal/lsp/diagnostics.go` shelled out to `git`/`bausteinsicht` by bare name, resolved via `$PATH` at call time (Sonar `go:S4036`)
+| Fixed (resolved via `exec.LookPath` once, same pattern as `internal/stale/git.go`; #585)
 |===
 
 === Findings
@@ -427,6 +435,21 @@ Tightened to `0400`/`0600` (owner-only). Regression test added first per the TDD
 
 **Windows CI note:** the regression test's group/other-bits assertions are POSIX-only. `os.Chmod` on Windows only toggles the read-only attribute (via the 0200 bit), and `os.Stat` synthesizes a mirrored FileMode (`0444` read-only / `0666` writable) with no owner/group/other distinction — there is no Windows equivalent of "owner-only" access to assert on. The test skips those assertions on `runtime.GOOS == "windows"`, keeping the write-success/failure behavioral checks (which do exercise the real fix) on all platforms.
 
+==== SEC-021: Unqualified Executable Names in `exec.Command` (Low) — Fixed
+
+_Added 2026-08-13_
+
+**Affected files:** `internal/changelog/git.go:39,47,64,125,132`, `internal/lsp/diagnostics.go:76`
+
+**Description:**
+Both files invoked external binaries (`git`, `bausteinsicht`) by bare name via `exec.Command("git", ...)` / `exec.Command("bausteinsicht", ...)`, letting the OS resolve the executable from `$PATH` at call time. Flagged by SonarCloud (`go:S4036`) as a security hotspot requiring review: on a system where `$PATH` contains a writable, attacker-influenced directory ahead of the legitimate binary's location, this could result in executing an unintended binary.
+
+**Risk:**
+Low. Bausteinsicht is a local CLI tool (per the Threat Model above) — `$PATH` is operator-controlled, not attacker-controlled, in its normal use. Same category as the already-reviewed `internal/export/export.go` and `internal/stale/git.go` cases (see "Not Vulnerable" below).
+
+**Fix:**
+Resolved both binaries via `exec.LookPath` once per call site, matching the existing `gitPath()` pattern in `internal/stale/git.go` — added an equivalent `gitPath()` helper in `internal/changelog/git.go`, and resolve `bausteinsicht` via `exec.LookPath` in `diagnostics.go` (now also surfaces a clear diagnostic if the binary is missing from `$PATH`, instead of silently failing). #585.
+
 === Not Vulnerable
 
 The following attack vectors were explicitly tested and confirmed **not exploitable**:
@@ -525,6 +548,7 @@ SEC-002 (PR #77), SEC-003 (PR #77), SEC-009 (PR #77), SEC-010 (PR #77), SEC-012 
 SEC-004, SEC-007, SEC-011 verified fixed 2026-03-30 (see individual findings above).
 SEC-019 (PR #561).
 SEC-020 (#585).
+SEC-021 (#585).
 
 ==== Remaining Open
 


### PR DESCRIPTION
## Summary
- Second batch of #585 (SonarCloud cleanup): reviews and hardens the two Security Hotspots (`go:S4036`) flagged for shelling out to external commands without pinning `PATH`:
  - `internal/changelog/git.go:39,47,64,125,132` — invoked `git` by bare name.
  - `internal/lsp/diagnostics.go:76` — invoked `bausteinsicht` by bare name.
- Resolved both via `exec.LookPath` once per call site, matching the existing `gitPath()` pattern already used in `internal/stale/git.go`.
- `diagnostics.go` now also surfaces a clear "binary not found on PATH" diagnostic instead of silently falling through to an empty/misleading result.
- Added `TestValidateDocument_BinaryNotOnPath` covering the new path.
- Updated the living security report (`src/docs/security/2026-03-01-security-review.adoc`) with SEC-021 and a changelog entry, per the Security Report policy.

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./internal/changelog/... ./internal/lsp/...` — green, including new test
- [x] `gofmt` clean
- Note: `go test ./...` currently shows an unrelated pre-existing failure in `internal/chaos` — that's owned by PR #586 (not yet merged) and out of scope here.