### PR TITLE
refactor(sync): reduce cognitive complexity in forward/layout/diff (#585)

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/beevik/etree"
 	"github.com/docToolchain/Bausteinsicht/internal/drawio"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
@@ -247,33 +248,8 @@ func detectUnmanagedDrawioElements(cs *ChangeSet, doc *drawio.Document) {
 			continue
 		}
 		for _, obj := range root.SelectElements("object") {
-			if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
-				continue // managed element, already handled
-			}
-			// Skip non-model elements created by forward sync.
-			objID := obj.SelectAttrValue("id", "")
-			if strings.HasPrefix(objID, "nav-back-") ||
-				strings.HasPrefix(objID, metadataPrefix) ||
-				strings.HasPrefix(objID, legendPrefix) ||
-				strings.HasPrefix(objID, docLinkPrefix) {
-				continue
-			}
-			// Check that it wraps a vertex cell (not a connector).
-			cell := obj.SelectElement("mxCell")
-			if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
-				continue
-			}
-			// Try sub-cell reading first, then HTML label.
-			title, _, _ := page.ReadElementFields(obj)
-			if title == "" {
-				label := obj.SelectAttrValue("label", "")
-				if label == "" {
-					continue
-				}
-				title, _, _ = drawio.ParseLabel(label)
-			}
-			id := sanitizeID(title)
-			if id == "" {
+			title, id, ok := unmanagedDrawioElementTitle(page, obj)
+			if !ok {
 				continue
 			}
 			cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{
@@ -283,6 +259,44 @@ func detectUnmanagedDrawioElements(cs *ChangeSet, doc *drawio.Document) {
 			})
 		}
 	}
+}
+
+// unmanagedDrawioElementTitle returns the title and sanitized ID for obj if
+// it is an unmanaged (no bausteinsicht_id) vertex representing a
+// user-created element forward sync hasn't seen before — as opposed to
+// non-model elements forward sync itself creates (back-nav button,
+// metadata/legend boxes, doc-link icons), which are skipped by ID prefix.
+func unmanagedDrawioElementTitle(page *drawio.Page, obj *etree.Element) (title, id string, ok bool) {
+	if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+		return "", "", false // managed element, already handled
+	}
+	// Skip non-model elements created by forward sync.
+	objID := obj.SelectAttrValue("id", "")
+	if strings.HasPrefix(objID, "nav-back-") ||
+		strings.HasPrefix(objID, metadataPrefix) ||
+		strings.HasPrefix(objID, legendPrefix) ||
+		strings.HasPrefix(objID, docLinkPrefix) {
+		return "", "", false
+	}
+	// Check that it wraps a vertex cell (not a connector).
+	cell := obj.SelectElement("mxCell")
+	if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
+		return "", "", false
+	}
+	// Try sub-cell reading first, then HTML label.
+	title, _, _ = page.ReadElementFields(obj)
+	if title == "" {
+		label := obj.SelectAttrValue("label", "")
+		if label == "" {
+			return "", "", false
+		}
+		title, _, _ = drawio.ParseLabel(label)
+	}
+	id = sanitizeID(title)
+	if id == "" {
+		return "", "", false
+	}
+	return title, id, true
 }
 
 // sanitizeID converts a title to a lowercase, hyphen-separated ID suitable
@@ -322,47 +336,68 @@ func resolveCellID(cellID string, cellToElem map[string]string) string {
 func buildCellIDToElemID(doc *drawio.Document) map[string]string {
 	m := make(map[string]string)
 	for _, page := range doc.Pages() {
-		for _, obj := range page.FindAllElements() {
-			elemID := obj.SelectAttrValue("bausteinsicht_id", "")
-			cellID := obj.SelectAttrValue("id", "")
-			if elemID != "" && cellID != "" {
-				m[cellID] = elemID
-			}
-		}
-		// Also map unmanaged elements (no bausteinsicht_id) to their
-		// sanitized label-based IDs so that connectors targeting them
-		// resolve correctly during reverse sync (#211).
-		root := page.Root()
-		if root == nil {
-			continue
-		}
-		for _, obj := range root.SelectElements("object") {
-			if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
-				continue
-			}
-			cellID := obj.SelectAttrValue("id", "")
-			if cellID == "" {
-				continue
-			}
-			if strings.HasPrefix(cellID, "nav-back-") || strings.HasPrefix(cellID, docLinkPrefix) {
-				continue
-			}
-			cell := obj.SelectElement("mxCell")
-			if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
-				continue
-			}
-			label := obj.SelectAttrValue("label", "")
-			if label == "" {
-				continue
-			}
-			title, _, _ := drawio.ParseLabel(label)
-			id := sanitizeID(title)
-			if id != "" {
-				m[cellID] = id
-			}
-		}
+		mapManagedElementsOnPage(page, m)
+		mapUnmanagedElementsOnPage(page, m)
 	}
 	return m
+}
+
+// mapManagedElementsOnPage maps each bausteinsicht-managed element's cell ID
+// to its element ID.
+func mapManagedElementsOnPage(page *drawio.Page, m map[string]string) {
+	for _, obj := range page.FindAllElements() {
+		elemID := obj.SelectAttrValue("bausteinsicht_id", "")
+		cellID := obj.SelectAttrValue("id", "")
+		if elemID != "" && cellID != "" {
+			m[cellID] = elemID
+		}
+	}
+}
+
+// mapUnmanagedElementsOnPage maps unmanaged elements (no bausteinsicht_id)
+// to their sanitized label-based IDs so that connectors targeting them
+// resolve correctly during reverse sync (#211).
+func mapUnmanagedElementsOnPage(page *drawio.Page, m map[string]string) {
+	root := page.Root()
+	if root == nil {
+		return
+	}
+	for _, obj := range root.SelectElements("object") {
+		if cellID, id, ok := unmanagedElementID(obj); ok {
+			m[cellID] = id
+		}
+	}
+}
+
+// unmanagedElementID returns the sanitized label-based ID for obj if it is
+// an unmanaged (no bausteinsicht_id) vertex with a usable label — used so
+// connectors targeting unmanaged elements resolve correctly during reverse
+// sync (#211).
+func unmanagedElementID(obj *etree.Element) (cellID, id string, ok bool) {
+	if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+		return "", "", false
+	}
+	cellID = obj.SelectAttrValue("id", "")
+	if cellID == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(cellID, "nav-back-") || strings.HasPrefix(cellID, docLinkPrefix) {
+		return "", "", false
+	}
+	cell := obj.SelectElement("mxCell")
+	if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
+		return "", "", false
+	}
+	label := obj.SelectAttrValue("label", "")
+	if label == "" {
+		return "", "", false
+	}
+	title, _, _ := drawio.ParseLabel(label)
+	id = sanitizeID(title)
+	if id == "" {
+		return "", "", false
+	}
+	return cellID, id, true
 }
 
 // extractDrawioRelationships gathers connector data from all pages.
@@ -474,68 +509,109 @@ func detectElementChanges(
 	sort.Strings(allIDs)
 
 	for _, id := range allIDs {
-		me, inModel := flatModel[id]
-		de, inDrawio := drawioElems[id]
-		lastElem, inLast := lastState.Elements[id]
-
-		// Model side changes
-		switch {
-		case inModel && !inLast:
-			cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{ID: id, Type: Added})
-		case !inModel && inLast:
-			cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{ID: id, Type: Deleted})
-		case inModel && inLast:
-			appendIfChanged(id, "title", lastElem.Title, me.Title, &cs.ModelElementChanges)
-			appendIfChanged(id, "description", lastElem.Description, me.Description, &cs.ModelElementChanges)
-			appendIfChanged(id, "technology", lastElem.Technology, me.Technology, &cs.ModelElementChanges)
-			appendIfChanged(id, "kind", lastElem.Kind, me.Kind, &cs.ModelElementChanges)
-			appendIfChanged(id, "link", lastElem.Link, me.Link, &cs.ModelElementChanges)
-		}
-
-		// Draw.io side changes
-		switch {
-		case inDrawio && !inLast:
-			cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Added})
-		case !inDrawio && inLast:
-			// Only treat as deleted if the element should be visible on at least one
-			// view page. Elements not in any view's resolved set are simply filtered
-			// out and their absence from draw.io is expected, not a deletion. (#108, #118)
-			// Also skip elements that are only expected on newly created pages — those
-			// pages haven't been populated by forward sync yet (#184, #188, #189).
-			if visibleElems == nil || visibleElems[id] {
-				if newPageOnly != nil && newPageOnly[id] {
-					continue
-				}
-				// Skip elements that were never rendered to a draw.io page.
-				// When RenderedElements is available (state from v2+), an element
-				// absent from draw.io but not in RenderedElements was never on any
-				// page — it was filtered by views. Forward sync will create it now
-				// that views include it. (#240)
-				// When RenderedElements is nil (old state files), fall back to
-				// treating all elements as rendered (preserving old behavior).
-				if lastState.RenderedElements != nil && !lastState.RenderedElements[id] {
-					continue
-				}
-				cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Deleted})
-			}
-		case inDrawio && inLast:
-			appendIfChanged(id, "title", lastElem.Title, de.title, &cs.DrawioElementChanges)
-			appendIfChanged(id, "description", lastElem.Description, de.description, &cs.DrawioElementChanges)
-			appendIfChanged(id, "technology", lastElem.Technology, de.technology, &cs.DrawioElementChanges)
-			// Note: kind is not compared on the draw.io side because scope
-			// boundary elements have a derived kind (e.g. "system_boundary")
-			// that legitimately differs from the model kind ("system").
-		}
-
-		// Conflicts: both sides modified the same field
-		if inModel && inDrawio && inLast {
-			checkElemConflict(cs, id, "title", lastElem.Title, me.Title, de.title)
-			checkElemConflict(cs, id, "description", lastElem.Description, me.Description, de.description)
-			checkElemConflict(cs, id, "technology", lastElem.Technology, me.Technology, de.technology)
-			// Note: kind conflicts are not checked because kind is
-			// model-authoritative and draw.io boundary kinds are derived.
-		}
+		detectElementChangeForID(cs, id, flatModel, drawioElems, lastState, visibleElems, newPageOnly)
 	}
+}
+
+// detectElementChangeForID performs the three-way comparison (model /
+// draw.io / last-sync state) for a single element ID and appends the
+// resulting changes and conflicts to cs.
+func detectElementChangeForID(
+	cs *ChangeSet,
+	id string,
+	flatModel map[string]*model.Element,
+	drawioElems map[string]drawioElemSnapshot,
+	lastState *SyncState,
+	visibleElems map[string]bool,
+	newPageOnly map[string]bool,
+) {
+	me, inModel := flatModel[id]
+	de, inDrawio := drawioElems[id]
+	lastElem, inLast := lastState.Elements[id]
+
+	detectModelElementChange(cs, id, me, inModel, lastElem, inLast)
+	detectDrawioElementChange(cs, id, de, inDrawio, lastElem, inLast, lastState, visibleElems, newPageOnly)
+
+	// Conflicts: both sides modified the same field
+	if inModel && inDrawio && inLast {
+		checkElemConflict(cs, id, "title", lastElem.Title, me.Title, de.title)
+		checkElemConflict(cs, id, "description", lastElem.Description, me.Description, de.description)
+		checkElemConflict(cs, id, "technology", lastElem.Technology, me.Technology, de.technology)
+		// Note: kind conflicts are not checked because kind is
+		// model-authoritative and draw.io boundary kinds are derived.
+	}
+}
+
+// detectModelElementChange appends the model-side ElementChange for a single
+// element, comparing against last-sync state.
+func detectModelElementChange(cs *ChangeSet, id string, me *model.Element, inModel bool, lastElem ElementState, inLast bool) {
+	switch {
+	case inModel && !inLast:
+		cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{ID: id, Type: Added})
+	case !inModel && inLast:
+		cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{ID: id, Type: Deleted})
+	case inModel && inLast:
+		appendIfChanged(id, "title", lastElem.Title, me.Title, &cs.ModelElementChanges)
+		appendIfChanged(id, "description", lastElem.Description, me.Description, &cs.ModelElementChanges)
+		appendIfChanged(id, "technology", lastElem.Technology, me.Technology, &cs.ModelElementChanges)
+		appendIfChanged(id, "kind", lastElem.Kind, me.Kind, &cs.ModelElementChanges)
+		appendIfChanged(id, "link", lastElem.Link, me.Link, &cs.ModelElementChanges)
+	}
+}
+
+// detectDrawioElementChange appends the draw.io-side ElementChange for a
+// single element, comparing against last-sync state.
+func detectDrawioElementChange(
+	cs *ChangeSet,
+	id string,
+	de drawioElemSnapshot,
+	inDrawio bool,
+	lastElem ElementState,
+	inLast bool,
+	lastState *SyncState,
+	visibleElems map[string]bool,
+	newPageOnly map[string]bool,
+) {
+	switch {
+	case inDrawio && !inLast:
+		cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Added})
+	case !inDrawio && inLast:
+		appendDrawioDeletionIfVisible(cs, id, lastState, visibleElems, newPageOnly)
+	case inDrawio && inLast:
+		appendIfChanged(id, "title", lastElem.Title, de.title, &cs.DrawioElementChanges)
+		appendIfChanged(id, "description", lastElem.Description, de.description, &cs.DrawioElementChanges)
+		appendIfChanged(id, "technology", lastElem.Technology, de.technology, &cs.DrawioElementChanges)
+		// Note: kind is not compared on the draw.io side because scope
+		// boundary elements have a derived kind (e.g. "system_boundary")
+		// that legitimately differs from the model kind ("system").
+	}
+}
+
+// appendDrawioDeletionIfVisible appends a Deleted DrawioElementChange for id
+// unless its absence from draw.io is expected rather than a real deletion.
+func appendDrawioDeletionIfVisible(cs *ChangeSet, id string, lastState *SyncState, visibleElems map[string]bool, newPageOnly map[string]bool) {
+	// Only treat as deleted if the element should be visible on at least one
+	// view page. Elements not in any view's resolved set are simply filtered
+	// out and their absence from draw.io is expected, not a deletion. (#108, #118)
+	if visibleElems != nil && !visibleElems[id] {
+		return
+	}
+	// Skip elements that are only expected on newly created pages — those
+	// pages haven't been populated by forward sync yet (#184, #188, #189).
+	if newPageOnly != nil && newPageOnly[id] {
+		return
+	}
+	// Skip elements that were never rendered to a draw.io page.
+	// When RenderedElements is available (state from v2+), an element
+	// absent from draw.io but not in RenderedElements was never on any
+	// page — it was filtered by views. Forward sync will create it now
+	// that views include it. (#240)
+	// When RenderedElements is nil (old state files), fall back to
+	// treating all elements as rendered (preserving old behavior).
+	if lastState.RenderedElements != nil && !lastState.RenderedElements[id] {
+		return
+	}
+	cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Deleted})
 }
 
 // unionElementIDs returns the union of IDs across all three sources.
@@ -562,90 +638,103 @@ func unionElementIDs(
 // that doesn't match the model, even though model and state agree.
 // This handles the case where reverse sync updated one view but other views
 // still show the old value (#236).
+// fieldKey identifies a single (element, field) combo, used to track which
+// cross-view field changes have already been emitted to avoid duplicates.
+type fieldKey struct {
+	id, field string
+}
+
 func detectCrossViewInconsistencies(
 	cs *ChangeSet,
 	doc *drawio.Document,
 	flatModel map[string]*model.Element,
 	lastState *SyncState,
 ) {
-	// Track which element+field combos we've already emitted to avoid duplicates.
-	type fieldKey struct {
-		id, field string
+	emitted := buildEmittedFieldSet(cs)
+
+	for _, page := range doc.Pages() {
+		for _, obj := range page.FindAllElements() {
+			reconcileElementFieldsAcrossViews(cs, obj, page, flatModel, lastState, emitted)
+		}
 	}
+}
+
+// buildEmittedFieldSet returns the (element, field) pairs already covered by
+// a model-side change (already forward-synced) or a draw.io-side change
+// (a legitimate user edit that should be reverse-synced, not overwritten by
+// forward sync) in cs, so detectCrossViewInconsistencies doesn't also emit a
+// stale-value change for them.
+func buildEmittedFieldSet(cs *ChangeSet) map[fieldKey]bool {
 	emitted := make(map[fieldKey]bool)
-	// Skip fields that detectElementChanges already emitted as model changes.
 	for _, ch := range cs.ModelElementChanges {
 		if ch.Field != "" {
 			emitted[fieldKey{ch.ID, ch.Field}] = true
 		}
 	}
-	// Skip fields that have a legitimate draw.io-side change — those are user
-	// edits that should be reverse-synced, not overwritten by forward sync.
 	for _, ch := range cs.DrawioElementChanges {
 		if ch.Field != "" {
 			emitted[fieldKey{ch.ID, ch.Field}] = true
 		}
 	}
+	return emitted
+}
 
-	for _, page := range doc.Pages() {
-		for _, obj := range page.FindAllElements() {
-			id := obj.SelectAttrValue("bausteinsicht_id", "")
-			if id == "" {
-				continue
-			}
-			me, inModel := flatModel[id]
-			if !inModel {
-				continue
-			}
-			lastElem, inLast := lastState.Elements[id]
-			if !inLast {
-				continue
-			}
-
-			title, technology, labelDesc := page.ReadElementFields(obj)
-			if technology == "" {
-				technology = obj.SelectAttrValue("technology", "")
-			}
-			tooltipDesc := obj.SelectAttrValue("tooltip", "")
-			description := tooltipDesc
-			if description == "" {
-				description = labelDesc
-			}
-
-			// If model and state agree but this page shows a stale value,
-			// emit a forward change so all views are brought up to date.
-			if me.Title == lastElem.Title && title != me.Title {
-				fk := fieldKey{id, "title"}
-				if !emitted[fk] {
-					emitted[fk] = true
-					cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{
-						ID: id, Type: Modified, Field: "title",
-						OldValue: title, NewValue: me.Title,
-					})
-				}
-			}
-			if me.Description == lastElem.Description && description != me.Description {
-				fk := fieldKey{id, "description"}
-				if !emitted[fk] {
-					emitted[fk] = true
-					cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{
-						ID: id, Type: Modified, Field: "description",
-						OldValue: description, NewValue: me.Description,
-					})
-				}
-			}
-			if me.Technology == lastElem.Technology && technology != me.Technology {
-				fk := fieldKey{id, "technology"}
-				if !emitted[fk] {
-					emitted[fk] = true
-					cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{
-						ID: id, Type: Modified, Field: "technology",
-						OldValue: technology, NewValue: me.Technology,
-					})
-				}
-			}
-		}
+// reconcileElementFieldsAcrossViews checks a single page element against the
+// model and last-sync state, emitting a forward change for any field where
+// model and state agree (no real model change) but this page's rendered
+// value is stale — bringing all views up to date with the model.
+func reconcileElementFieldsAcrossViews(
+	cs *ChangeSet,
+	obj *etree.Element,
+	page *drawio.Page,
+	flatModel map[string]*model.Element,
+	lastState *SyncState,
+	emitted map[fieldKey]bool,
+) {
+	id := obj.SelectAttrValue("bausteinsicht_id", "")
+	if id == "" {
+		return
 	}
+	me, inModel := flatModel[id]
+	if !inModel {
+		return
+	}
+	lastElem, inLast := lastState.Elements[id]
+	if !inLast {
+		return
+	}
+
+	title, technology, labelDesc := page.ReadElementFields(obj)
+	if technology == "" {
+		technology = obj.SelectAttrValue("technology", "")
+	}
+	tooltipDesc := obj.SelectAttrValue("tooltip", "")
+	description := tooltipDesc
+	if description == "" {
+		description = labelDesc
+	}
+
+	emitStaleFieldChange(cs, emitted, id, "title", lastElem.Title, me.Title, title)
+	emitStaleFieldChange(cs, emitted, id, "description", lastElem.Description, me.Description, description)
+	emitStaleFieldChange(cs, emitted, id, "technology", lastElem.Technology, me.Technology, technology)
+}
+
+// emitStaleFieldChange appends a Modified ElementChange for field if the
+// model and last-sync state agree (no real model change occurred) but
+// pageValue has drifted from the model, unless already covered by emitted.
+func emitStaleFieldChange(cs *ChangeSet, emitted map[fieldKey]bool, id, field, lastValue, modelValue, pageValue string) {
+	if modelValue != lastValue || pageValue == modelValue {
+		return
+	}
+	fk := fieldKey{id, field}
+	if emitted[fk] {
+		return
+	}
+	emitted[fk] = true
+	cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{
+		ID: id, Type: Modified, Field: field,
+		OldValue: pageValue, NewValue: modelValue,
+	})
 }
 
 // appendIfChanged adds a Modified ElementChange if newValue differs from lastValue.
@@ -694,72 +783,127 @@ func detectRelationshipChanges(
 	allKeys := unionRelKeys(modelRels, drawioRels, lastRels)
 
 	for k := range allKeys {
-		mr, inModel := modelRels[k]
-		dr, inDrawio := drawioRels[k]
-		lr, inLast := lastRels[k]
-
-		from, to, index := resolveRelFromTo(mr, lr, dr)
-
-		// Model side
-		switch {
-		case inModel && !inLast:
-			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Added, NewValue: mr.Label, Kind: mr.Kind,
-			})
-		case !inModel && inLast:
-			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Deleted,
-			})
-		case inModel && inLast && (mr.Label != lr.Label || mr.Kind != lr.Kind):
-			cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Modified, Field: "label",
-				OldValue: lr.Label, NewValue: mr.Label, Kind: mr.Kind,
-			})
-		}
-
-		// Draw.io side
-		switch {
-		case inDrawio && !inLast:
-			// Skip lifted connectors: when a view lifts a relationship
-			// endpoint to a parent (e.g., A→B.child becomes A→B),
-			// the lifted connector should not be treated as a new relationship.
-			if isLiftedRelationship(from, to, modelRels) {
-				continue
-			}
-			// Collect page IDs where this relationship exists.
-			pageID := ""
-			if len(dr.PageIDs) > 0 {
-				pageID = dr.PageIDs[0]
-			}
-			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Added, NewValue: dr.Label, PageID: pageID,
-			})
-		case !inDrawio && inLast:
-			// Only treat as deleted if the relationship should have a connector
-			// on at least one view page. Relationships whose endpoints are not
-			// visible on any view (due to filter changes) are simply absent from
-			// draw.io — not user deletions. (#167)
-			if visibleRels != nil && !visibleRels[k] {
-				continue
-			}
-			// Skip if a lifted version of this relationship exists in draw.io.
-			// When a view lifts endpoints (e.g., cli→model.loader becomes
-			// cli→model), the connector has different keys but still represents
-			// this relationship. Without this check, the original relationship
-			// would be incorrectly deleted (#223).
-			if hasLiftedConnectorInDrawio(from, to, drawioRels) {
-				continue
-			}
-			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Deleted,
-			})
-		case inDrawio && inLast && dr.Label != lr.Label:
-			cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-				From: from, To: to, Index: index, Type: Modified, Field: "label",
-				OldValue: lr.Label, NewValue: dr.Label,
-			})
-		}
+		detectRelationshipChangeForKey(cs, k, modelRels, drawioRels, lastRels, visibleRels)
 	}
+}
+
+// detectRelationshipChangeForKey performs the three-way comparison (model /
+// draw.io / last-sync state) for a single relationship key and appends the
+// resulting changes to cs.
+func detectRelationshipChangeForKey(
+	cs *ChangeSet,
+	k string,
+	modelRels map[string]RelationshipState,
+	drawioRels map[string]RelationshipState,
+	lastRels map[string]RelationshipState,
+	visibleRels map[string]bool,
+) {
+	mr, inModel := modelRels[k]
+	dr, inDrawio := drawioRels[k]
+	lr, inLast := lastRels[k]
+
+	from, to, index := resolveRelFromTo(mr, lr, dr)
+
+	detectModelRelationshipChange(cs, from, to, index, mr, inModel, lr, inLast)
+	detectDrawioRelationshipChange(cs, k, from, to, index, dr, inDrawio, lr, inLast, modelRels, drawioRels, visibleRels)
+}
+
+// detectModelRelationshipChange appends the model-side RelationshipChange
+// for a single relationship, comparing against last-sync state.
+func detectModelRelationshipChange(
+	cs *ChangeSet,
+	from, to string,
+	index int,
+	mr RelationshipState,
+	inModel bool,
+	lr RelationshipState,
+	inLast bool,
+) {
+	switch {
+	case inModel && !inLast:
+		cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
+			From: from, To: to, Index: index, Type: Added, NewValue: mr.Label, Kind: mr.Kind,
+		})
+	case !inModel && inLast:
+		cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
+			From: from, To: to, Index: index, Type: Deleted,
+		})
+	case inModel && inLast && (mr.Label != lr.Label || mr.Kind != lr.Kind):
+		cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
+			From: from, To: to, Index: index, Type: Modified, Field: "label",
+			OldValue: lr.Label, NewValue: mr.Label, Kind: mr.Kind,
+		})
+	}
+}
+
+// detectDrawioRelationshipChange appends the draw.io-side RelationshipChange
+// for a single relationship, comparing against last-sync state.
+func detectDrawioRelationshipChange(
+	cs *ChangeSet,
+	k string,
+	from, to string,
+	index int,
+	dr RelationshipState,
+	inDrawio bool,
+	lr RelationshipState,
+	inLast bool,
+	modelRels map[string]RelationshipState,
+	drawioRels map[string]RelationshipState,
+	visibleRels map[string]bool,
+) {
+	switch {
+	case inDrawio && !inLast:
+		appendAddedDrawioRelationship(cs, from, to, index, dr, modelRels)
+	case !inDrawio && inLast:
+		appendDeletedDrawioRelationship(cs, k, from, to, index, drawioRels, visibleRels)
+	case inDrawio && inLast && dr.Label != lr.Label:
+		cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
+			From: from, To: to, Index: index, Type: Modified, Field: "label",
+			OldValue: lr.Label, NewValue: dr.Label,
+		})
+	}
+}
+
+// appendAddedDrawioRelationship appends an Added DrawioRelationshipChange
+// unless the connector is a lifted view of an existing model relationship
+// (e.g. A→B.child becomes A→B via view endpoint lifting) — those must not
+// be treated as new relationships.
+func appendAddedDrawioRelationship(cs *ChangeSet, from, to string, index int, dr RelationshipState, modelRels map[string]RelationshipState) {
+	if isLiftedRelationship(from, to, modelRels) {
+		return
+	}
+	// Collect page IDs where this relationship exists.
+	pageID := ""
+	if len(dr.PageIDs) > 0 {
+		pageID = dr.PageIDs[0]
+	}
+	cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
+		From: from, To: to, Index: index, Type: Added, NewValue: dr.Label, PageID: pageID,
+	})
+}
+
+// appendDeletedDrawioRelationship appends a Deleted DrawioRelationshipChange
+// unless the relationship isn't expected to have a connector on any visible
+// view (#167), or a lifted version of it still exists in draw.io (#223).
+func appendDeletedDrawioRelationship(cs *ChangeSet, k string, from, to string, index int, drawioRels map[string]RelationshipState, visibleRels map[string]bool) {
+	// Only treat as deleted if the relationship should have a connector
+	// on at least one view page. Relationships whose endpoints are not
+	// visible on any view (due to filter changes) are simply absent from
+	// draw.io — not user deletions. (#167)
+	if visibleRels != nil && !visibleRels[k] {
+		return
+	}
+	// Skip if a lifted version of this relationship exists in draw.io.
+	// When a view lifts endpoints (e.g., cli→model.loader becomes
+	// cli→model), the connector has different keys but still represents
+	// this relationship. Without this check, the original relationship
+	// would be incorrectly deleted (#223).
+	if hasLiftedConnectorInDrawio(from, to, drawioRels) {
+		return
+	}
+	cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
+		From: from, To: to, Index: index, Type: Deleted,
+	})
 }
 
 // unionRelKeys returns the union of relationship keys from all three sources.

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -166,99 +166,137 @@ func applyForwardPerView(
 	opts *ForwardOptions,
 	result *ForwardResult,
 ) {
-	// Build drill-down link map: elementID → "data:page/id,view-<viewID>"
-	// An element gets a link when a view's scope matches that element.
+	drillDownLinks := buildDrillDownLinks(m)
+
+	for viewID, view := range m.Views {
+		applyForwardToView(cs, doc, templates, flat, m, opts, viewID, view, drillDownLinks, result)
+	}
+}
+
+// buildDrillDownLinks maps elementID → "data:page/id,view-<viewID>" for
+// every element that is the scope of some view. An element gets a link when
+// a view's scope matches that element.
+func buildDrillDownLinks(m *model.BausteinsichtModel) map[string]string {
 	drillDownLinks := make(map[string]string)
 	for vID, v := range m.Views {
 		if v.Scope != "" {
 			drillDownLinks[v.Scope] = "data:page/id,view-" + vID
 		}
 	}
+	return drillDownLinks
+}
 
-	for viewID, view := range m.Views {
-		pageID := "view-" + viewID
-		page := doc.GetPage(pageID)
-		if page == nil {
-			result.Warnings = append(result.Warnings,
-				"no page found for view: "+viewID)
-			continue
+// applyForwardToView runs the full forward-sync pipeline for a single view's
+// page: placement of new elements, model changes, connectors, reconciliation,
+// drill-down links, back navigation, metadata/legend, and doc-link icons.
+func applyForwardToView(
+	cs *ChangeSet,
+	doc *drawio.Document,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	m *model.BausteinsichtModel,
+	opts *ForwardOptions,
+	viewID string,
+	view model.View,
+	drillDownLinks map[string]string,
+	result *ForwardResult,
+) {
+	pageID := "view-" + viewID
+	page := doc.GetPage(pageID)
+	if page == nil {
+		result.Warnings = append(result.Warnings, "no page found for view: "+viewID)
+		return
+	}
+
+	viewCopy := view
+	resolved, err := model.ResolveView(m, &viewCopy)
+	if err != nil {
+		result.Warnings = append(result.Warnings, "resolving view "+viewID+": "+err.Error())
+		return
+	}
+
+	elemSet := make(map[string]bool, len(resolved))
+	for _, id := range resolved {
+		elemSet[id] = true
+	}
+
+	scopeID := view.Scope
+
+	// --relayout: clear all managed elements from the page so
+	// populateNewPage treats it as a fresh page.
+	if opts != nil && opts.Relayout {
+		clearPageElements(page)
+	}
+
+	if scopeID != "" {
+		createScopeBoundary(scopeID, viewID, page, templates, flat, &m.Specification, result)
+		// Include scope element in the filter so connectors targeting the
+		// boundary element are rendered (#217).
+		elemSet[scopeID] = true
+	}
+
+	// Populate resolved elements that aren't already on the page.
+	// This runs BEFORE applyChangesToPage so the layout engine can
+	// position elements on fresh pages. applyChangesToPage will then
+	// skip Added elements that are already placed. For existing pages,
+	// this handles elements newly included via view changes (#231).
+	populateNewPage(page, viewID, scopeID, templates, flat, elemSet, m, result)
+
+	applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, &m.Specification, result)
+
+	// Populate connectors for relationships whose endpoints are both
+	// on the page but whose connector doesn't exist yet. This handles
+	// relationships involving newly populated elements (#231).
+	populateConnectors(page, viewID, scopeID, m, elemSet, templates, result)
+
+	// Reconciliation: remove elements on the page that are no longer
+	// in the resolved view (e.g., after exclude list changes). #102
+	reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
+
+	// Set drill-down links on elements that have a detail view. (#198)
+	// Drill-down links take priority over user-defined element links (ADR-009).
+	result.Warnings = append(result.Warnings, applyDrillDownLinks(page, drillDownLinks)...)
+
+	// Create back-navigation button on detail views (views with scope). (#198)
+	if scopeID != "" {
+		createBackNavButton(page, viewID, scopeID, m)
+	}
+
+	// Create metadata and legend boxes on each view page. (#233)
+	applyViewMetadataAndLegend(page, viewID, view, m, opts, elemSet, flat, templates, result)
+
+	// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
+	synchronizeDocLinkIcons(page, m)
+
+	// Synchronize the view-level DocLinks icon row (e.g. PRD/persona links for the whole page). (#543)
+	synchronizeViewDocLinkIcons(page, viewID, view)
+}
+
+// applyViewMetadataAndLegend creates the metadata and legend boxes on page,
+// if enabled by config. (#233)
+func applyViewMetadataAndLegend(
+	page *drawio.Page,
+	viewID string,
+	view model.View,
+	m *model.BausteinsichtModel,
+	opts *ForwardOptions,
+	elemSet map[string]bool,
+	flat map[string]*model.Element,
+	templates *drawio.TemplateSet,
+	result *ForwardResult,
+) {
+	metadataEnabled := m.Config.Metadata == nil || *m.Config.Metadata
+	legendEnabled := m.Config.Legend == nil || *m.Config.Legend
+
+	if metadataEnabled && opts != nil {
+		if createMetadata(page, viewID, view, m.Config, opts.ModelPath, opts.SyncTime) {
+			result.MetadataUpdated++
 		}
-
-		viewCopy := view
-		resolved, err := model.ResolveView(m, &viewCopy)
-		if err != nil {
-			result.Warnings = append(result.Warnings,
-				"resolving view "+viewID+": "+err.Error())
-			continue
+	}
+	if legendEnabled {
+		if createLegend(page, viewID, m.Specification, templates, elemSet, flat) {
+			result.MetadataUpdated++
 		}
-
-		elemSet := make(map[string]bool, len(resolved))
-		for _, id := range resolved {
-			elemSet[id] = true
-		}
-
-		scopeID := view.Scope
-
-		// --relayout: clear all managed elements from the page so
-		// populateNewPage treats it as a fresh page.
-		if opts != nil && opts.Relayout {
-			clearPageElements(page)
-		}
-
-		if scopeID != "" {
-			createScopeBoundary(scopeID, viewID, page, templates, flat, &m.Specification, result)
-			// Include scope element in the filter so connectors targeting the
-			// boundary element are rendered (#217).
-			elemSet[scopeID] = true
-		}
-
-		// Populate resolved elements that aren't already on the page.
-		// This runs BEFORE applyChangesToPage so the layout engine can
-		// position elements on fresh pages. applyChangesToPage will then
-		// skip Added elements that are already placed. For existing pages,
-		// this handles elements newly included via view changes (#231).
-		populateNewPage(page, viewID, scopeID, templates, flat, elemSet, m, result)
-
-		applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, &m.Specification, result)
-
-		// Populate connectors for relationships whose endpoints are both
-		// on the page but whose connector doesn't exist yet. This handles
-		// relationships involving newly populated elements (#231).
-		populateConnectors(page, viewID, scopeID, m, elemSet, templates, result)
-
-		// Reconciliation: remove elements on the page that are no longer
-		// in the resolved view (e.g., after exclude list changes). #102
-		reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
-
-		// Set drill-down links on elements that have a detail view. (#198)
-		// Drill-down links take priority over user-defined element links (ADR-009).
-		result.Warnings = append(result.Warnings, applyDrillDownLinks(page, drillDownLinks)...)
-
-		// Create back-navigation button on detail views (views with scope). (#198)
-		if scopeID != "" {
-			createBackNavButton(page, viewID, scopeID, m)
-		}
-
-		// Create metadata and legend boxes on each view page. (#233)
-		metadataEnabled := m.Config.Metadata == nil || *m.Config.Metadata
-		legendEnabled := m.Config.Legend == nil || *m.Config.Legend
-
-		if metadataEnabled && opts != nil {
-			if createMetadata(page, viewID, view, m.Config, opts.ModelPath, opts.SyncTime) {
-				result.MetadataUpdated++
-			}
-		}
-		if legendEnabled {
-			if createLegend(page, viewID, m.Specification, templates, elemSet, flat) {
-				result.MetadataUpdated++
-			}
-		}
-
-		// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
-		synchronizeDocLinkIcons(page, m)
-
-		// Synchronize the view-level DocLinks icon row (e.g. PRD/persona links for the whole page). (#543)
-		synchronizeViewDocLinkIcons(page, viewID, view)
 	}
 }
 
@@ -276,7 +314,22 @@ func populateNewPage(
 	m *model.BausteinsichtModel,
 	result *ForwardResult,
 ) {
-	// Collect elements that need placement.
+	toPlace := collectElementsToPlace(page, scopeID, elemSet)
+	if len(toPlace) == 0 {
+		return
+	}
+
+	if isFreshPage(page, scopeID) {
+		layoutMode := viewLayoutMode(m, page.ID())
+		placeElementsWithLayout(page, viewID, scopeID, templates, flat, m, toPlace, layoutMode, result)
+	} else {
+		placeElementsIncrementally(page, viewID, scopeID, templates, flat, m, toPlace, result)
+	}
+}
+
+// collectElementsToPlace returns the elements of elemSet that still need to
+// be placed on page: not the scope element itself, and not already present.
+func collectElementsToPlace(page *drawio.Page, scopeID string, elemSet map[string]bool) []string {
 	var toPlace []string
 	for id := range elemSet {
 		if id == scopeID {
@@ -287,59 +340,82 @@ func populateNewPage(
 		}
 		toPlace = append(toPlace, id)
 	}
-	if len(toPlace) == 0 {
-		return
-	}
+	return toPlace
+}
 
-	// Determine if this is a fresh page (no existing bausteinsicht elements
-	// besides the scope boundary which is created before this function runs).
-	existingElems := page.FindAllElements()
+// isFreshPage reports whether page has no existing bausteinsicht elements
+// besides the scope boundary, which is created before populateNewPage runs.
+func isFreshPage(page *drawio.Page, scopeID string) bool {
 	nonBoundaryCount := 0
-	for _, obj := range existingElems {
+	for _, obj := range page.FindAllElements() {
 		if obj.SelectAttrValue("bausteinsicht_id", "") != scopeID || scopeID == "" {
 			nonBoundaryCount++
 		}
 	}
-	isFreshPage := nonBoundaryCount == 0
+	return nonBoundaryCount == 0
+}
 
-	// Look up the view's layout mode.
-	layoutMode := ""
+// viewLayoutMode looks up the layout mode of the view whose page ID is pageID.
+func viewLayoutMode(m *model.BausteinsichtModel, pageID string) string {
 	for vID, v := range m.Views {
-		if "view-"+vID == page.ID() {
-			layoutMode = v.Layout
-			break
+		if "view-"+vID == pageID {
+			return v.Layout
 		}
 	}
+	return ""
+}
 
-	if isFreshPage {
-		// Use layout engine for fresh pages.
-		lr := computeLayout(toPlace, flat, templates, m.ElementOrder, scopeID, layoutMode, m.Relationships)
+// placeElementsWithLayout uses the layout engine to position toPlace on a
+// fresh page, resizing the scope boundary to fit if the engine computed
+// boundary dimensions.
+func placeElementsWithLayout(
+	page *drawio.Page,
+	viewID string,
+	scopeID string,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	m *model.BausteinsichtModel,
+	toPlace []string,
+	layoutMode string,
+	result *ForwardResult,
+) {
+	lr := computeLayout(toPlace, flat, templates, m.ElementOrder, scopeID, layoutMode, m.Relationships)
 
-		// Resize and reposition the scope boundary if the layout engine computed dimensions.
-		if scopeID != "" && lr.BoundaryWidth > 0 && lr.BoundaryHeight > 0 {
-			resizeScopeBoundary(page, scopeID, lr.BoundaryX, lr.BoundaryY, lr.BoundaryWidth, lr.BoundaryHeight)
-		}
+	if scopeID != "" && lr.BoundaryWidth > 0 && lr.BoundaryHeight > 0 {
+		resizeScopeBoundary(page, scopeID, lr.BoundaryX, lr.BoundaryY, lr.BoundaryWidth, lr.BoundaryHeight)
+	}
 
-		sort.Strings(toPlace)
-		for _, id := range toPlace {
-			pos, ok := lr.Positions[id]
-			if !ok {
-				continue
-			}
-			placeSingleElement(id, viewID, scopeID, page, templates, flat, &m.Specification, pos.X, pos.Y, false, result)
+	sort.Strings(toPlace)
+	for _, id := range toPlace {
+		pos, ok := lr.Positions[id]
+		if !ok {
+			continue
 		}
-	} else {
-		// Incremental: fall back to cursor-based placement.
-		pl := computePlacement(page)
-		pl.childCount[scopeID] = countScopeChildren(page, viewID, scopeID)
-		initialChildCount := pl.childCount[scopeID]
-		for _, id := range toPlace {
-			applyElementAdded(id, viewID, scopeID, page, templates, flat, &m.Specification, &pl, result)
-		}
-		// Expand only when new children were added in this pass (#330).
-		if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
-			expandScopeToFitChildren(page, scopeID, viewID)
-		}
+		placeSingleElement(id, viewID, scopeID, page, templates, flat, &m.Specification, pos.X, pos.Y, false, result)
+	}
+}
+
+// placeElementsIncrementally falls back to cursor-based grid placement for
+// elements newly included on an existing (non-fresh) page.
+func placeElementsIncrementally(
+	page *drawio.Page,
+	viewID string,
+	scopeID string,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	m *model.BausteinsichtModel,
+	toPlace []string,
+	result *ForwardResult,
+) {
+	pl := computePlacement(page)
+	pl.childCount[scopeID] = countScopeChildren(page, viewID, scopeID)
+	initialChildCount := pl.childCount[scopeID]
+	for _, id := range toPlace {
+		applyElementAdded(id, viewID, scopeID, page, templates, flat, &m.Specification, &pl, result)
+	}
+	// Expand only when new children were added in this pass (#330).
+	if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
+		expandScopeToFitChildren(page, scopeID, viewID)
 	}
 }
 
@@ -366,75 +442,96 @@ func populateConnectors(
 	templates *drawio.TemplateSet,
 	result *ForwardResult,
 ) {
-	// Pre-compute, per lifted (from,to) pair, whether ANY contributing
-	// relationship is dashed. Multiple relationships can collapse onto the
-	// same rendered connector (endpoint lifting); without this, only the
-	// first-processed relationship's kind would decide the connector's
-	// style, making it depend on m.Relationships array order (#518).
-	dashedForPair := make(map[string]bool)
-	for _, rel := range m.Relationships {
-		from := liftEndpoint(rel.From, elemSet)
-		to := liftEndpoint(rel.To, elemSet)
-		if from == "" || to == "" || (from == to && (from != rel.From || to != rel.To)) {
+	dashedForPair := computeDashedPairs(m, elemSet, scopeID)
+
+	liftedSeen := make(map[string]bool)
+	for i, rel := range m.Relationships {
+		from, to, ok := liftModelRelationshipEndpoints(rel, elemSet, scopeID)
+		if !ok {
 			continue
 		}
-		if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
+		isLifted := from != rel.From || to != rel.To
+		if isDuplicateLiftedRelationship(from, to, isLifted, liftedSeen) {
+			continue
+		}
+		createConnectorIfAbsent(page, viewID, from, to, i, rel.Label, dashedForPair[from+"->"+to], templates, result)
+	}
+}
+
+// computeDashedPairs precomputes, per lifted (from,to) pair, whether ANY
+// contributing relationship is dashed. Multiple relationships can collapse
+// onto the same rendered connector (endpoint lifting); without this, only
+// the first-processed relationship's kind would decide the connector's
+// style, making it depend on m.Relationships array order (#518).
+func computeDashedPairs(m *model.BausteinsichtModel, elemSet map[string]bool, scopeID string) map[string]bool {
+	dashedForPair := make(map[string]bool)
+	for _, rel := range m.Relationships {
+		from, to, ok := liftModelRelationshipEndpoints(rel, elemSet, scopeID)
+		if !ok {
 			continue
 		}
 		if m.Specification.IsDashed(rel.Kind) {
 			dashedForPair[from+"->"+to] = true
 		}
 	}
+	return dashedForPair
+}
 
-	liftedSeen := make(map[string]bool)
-	for i, rel := range m.Relationships {
-		from := liftEndpoint(rel.From, elemSet)
-		to := liftEndpoint(rel.To, elemSet)
-		if from == "" || to == "" {
-			continue
-		}
-		// Skip self-referencing lifted relationships.
-		if from == to && (from != rel.From || to != rel.To) {
-			continue
-		}
-		// Skip connectors between the scope boundary and external elements.
-		// The boundary is a visual container — scope↔external relationships
-		// belong in the parent view. Child↔scope connections are allowed.
-		if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
-			continue
-		}
-
-		isLifted := from != rel.From || to != rel.To
-		pairKey := from + "->" + to
-		if isLifted {
-			if liftedSeen[pairKey] {
-				continue
-			}
-			liftedSeen[pairKey] = true
-		} else {
-			liftedSeen[pairKey] = true
-		}
-
-		srcRef := scopedCellID(viewID, from)
-		tgtRef := scopedCellID(viewID, to)
-		if page.FindConnector(srcRef, tgtRef, i) != nil {
-			continue // Already exists.
-		}
-		style := templates.GetConnectorStyle()
-		if dashedForPair[pairKey] {
-			style = mergeStyles(style, "dashed=1;")
-		}
-		data := drawio.ConnectorData{
-			From:      from,
-			To:        to,
-			Label:     rel.Label,
-			SourceRef: srcRef,
-			TargetRef: tgtRef,
-			Index:     i,
-		}
-		page.CreateConnector(data, style)
-		result.ConnectorsCreated++
+// liftModelRelationshipEndpoints applies view-filter lifting to rel's
+// endpoints and reports whether the connector should still be processed:
+// false if either endpoint lifts to nothing in view, lifting collapses the
+// relationship into a self-loop, or the relationship crosses the scope
+// boundary to an external element.
+func liftModelRelationshipEndpoints(rel model.Relationship, elemSet map[string]bool, scopeID string) (from, to string, ok bool) {
+	from = liftEndpoint(rel.From, elemSet)
+	to = liftEndpoint(rel.To, elemSet)
+	if from == "" || to == "" {
+		return "", "", false
 	}
+	// Skip self-referencing lifted relationships.
+	if from == to && (from != rel.From || to != rel.To) {
+		return "", "", false
+	}
+	// Skip connectors between the scope boundary and external elements.
+	// The boundary is a visual container — scope↔external relationships
+	// belong in the parent view. Child↔scope connections are allowed.
+	if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
+		return "", "", false
+	}
+	return from, to, true
+}
+
+// createConnectorIfAbsent creates the connector for a (possibly lifted)
+// relationship on page, unless a connector already exists at that index.
+func createConnectorIfAbsent(
+	page *drawio.Page,
+	viewID string,
+	from, to string,
+	index int,
+	label string,
+	dashed bool,
+	templates *drawio.TemplateSet,
+	result *ForwardResult,
+) {
+	srcRef := scopedCellID(viewID, from)
+	tgtRef := scopedCellID(viewID, to)
+	if page.FindConnector(srcRef, tgtRef, index) != nil {
+		return // Already exists.
+	}
+	style := templates.GetConnectorStyle()
+	if dashed {
+		style = mergeStyles(style, "dashed=1;")
+	}
+	data := drawio.ConnectorData{
+		From:      from,
+		To:        to,
+		Label:     label,
+		SourceRef: srcRef,
+		TargetRef: tgtRef,
+		Index:     index,
+	}
+	page.CreateConnector(data, style)
+	result.ConnectorsCreated++
 }
 
 // scopedCellID returns a page-scoped cell ID to ensure file-wide uniqueness.
@@ -571,118 +668,186 @@ func applyChangesToPage(
 	pl.childCount[scopeID] = countScopeChildren(page, viewID, scopeID)
 	initialChildCount := pl.childCount[scopeID]
 
+	applyModelElementChanges(cs, page, templates, flat, elemFilter, viewID, scopeID, spec, &pl, result)
+	applyModelRelationshipChanges(cs, page, templates, elemFilter, viewID, scopeID, spec, result)
+
+	// Expand scope boundary to fit any children added in this pass (#330).
+	if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
+		expandScopeToFitChildren(page, scopeID, viewID)
+	}
+}
+
+// applyModelElementChanges applies Added/Modified/Deleted element changes from cs to page.
+func applyModelElementChanges(
+	cs *ChangeSet,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	flat map[string]*model.Element,
+	elemFilter map[string]bool,
+	viewID string,
+	scopeID string,
+	spec *model.Specification,
+	pl *placement,
+	result *ForwardResult,
+) {
 	for _, ch := range cs.ModelElementChanges {
 		switch ch.Type {
 		case Added:
 			if elemFilter != nil && !elemFilter[ch.ID] {
 				continue
 			}
-			applyElementAdded(ch.ID, viewID, scopeID, page, templates, flat, spec, &pl, result)
+			applyElementAdded(ch.ID, viewID, scopeID, page, templates, flat, spec, pl, result)
 		case Modified:
 			if elemFilter != nil && !elemFilter[ch.ID] && ch.ID != scopeID {
 				continue
 			}
 			applyElementModified(ch, page, templates, flat, result)
 		case Deleted:
-			// Deleted elements are removed from all pages where they exist,
-			// regardless of the current view filter — a deleted element is
-			// no longer in the model, so it can't appear in any view's
-			// resolved set. We just check if it exists on this page.
-			cellID := scopedCellID(viewID, ch.ID)
-			if page.FindElement(ch.ID) != nil {
-				// Delete connectors referencing this element's cell ID before
-				// removing the element itself. (#101)
-				result.ConnectorsDeleted += countConnectorsFor(page, cellID)
-				page.DeleteConnectorsFor(cellID)
-				page.DeleteElement(ch.ID)
-				result.ElementsDeleted++
-			}
+			applyElementDeleted(ch, viewID, page, result)
 		}
 	}
+}
 
+// applyElementDeleted removes ch's element from page, if present. Deleted
+// elements are removed from all pages where they exist, regardless of the
+// current view filter — a deleted element is no longer in the model, so it
+// can't appear in any view's resolved set. We just check if it exists on
+// this page.
+func applyElementDeleted(ch ElementChange, viewID string, page *drawio.Page, result *ForwardResult) {
+	cellID := scopedCellID(viewID, ch.ID)
+	if page.FindElement(ch.ID) != nil {
+		// Delete connectors referencing this element's cell ID before
+		// removing the element itself. (#101)
+		result.ConnectorsDeleted += countConnectorsFor(page, cellID)
+		page.DeleteConnectorsFor(cellID)
+		page.DeleteElement(ch.ID)
+		result.ElementsDeleted++
+	}
+}
+
+// applyModelRelationshipChanges applies relationship changes in two passes:
+// direct first, then lifted. This ensures that when a direct relationship
+// (e.g., api→db) and a lifted relationship (e.g., api.catalog→db lifted to
+// api→db) map to the same pair, the direct one's label is used for the
+// connector.
+func applyModelRelationshipChanges(
+	cs *ChangeSet,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	elemFilter map[string]bool,
+	viewID string,
+	scopeID string,
+	spec *model.Specification,
+	result *ForwardResult,
+) {
 	liftedSeen := make(map[string]bool)
-
-	// Process relationships in two passes: direct first, then lifted.
-	// This ensures that when a direct relationship (e.g., api→db) and a
-	// lifted relationship (e.g., api.catalog→db lifted to api→db) map to
-	// the same pair, the direct one's label is used for the connector.
 	for pass := 0; pass < 2; pass++ {
 		for _, ch := range cs.ModelRelationshipChanges {
-			switch ch.Type {
-			case Deleted:
-				if pass != 0 {
-					continue
+			if ch.Type == Deleted {
+				if pass == 0 {
+					applyRelationshipDeleted(ch, viewID, page, result)
 				}
-				// For deletions, use scoped cell IDs to find and remove the
-				// connector. The original endpoints may no longer be in the
-				// view's element filter, so we bypass lifting entirely.
-				fromRef := scopedCellID(viewID, ch.From)
-				toRef := scopedCellID(viewID, ch.To)
-				if page.FindConnector(fromRef, toRef, ch.Index) != nil {
-					page.DeleteConnector(fromRef, toRef, ch.Index)
-					result.ConnectorsDeleted++
-				}
-			default:
-				from := ch.From
-				to := ch.To
-				if elemFilter != nil {
-					from = liftEndpoint(from, elemFilter)
-					to = liftEndpoint(to, elemFilter)
-					if from == "" || to == "" || (from == to && (from != ch.From || to != ch.To)) {
-						continue
-					}
-					// Skip connectors between scope boundary and externals.
-					if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
-						continue
-					}
-				}
-				isLifted := from != ch.From || to != ch.To
-				if pass == 0 && isLifted {
-					continue // First pass: only direct relationships
-				}
-				if pass == 1 && !isLifted {
-					continue // Second pass: only lifted relationships
-				}
-				lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue, Kind: ch.Kind}
-				switch ch.Type {
-				case Added:
-					// Only deduplicate lifted relationships. When multiple
-					// child relationships (e.g., a.x→b.z and a.y→b.z) are
-					// lifted to the same parent pair (a→b), only one connector
-					// should be created. Direct (non-lifted) relationships
-					// with the same pair must not be deduplicated. (#142)
-					pairKey := from + "->" + to
-					if isLifted {
-						// Skip lifted relationships when a direct relationship
-						// or another lifted relationship already covers this
-						// pair. (#142, #197)
-						if liftedSeen[pairKey] {
-							continue
-						}
-						liftedSeen[pairKey] = true
-					} else {
-						// Record direct relationships so lifted ones targeting
-						// the same pair are suppressed in pass 1. (#197)
-						liftedSeen[pairKey] = true
-					}
-					applyRelAdded(lifted, viewID, page, templates, spec, result)
-				case Modified:
-					page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
-					// Recompute style from the template base rather than
-					// patching the existing style, so a kind change that
-					// flips dashed on or off is reflected either way (#518),
-					// mirroring UpdateElementKind's full-replacement approach.
-					page.SetConnectorStyle(from, to, ch.Index, connectorStyle(templates.GetConnectorStyle(), ch.Kind, spec))
-					result.ConnectorsUpdated++
-				}
+				continue
 			}
+			applyRelationshipUpsert(ch, pass, elemFilter, viewID, scopeID, page, templates, spec, liftedSeen, result)
 		}
 	}
+}
 
-	// Expand scope boundary to fit any children added in this pass (#330).
-	if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
-		expandScopeToFitChildren(page, scopeID, viewID)
+// applyRelationshipDeleted removes the connector for a deleted relationship.
+// It uses scoped cell IDs to find and remove the connector directly — the
+// original endpoints may no longer be in the view's element filter, so
+// lifting is bypassed entirely.
+func applyRelationshipDeleted(ch RelationshipChange, viewID string, page *drawio.Page, result *ForwardResult) {
+	fromRef := scopedCellID(viewID, ch.From)
+	toRef := scopedCellID(viewID, ch.To)
+	if page.FindConnector(fromRef, toRef, ch.Index) != nil {
+		page.DeleteConnector(fromRef, toRef, ch.Index)
+		result.ConnectorsDeleted++
 	}
+}
+
+// applyRelationshipUpsert applies a single Added/Modified relationship change
+// for one pass of the two-pass direct/lifted processing in
+// applyModelRelationshipChanges.
+func applyRelationshipUpsert(
+	ch RelationshipChange,
+	pass int,
+	elemFilter map[string]bool,
+	viewID string,
+	scopeID string,
+	page *drawio.Page,
+	templates *drawio.TemplateSet,
+	spec *model.Specification,
+	liftedSeen map[string]bool,
+	result *ForwardResult,
+) {
+	from, to, ok := liftRelationshipEndpoints(ch, elemFilter, scopeID)
+	if !ok {
+		return
+	}
+	isLifted := from != ch.From || to != ch.To
+	if pass == 0 && isLifted {
+		return // First pass: only direct relationships
+	}
+	if pass == 1 && !isLifted {
+		return // Second pass: only lifted relationships
+	}
+
+	switch ch.Type {
+	case Added:
+		if isDuplicateLiftedRelationship(from, to, isLifted, liftedSeen) {
+			return
+		}
+		lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue, Kind: ch.Kind}
+		applyRelAdded(lifted, viewID, page, templates, spec, result)
+	case Modified:
+		page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
+		// Recompute style from the template base rather than patching the
+		// existing style, so a kind change that flips dashed on or off is
+		// reflected either way (#518), mirroring UpdateElementKind's
+		// full-replacement approach.
+		page.SetConnectorStyle(from, to, ch.Index, connectorStyle(templates.GetConnectorStyle(), ch.Kind, spec))
+		result.ConnectorsUpdated++
+	}
+}
+
+// liftRelationshipEndpoints applies view-filter lifting to ch's endpoints and
+// reports whether the relationship should still be processed. It returns
+// ok=false for relationships that lift to nothing in view, collapse to a
+// self-loop introduced by lifting, or cross the scope boundary to an
+// external element.
+func liftRelationshipEndpoints(ch RelationshipChange, elemFilter map[string]bool, scopeID string) (from, to string, ok bool) {
+	from, to = ch.From, ch.To
+	if elemFilter == nil {
+		return from, to, true
+	}
+	from = liftEndpoint(from, elemFilter)
+	to = liftEndpoint(to, elemFilter)
+	if from == "" || to == "" || (from == to && (from != ch.From || to != ch.To)) {
+		return "", "", false
+	}
+	// Skip connectors between scope boundary and externals.
+	if scopeID != "" && isScopeExternalConnector(from, to, scopeID) {
+		return "", "", false
+	}
+	return from, to, true
+}
+
+// isDuplicateLiftedRelationship reports whether an Added relationship should
+// be skipped as a duplicate. Only lifted relationships are deduplicated —
+// when multiple child relationships (e.g., a.x→b.z and a.y→b.z) are lifted
+// to the same parent pair (a→b), only one connector should be created.
+// Direct (non-lifted) relationships with the same pair must not be
+// deduplicated. (#142) The pair is also recorded for direct relationships so
+// lifted ones targeting the same pair are suppressed in pass 1. (#197)
+func isDuplicateLiftedRelationship(from, to string, isLifted bool, liftedSeen map[string]bool) bool {
+	pairKey := from + "->" + to
+	if isLifted && liftedSeen[pairKey] {
+		return true
+	}
+	liftedSeen[pairKey] = true
+	return false
 }
 
 // firstPage returns the first page in doc, or nil if there are none.
@@ -878,32 +1043,7 @@ func resizeScopeBoundary(page *drawio.Page, scopeID string, x, y, width, height 
 func expandScopeToFitChildren(page *drawio.Page, scopeID, viewID string) {
 	parentCellID := scopedCellID(viewID, scopeID)
 
-	maxRight := 0.0
-	maxBottom := 0.0
-	for _, obj := range page.FindAllElements() {
-		cell := obj.FindElement("mxCell")
-		if cell == nil {
-			continue
-		}
-		if cell.SelectAttrValue("parent", "") != parentCellID {
-			continue
-		}
-		geo := cell.FindElement("mxGeometry")
-		if geo == nil {
-			continue
-		}
-		x, _ := strconv.ParseFloat(geo.SelectAttrValue("x", "0"), 64)
-		y, _ := strconv.ParseFloat(geo.SelectAttrValue("y", "0"), 64)
-		w, _ := strconv.ParseFloat(geo.SelectAttrValue("width", "0"), 64)
-		h, _ := strconv.ParseFloat(geo.SelectAttrValue("height", "0"), 64)
-		if right := x + w + childStartX; right > maxRight {
-			maxRight = right
-		}
-		if bottom := y + h + childStartX; bottom > maxBottom {
-			maxBottom = bottom
-		}
-	}
-
+	maxRight, maxBottom := computeChildBounds(page, parentCellID)
 	if maxRight == 0 && maxBottom == 0 {
 		return
 	}
@@ -929,6 +1069,35 @@ func expandScopeToFitChildren(page *drawio.Page, scopeID, viewID string) {
 	if maxBottom > currentH {
 		geo.CreateAttr("height", strconv.FormatFloat(maxBottom, 'f', -1, 64))
 	}
+}
+
+// computeChildBounds returns the maximum right/bottom extent (plus
+// childStartX padding) of all elements parented to parentCellID on page.
+func computeChildBounds(page *drawio.Page, parentCellID string) (maxRight, maxBottom float64) {
+	for _, obj := range page.FindAllElements() {
+		cell := obj.FindElement("mxCell")
+		if cell == nil {
+			continue
+		}
+		if cell.SelectAttrValue("parent", "") != parentCellID {
+			continue
+		}
+		geo := cell.FindElement("mxGeometry")
+		if geo == nil {
+			continue
+		}
+		x, _ := strconv.ParseFloat(geo.SelectAttrValue("x", "0"), 64)
+		y, _ := strconv.ParseFloat(geo.SelectAttrValue("y", "0"), 64)
+		w, _ := strconv.ParseFloat(geo.SelectAttrValue("width", "0"), 64)
+		h, _ := strconv.ParseFloat(geo.SelectAttrValue("height", "0"), 64)
+		if right := x + w + childStartX; right > maxRight {
+			maxRight = right
+		}
+		if bottom := y + h + childStartX; bottom > maxBottom {
+			maxBottom = bottom
+		}
+	}
+	return maxRight, maxBottom
 }
 
 // clearPageElements removes all managed bausteinsicht elements and connectors
@@ -1228,50 +1397,64 @@ func mergeStyles(base, overlay string) string {
 		return overlay
 	}
 
-	// Parse overlay keys. overlayOrder preserves the overlay's original
-	// declaration order so the merged style string is deterministic —
-	// ranging over overlayKeys directly would iterate in Go's randomized
-	// map order, producing a different byte sequence on every run even for
-	// identical input (found via e2e testing, #519).
-	overlayKeys := make(map[string]string)
-	var overlayOrder []string
-	for _, part := range strings.Split(overlay, ";") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		key := part
-		if idx := strings.IndexByte(part, '='); idx > 0 {
-			key = part[:idx]
-		}
-		if _, exists := overlayKeys[key]; !exists {
-			overlayOrder = append(overlayOrder, key)
-		}
-		overlayKeys[key] = part
-	}
+	// overlayOrder preserves the overlay's original declaration order so the
+	// merged style string is deterministic — ranging over overlayKeys
+	// directly would iterate in Go's randomized map order, producing a
+	// different byte sequence on every run even for identical input (found
+	// via e2e testing, #519).
+	overlayKeys, overlayOrder := parseStyleKeys(overlay)
 
 	// Build result: base properties (skipping those overridden) + overlay.
 	var sb strings.Builder
-	for _, part := range strings.Split(base, ";") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		key := part
-		if idx := strings.IndexByte(part, '='); idx > 0 {
-			key = part[:idx]
-		}
-		if _, overridden := overlayKeys[key]; overridden {
-			continue
-		}
-		sb.WriteString(part)
-		sb.WriteByte(';')
-	}
+	writeUnoverriddenStyleParts(&sb, base, overlayKeys)
 	for _, key := range overlayOrder {
 		sb.WriteString(overlayKeys[key])
 		sb.WriteByte(';')
 	}
 	return sb.String()
+}
+
+// styleKey returns the key portion of a draw.io style part ("key=value" or
+// a bare flag like "dashed").
+func styleKey(part string) string {
+	if idx := strings.IndexByte(part, '='); idx > 0 {
+		return part[:idx]
+	}
+	return part
+}
+
+// parseStyleKeys splits a draw.io style string into its parts, keyed by
+// style property. order preserves the string's original declaration order.
+func parseStyleKeys(style string) (keys map[string]string, order []string) {
+	keys = make(map[string]string)
+	for _, part := range strings.Split(style, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key := styleKey(part)
+		if _, exists := keys[key]; !exists {
+			order = append(order, key)
+		}
+		keys[key] = part
+	}
+	return keys, order
+}
+
+// writeUnoverriddenStyleParts writes each part of the base style string to
+// sb, skipping any part whose key is present in overlayKeys.
+func writeUnoverriddenStyleParts(sb *strings.Builder, base string, overlayKeys map[string]string) {
+	for _, part := range strings.Split(base, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, overridden := overlayKeys[styleKey(part)]; overridden {
+			continue
+		}
+		sb.WriteString(part)
+		sb.WriteByte(';')
+	}
 }
 
 // applyDrillDownLinks sets the link attribute on elements that have a detail
@@ -1316,41 +1499,15 @@ func createBackNavButton(
 ) {
 	navCellID := "nav-back-" + viewID
 
-	// Don't create if already exists.
 	root := page.Root()
 	if root == nil {
 		return
 	}
-	for _, obj := range root.SelectElements("object") {
-		if obj.SelectAttrValue("id", "") == navCellID {
-			return
-		}
+	if backNavButtonExists(root, navCellID) {
+		return
 	}
 
-	// Find the parent view: a view that includes the scope element.
-	var parentViewID string
-	var parentTitle string
-	for vID, v := range m.Views {
-		if vID == viewID {
-			continue
-		}
-		viewCopy := v
-		resolved, err := model.ResolveView(m, &viewCopy)
-		if err != nil {
-			continue
-		}
-		for _, id := range resolved {
-			if id == scopeID {
-				parentViewID = vID
-				parentTitle = v.Title
-				break
-			}
-		}
-		if parentViewID != "" {
-			break
-		}
-	}
-
+	parentViewID, parentTitle := findParentView(m, viewID, scopeID)
 	if parentViewID == "" {
 		return // No parent view found.
 	}
@@ -1371,6 +1528,38 @@ func createBackNavButton(
 	geo.CreateAttr("width", "140")
 	geo.CreateAttr("height", "30")
 	geo.CreateAttr("as", "geometry")
+}
+
+// backNavButtonExists reports whether a back-nav button with the given cell
+// ID already exists among root's direct object children.
+func backNavButtonExists(root *etree.Element, navCellID string) bool {
+	for _, obj := range root.SelectElements("object") {
+		if obj.SelectAttrValue("id", "") == navCellID {
+			return true
+		}
+	}
+	return false
+}
+
+// findParentView finds the view (other than viewID) that resolves to include
+// scopeID — the "parent" of a detail view for back-navigation purposes.
+func findParentView(m *model.BausteinsichtModel, viewID, scopeID string) (parentViewID, parentTitle string) {
+	for vID, v := range m.Views {
+		if vID == viewID {
+			continue
+		}
+		viewCopy := v
+		resolved, err := model.ResolveView(m, &viewCopy)
+		if err != nil {
+			continue
+		}
+		for _, id := range resolved {
+			if id == scopeID {
+				return vID, v.Title
+			}
+		}
+	}
+	return "", ""
 }
 
 // findElementByID finds an element in the model by its dot-path ID (e.g., "system.backend.api")

--- a/internal/sync/layout.go
+++ b/internal/sync/layout.go
@@ -87,23 +87,7 @@ func computeLayeredLayout(
 
 	// Separate scoped children from external elements.
 	// For externals, further split into actors (top) and non-actors (bottom).
-	var scopeChildren []string
-	var actorExternals []string
-	var otherExternals []string
-	for _, id := range ids {
-		if id == scopeID {
-			continue
-		}
-		if scopeID != "" && isChildOf(id, scopeID) {
-			scopeChildren = append(scopeChildren, id)
-		} else {
-			if isActorKind(id, flat) {
-				actorExternals = append(actorExternals, id)
-			} else {
-				otherExternals = append(otherExternals, id)
-			}
-		}
-	}
+	scopeChildren, actorExternals, otherExternals := groupElementsByScope(ids, scopeID, flat)
 
 	// If no scope, treat everything as one group (actors first, then rest).
 	if scopeID == "" {
@@ -115,31 +99,7 @@ func computeLayeredLayout(
 
 	// Compute boundary dimensions first (needed for centering actors/externals).
 	boundaryX := cfg.startX
-	var boundaryContentW, boundaryContentH float64
-	boundaryStartSize := 30.0
-
-	scopeChildPositions := make(map[string]position)
-	if len(scopeChildren) > 0 {
-		innerX := cfg.padding
-		innerY := boundaryStartSize + cfg.padding
-		minContentWidth := minBoundaryContentWidth(scopeChildren, flat, templates, cfg)
-
-		boundaryContentW, boundaryContentH = placeBFS(scopeChildren, flat, templates, cfg, innerX, innerY, minContentWidth, actorExternals, relationships, scopeChildPositions)
-
-		if boundaryContentW < minContentWidth {
-			boundaryContentW = minContentWidth
-		}
-
-		result.BoundaryWidth = boundaryContentW + 2*cfg.padding
-		result.BoundaryHeight = boundaryContentH + boundaryStartSize + 2*cfg.padding
-
-		if result.BoundaryWidth < 400 {
-			result.BoundaryWidth = 400
-		}
-		if result.BoundaryHeight < 300 {
-			result.BoundaryHeight = 300
-		}
-	}
+	scopeChildPositions := computeScopeBoundary(&result, scopeChildren, flat, templates, cfg, actorExternals, relationships)
 
 	// Reference width for centering: the wider of boundary or page content.
 	refWidth := result.BoundaryWidth
@@ -153,16 +113,7 @@ func computeLayeredLayout(
 	// Reserve the first row even when there are no actors so users can add them later.
 	if len(actorExternals) > 0 {
 		actorW, actorH := placeLayered(actorExternals, flat, templates, kindTier, maxTier, cfg, cfg.startX, curY, result.Positions)
-		// Center actor row relative to boundary width.
-		if actorW < refWidth {
-			offset := (refWidth - actorW) / 2
-			for _, id := range actorExternals {
-				if p, ok := result.Positions[id]; ok {
-					p.X += offset
-					result.Positions[id] = p
-				}
-			}
-		}
+		centerRow(actorExternals, actorW, refWidth, result.Positions)
 		curY += actorH + cfg.elementGap
 	} else {
 		// No actors — still reserve space for a potential actor row.
@@ -186,18 +137,84 @@ func computeLayeredLayout(
 	// 3. Place non-actor externals below the boundary, centered.
 	if len(otherExternals) > 0 {
 		extW, _ := placeLayered(otherExternals, flat, templates, kindTier, maxTier, cfg, cfg.startX, curY, result.Positions)
-		if extW < refWidth {
-			offset := (refWidth - extW) / 2
-			for _, id := range otherExternals {
-				if p, ok := result.Positions[id]; ok {
-					p.X += offset
-					result.Positions[id] = p
-				}
-			}
-		}
+		centerRow(otherExternals, extW, refWidth, result.Positions)
 	}
 
 	return result
+}
+
+// groupElementsByScope splits ids into scoped children of scopeID, actor-kind
+// externals, and other externals, preserving the input order within each group.
+func groupElementsByScope(ids []string, scopeID string, flat map[string]*model.Element) (scopeChildren, actorExternals, otherExternals []string) {
+	for _, id := range ids {
+		if id == scopeID {
+			continue
+		}
+		if scopeID != "" && isChildOf(id, scopeID) {
+			scopeChildren = append(scopeChildren, id)
+			continue
+		}
+		if isActorKind(id, flat) {
+			actorExternals = append(actorExternals, id)
+		} else {
+			otherExternals = append(otherExternals, id)
+		}
+	}
+	return scopeChildren, actorExternals, otherExternals
+}
+
+// computeScopeBoundary lays out scopeChildren inside the scope boundary and
+// sets its computed width/height (clamped to a 400x300 minimum) on result.
+// Returns the computed child positions, to be merged into result.Positions
+// once the boundary's Y position is known.
+func computeScopeBoundary(
+	result *layoutResult,
+	scopeChildren []string,
+	flat map[string]*model.Element,
+	templates *drawio.TemplateSet,
+	cfg layoutConfig,
+	actorExternals []string,
+	relationships []model.Relationship,
+) map[string]position {
+	scopeChildPositions := make(map[string]position)
+	if len(scopeChildren) == 0 {
+		return scopeChildPositions
+	}
+
+	boundaryStartSize := 30.0
+	innerX := cfg.padding
+	innerY := boundaryStartSize + cfg.padding
+	minContentWidth := minBoundaryContentWidth(scopeChildren, flat, templates, cfg)
+
+	boundaryContentW, boundaryContentH := placeBFS(scopeChildren, flat, templates, cfg, innerX, innerY, minContentWidth, actorExternals, relationships, scopeChildPositions)
+	if boundaryContentW < minContentWidth {
+		boundaryContentW = minContentWidth
+	}
+
+	result.BoundaryWidth = boundaryContentW + 2*cfg.padding
+	result.BoundaryHeight = boundaryContentH + boundaryStartSize + 2*cfg.padding
+	if result.BoundaryWidth < 400 {
+		result.BoundaryWidth = 400
+	}
+	if result.BoundaryHeight < 300 {
+		result.BoundaryHeight = 300
+	}
+	return scopeChildPositions
+}
+
+// centerRow shifts the X position of each id in ids by the offset needed to
+// center a row of width rowWidth within refWidth. No-op if rowWidth >= refWidth.
+func centerRow(ids []string, rowWidth, refWidth float64, positions map[string]position) {
+	if rowWidth >= refWidth {
+		return
+	}
+	offset := (refWidth - rowWidth) / 2
+	for _, id := range ids {
+		if p, ok := positions[id]; ok {
+			p.X += offset
+			positions[id] = p
+		}
+	}
 }
 
 // isActorKind returns true if the element's kind contains "actor" (case-insensitive).
@@ -244,8 +261,32 @@ func placeLayered(
 	originX, originY float64,
 	positions map[string]position,
 ) (contentWidth, contentHeight float64) {
-	// Group by tier.
-	tiers := make(map[int][]string)
+	tiers, tierKeys := groupIntoTiers(ids, flat, kindTier, maxTier)
+
+	rows, maxRowWidth, endY := placeTierRows(tierKeys, tiers, flat, templates, cfg, originX, originY, positions)
+	centerRows(rows, maxRowWidth, positions)
+
+	contentWidth = maxRowWidth
+	contentHeight = endY - originY - cfg.elementGap // subtract trailing gap
+	if contentHeight < 0 {
+		contentHeight = 0
+	}
+	return contentWidth, contentHeight
+}
+
+// layeredRow tracks one row's placed elements and geometry, computed by
+// placeTierRows and consumed by centerRows.
+type layeredRow struct {
+	ids    []string
+	width  float64
+	height float64
+	y      float64
+}
+
+// groupIntoTiers groups ids by their kind's tier (elements with unknown
+// kinds fall into maxTier) and returns the tiers plus their sorted keys.
+func groupIntoTiers(ids []string, flat map[string]*model.Element, kindTier map[string]int, maxTier int) (tiers map[int][]string, tierKeys []int) {
+	tiers = make(map[int][]string)
 	for _, id := range ids {
 		elem := flat[id]
 		if elem == nil {
@@ -258,68 +299,96 @@ func placeLayered(
 		tiers[tier] = append(tiers[tier], id)
 	}
 
-	// Sort tier keys.
-	tierKeys := make([]int, 0, len(tiers))
+	tierKeys = make([]int, 0, len(tiers))
 	for k := range tiers {
 		tierKeys = append(tierKeys, k)
 	}
 	sort.Ints(tierKeys)
+	return tiers, tierKeys
+}
 
-	// First pass: place left-aligned and track row membership for centering.
-	type rowInfo struct {
-		ids    []string
-		width  float64
-		height float64
-		y      float64
-	}
-	var rows []rowInfo
+// placeTierRows places each tier's elements left-aligned in row order,
+// wrapping to a new row when the page width would be exceeded. Returns the
+// resulting rows (for later centering), the widest row's width, and the Y
+// position immediately after the last row.
+func placeTierRows(
+	tierKeys []int,
+	tiers map[int][]string,
+	flat map[string]*model.Element,
+	templates *drawio.TemplateSet,
+	cfg layoutConfig,
+	originX, originY float64,
+	positions map[string]position,
+) (rows []layeredRow, maxRowWidth float64, endY float64) {
 	curY := originY
-	maxRowWidth := 0.0
 
 	for _, tier := range tierKeys {
 		elems := tiers[tier]
 		sort.Strings(elems)
 
-		curX := originX
-		rowHeight := 0.0
-		var currentRow []string
-
-		for _, id := range elems {
-			w, h := elementSize(id, flat, templates)
-
-			// Row wrapping.
-			if curX > originX && curX+w > cfg.pageWidth-cfg.startX {
-				rowWidth := curX - cfg.elementGap - originX
-				rows = append(rows, rowInfo{ids: currentRow, width: rowWidth, height: rowHeight, y: curY})
-				if rowWidth > maxRowWidth {
-					maxRowWidth = rowWidth
-				}
-				curY += rowHeight + cfg.elementGap
-				curX = originX
-				rowHeight = 0
-				currentRow = nil
-			}
-
-			positions[id] = position{X: curX, Y: curY}
-			currentRow = append(currentRow, id)
-			curX += w + cfg.elementGap
-			if h > rowHeight {
-				rowHeight = h
+		var tierRows []layeredRow
+		tierRows, curY = placeOneTier(elems, flat, templates, cfg, originX, curY, positions)
+		for _, row := range tierRows {
+			rows = append(rows, row)
+			if row.width > maxRowWidth {
+				maxRowWidth = row.width
 			}
 		}
-
-		// Finish last row of this tier.
-		if len(currentRow) > 0 {
-			rowWidth := curX - cfg.elementGap - originX
-			rows = append(rows, rowInfo{ids: currentRow, width: rowWidth, height: rowHeight, y: curY})
-			if rowWidth > maxRowWidth {
-				maxRowWidth = rowWidth
-			}
-		}
-		curY += rowHeight + cfg.elementGap
 	}
 
-	// Second pass: center each row within the max row width.
+	return rows, maxRowWidth, curY
+}
+
+// placeOneTier places a single tier's elements left-aligned starting at
+// (originX, startY), wrapping to a new row when the page width would be
+// exceeded. Returns the resulting rows and the Y position after the last row.
+func placeOneTier(
+	elems []string,
+	flat map[string]*model.Element,
+	templates *drawio.TemplateSet,
+	cfg layoutConfig,
+	originX, startY float64,
+	positions map[string]position,
+) (rows []layeredRow, endY float64) {
+	curY := startY
+	curX := originX
+	rowHeight := 0.0
+	var currentRow []string
+
+	for _, id := range elems {
+		w, h := elementSize(id, flat, templates)
+
+		// Row wrapping.
+		if curX > originX && curX+w > cfg.pageWidth-cfg.startX {
+			rowWidth := curX - cfg.elementGap - originX
+			rows = append(rows, layeredRow{ids: currentRow, width: rowWidth, height: rowHeight, y: curY})
+			curY += rowHeight + cfg.elementGap
+			curX = originX
+			rowHeight = 0
+			currentRow = nil
+		}
+
+		positions[id] = position{X: curX, Y: curY}
+		currentRow = append(currentRow, id)
+		curX += w + cfg.elementGap
+		if h > rowHeight {
+			rowHeight = h
+		}
+	}
+
+	// Finish last row of this tier.
+	if len(currentRow) > 0 {
+		rowWidth := curX - cfg.elementGap - originX
+		rows = append(rows, layeredRow{ids: currentRow, width: rowWidth, height: rowHeight, y: curY})
+	}
+	curY += rowHeight + cfg.elementGap
+
+	return rows, curY
+}
+
+// centerRows shifts each row's elements so the row is horizontally centered
+// within maxRowWidth.
+func centerRows(rows []layeredRow, maxRowWidth float64, positions map[string]position) {
 	for _, row := range rows {
 		if row.width >= maxRowWidth {
 			continue
@@ -331,13 +400,6 @@ func placeLayered(
 			positions[id] = p
 		}
 	}
-
-	contentWidth = maxRowWidth
-	contentHeight = curY - originY - cfg.elementGap // subtract trailing gap
-	if contentHeight < 0 {
-		contentHeight = 0
-	}
-	return contentWidth, contentHeight
 }
 
 // placeBFS places scope children using relationship-based BFS ordering:
@@ -359,15 +421,24 @@ func placeBFS(
 	relationships []model.Relationship,
 	positions map[string]position,
 ) (contentWidth, contentHeight float64) {
-	// Build an adjacency map among the scope children.
+	adj, connectedToActor := buildScopeAdjacency(ids, actorIDs, relationships)
+	rows := assignBFSRows(ids, adj, connectedToActor)
+	return placeBFSRows(rows, flat, templates, cfg, originX, originY, minRowWidth, positions)
+}
+
+// buildScopeAdjacency builds an adjacency map among ids (scope children)
+// from relationships. adj maps each scope child to the other scope children
+// it is (directly or, via lifting, indirectly) connected to.
+// connectedToActor tracks which scope children have a direct or lifted
+// relationship to one of actorIDs — e.g. actor→onlineshop.frontend lifts to
+// the scope child onlineshop.frontend via resolveToScopeChild.
+func buildScopeAdjacency(ids []string, actorIDs []string, relationships []model.Relationship) (adj map[string]map[string]bool, connectedToActor map[string]bool) {
 	idSet := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		idSet[id] = true
 	}
 
-	// adj maps each scope child to its neighbors (other scope children
-	// or external elements it is connected to).
-	adj := make(map[string]map[string]bool)
+	adj = make(map[string]map[string]bool)
 	for _, id := range ids {
 		adj[id] = make(map[string]bool)
 	}
@@ -377,53 +448,90 @@ func placeBFS(
 		actorSet[id] = true
 	}
 
-	// connectedToActor tracks which scope children have a direct or
-	// indirect (via lifted) relationship to an actor.
-	connectedToActor := make(map[string]bool)
-
+	connectedToActor = make(map[string]bool)
 	for _, rel := range relationships {
-		from, to := rel.From, rel.To
+		addRelationshipToAdjacency(rel, idSet, actorSet, adj, connectedToActor)
+	}
 
-		// Check if this relationship connects a scope child to an actor.
-		if idSet[from] && actorSet[to] {
-			connectedToActor[from] = true
-		}
-		if idSet[to] && actorSet[from] {
-			connectedToActor[to] = true
-		}
+	return adj, connectedToActor
+}
 
-		// Also check lifted relationships: if an actor connects to a
-		// parent of a scope child (e.g., actor→onlineshop.frontend where
-		// frontend is a scope child via onlineshop.frontend).
-		fromInScope := idSet[from] || hasChildInSet(from, idSet)
-		toInScope := idSet[to] || hasChildInSet(to, idSet)
-		_ = fromInScope
-		_ = toInScope
+// addRelationshipToAdjacency updates adj and connectedToActor with the
+// contribution of a single relationship: direct and lifted (resolved via
+// resolveToScopeChild) actor connections, and adjacency between scope
+// children.
+func addRelationshipToAdjacency(
+	rel model.Relationship,
+	idSet map[string]bool,
+	actorSet map[string]bool,
+	adj map[string]map[string]bool,
+	connectedToActor map[string]bool,
+) {
+	from, to := rel.From, rel.To
 
-		// Build adjacency between scope children.
-		fromResolved := resolveToScopeChild(from, idSet)
-		toResolved := resolveToScopeChild(to, idSet)
-		if fromResolved != "" && toResolved != "" && fromResolved != toResolved {
-			if adj[fromResolved] != nil && adj[toResolved] != nil {
-				adj[fromResolved][toResolved] = true
-				adj[toResolved][fromResolved] = true
-			}
-		}
+	// Check if this relationship connects a scope child to an actor.
+	if idSet[from] && actorSet[to] {
+		connectedToActor[from] = true
+	}
+	if idSet[to] && actorSet[from] {
+		connectedToActor[to] = true
+	}
 
-		// Track actor connections via resolved scope children.
-		if fromResolved != "" && actorSet[to] {
-			connectedToActor[fromResolved] = true
-		}
-		if toResolved != "" && actorSet[from] {
-			connectedToActor[toResolved] = true
+	// Build adjacency between scope children.
+	fromResolved := resolveToScopeChild(from, idSet)
+	toResolved := resolveToScopeChild(to, idSet)
+	if fromResolved != "" && toResolved != "" && fromResolved != toResolved {
+		if adj[fromResolved] != nil && adj[toResolved] != nil {
+			adj[fromResolved][toResolved] = true
+			adj[toResolved][fromResolved] = true
 		}
 	}
 
-	// BFS: assign elements to rows.
+	// Track actor connections via resolved scope children.
+	if fromResolved != "" && actorSet[to] {
+		connectedToActor[fromResolved] = true
+	}
+	if toResolved != "" && actorSet[from] {
+		connectedToActor[toResolved] = true
+	}
+}
+
+// assignBFSRows assigns ids to rows via relationship-based BFS:
+//  1. Row 1: elements connected to actors (external seeds)
+//  2. Row 2: elements connected to row 1
+//  3. Row N: elements connected to row N-1
+//  4. Remaining: any unconnected elements at the end
+//
+// Within each row, the next element is chosen by adjacency to the last
+// placed element (greedy neighbor selection), with alphabetical fallback.
+func assignBFSRows(ids []string, adj map[string]map[string]bool, connectedToActor map[string]bool) [][]string {
 	placed := make(map[string]bool)
 	var rows [][]string
 
-	// Row 0: elements connected to actors.
+	if row0 := seedActorRow(ids, connectedToActor, placed); len(row0) > 0 {
+		rows = append(rows, orderByAdjacency(row0, adj))
+	}
+
+	// Subsequent rows: BFS from previous row.
+	for len(rows) > 0 && len(placed) < len(ids) {
+		nextRow := nextBFSRow(rows[len(rows)-1], adj, placed)
+		if len(nextRow) == 0 {
+			break
+		}
+		rows = append(rows, orderByAdjacency(nextRow, adj))
+	}
+
+	// Remaining: elements not reached by BFS (no relationships).
+	if remaining := unplacedSorted(ids, placed); len(remaining) > 0 {
+		rows = append(rows, remaining)
+	}
+
+	return rows
+}
+
+// seedActorRow returns, sorted, the ids directly or indirectly connected to
+// an actor (row 0 of the BFS), marking each as placed.
+func seedActorRow(ids []string, connectedToActor map[string]bool, placed map[string]bool) []string {
 	var row0 []string
 	for _, id := range ids {
 		if connectedToActor[id] {
@@ -432,45 +540,49 @@ func placeBFS(
 		}
 	}
 	sort.Strings(row0)
-	if len(row0) > 0 {
-		rows = append(rows, orderByAdjacency(row0, adj))
-	}
+	return row0
+}
 
-	// Subsequent rows: BFS from previous row.
-	for len(rows) > 0 {
-		if len(placed) >= len(ids) {
-			break
-		}
-		prevRow := rows[len(rows)-1]
-		var nextRow []string
-		for _, prev := range prevRow {
-			for neighbor := range adj[prev] {
-				if !placed[neighbor] {
-					nextRow = append(nextRow, neighbor)
-					placed[neighbor] = true
-				}
+// nextBFSRow returns, sorted, the not-yet-placed neighbors of prevRow's
+// elements, marking each as placed.
+func nextBFSRow(prevRow []string, adj map[string]map[string]bool, placed map[string]bool) []string {
+	var nextRow []string
+	for _, prev := range prevRow {
+		for neighbor := range adj[prev] {
+			if !placed[neighbor] {
+				nextRow = append(nextRow, neighbor)
+				placed[neighbor] = true
 			}
 		}
-		if len(nextRow) == 0 {
-			break
-		}
-		sort.Strings(nextRow)
-		rows = append(rows, orderByAdjacency(nextRow, adj))
 	}
+	sort.Strings(nextRow)
+	return nextRow
+}
 
-	// Remaining: elements not reached by BFS (no relationships).
+// unplacedSorted returns, sorted, the ids not yet marked placed.
+func unplacedSorted(ids []string, placed map[string]bool) []string {
 	var remaining []string
 	for _, id := range ids {
 		if !placed[id] {
 			remaining = append(remaining, id)
 		}
 	}
-	if len(remaining) > 0 {
-		sort.Strings(remaining)
-		rows = append(rows, remaining)
-	}
+	sort.Strings(remaining)
+	return remaining
+}
 
-	// Place rows.
+// placeBFSRows places each BFS row left-aligned starting at (originX,
+// originY), wrapping to a new line when minRowWidth would be exceeded, and
+// returns the overall content width/height.
+func placeBFSRows(
+	rows [][]string,
+	flat map[string]*model.Element,
+	templates *drawio.TemplateSet,
+	cfg layoutConfig,
+	originX, originY float64,
+	minRowWidth float64,
+	positions map[string]position,
+) (contentWidth, contentHeight float64) {
 	curY := originY
 	maxWidth := 0.0
 

--- a/internal/sync/layout.go
+++ b/internal/sync/layout.go
@@ -692,17 +692,6 @@ func resolveToScopeChild(id string, scopeChildren map[string]bool) string {
 	}
 }
 
-// hasChildInSet returns true if any key in the set is a child of id.
-func hasChildInSet(id string, set map[string]bool) bool {
-	prefix := id + "."
-	for k := range set {
-		if strings.HasPrefix(k, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
 // computeGridLayout arranges all elements in a simple grid.
 func computeGridLayout(
 	ids []string,


### PR DESCRIPTION
## Summary
- Cognitive Complexity batch 1 of #585 (SonarCloud cleanup): `internal/sync/{forward,layout,diff}.go`, the largest and riskiest batch — this is the bidirectional sync engine.
- Split all 23 functions flagged over the `go:S3776` threshold into smaller, single-purpose helpers. Worst offender: `applyChangesToPage` at cognitive complexity **75**, now fully delegated to focused sub-functions (each individually well under the threshold).
- **Purely structural — no logic changes.** Every extraction preserves the exact original conditional logic (verified line-by-line against the pre-refactor code); a few `if/else` chains were rewritten as logically-equivalent early-returns (De Morgan's laws applied explicitly, documented in commit history).
- Verified behavior-preserving by running the full existing test suite (200+ tests in the package, 69–100% per-function coverage on every touched function) after each individual extraction, not just at the end.

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green
- [x] `gofmt` clean
- [x] `gocognit -over 15 internal/sync/forward.go internal/sync/layout.go internal/sync/diff.go` — zero findings (was 15/3/5 across the three files)
- [x] Package coverage essentially unchanged: 87.3% → 87.1%

## Notes
- Per CLAUDE.md's Quality Gate Override Policy: if SonarCloud's new-code coverage gate trips on this PR despite no new logic being added (likely, since extracted helpers inherit coverage from their call sites but Sonar counts new-code lines), this qualifies for admin merge as a verified behavior-preserving refactor — all functional CI green, no new logic, noted here per policy.