### PR TITLE
refactor(importer): reduce cognitive complexity in structurizr/likec4/xmi (#585)

### DIFF
--- a/internal/importer/dsl/dsl.go
+++ b/internal/importer/dsl/dsl.go
@@ -169,6 +169,70 @@ func (s *Scanner) SkipNewlines() {
 	}
 }
 
+// IdentStartFunc reports whether c can start an identifier-like token in a
+// caller's language — this is where callers hook in language-specific
+// dispatch (e.g. Structurizr's "*"/"**" wildcard or "!"-prefixed
+// identifiers) without Next needing to know about it.
+type IdentStartFunc func(c rune) bool
+
+// ScanIdentFunc scans an identifier-like token starting at the scanner's
+// current position (the character identStart matched on is not yet
+// consumed).
+type ScanIdentFunc func(*Scanner, int) (Token, error)
+
+// Next scans the next token using the shared grammar common to Structurizr-
+// and LikeC4-style DSLs: {}/=/-> punctuation, "quoted strings", C-style
+// comments, and newline-as-statement-separator. Any character for which
+// identStart reports true is delegated to scanIdent, letting callers
+// implement their own identifier/wildcard/prefix handling on top of this
+// shared dispatch.
+func Next(s *Scanner, identStart IdentStartFunc, scanIdent ScanIdentFunc) (Token, error) {
+	// Skip horizontal whitespace and handle comments.
+	// Newlines are NOT skipped here — they are emitted as a Newline token.
+	if err := s.SkipWhitespaceAndComments(); err != nil {
+		return Token{}, err
+	}
+
+	c, ok := s.At(0)
+	if !ok {
+		return Token{Kind: EOF, Line: s.Line}, nil
+	}
+	line := s.Line
+
+	// Collapse consecutive newlines into a single Newline token.
+	if c == '\n' {
+		s.SkipNewlines()
+		return Token{Kind: Newline, Line: line}, nil
+	}
+
+	switch {
+	case c == '{':
+		s.Consume()
+		return Token{Kind: LBrace, Val: "{", Line: line}, nil
+	case c == '}':
+		s.Consume()
+		return Token{Kind: RBrace, Val: "}", Line: line}, nil
+	case c == '=':
+		s.Consume()
+		return Token{Kind: Assign, Val: "=", Line: line}, nil
+	case c == '-':
+		if n, _ := s.At(1); n == '>' {
+			s.Consume()
+			s.Consume()
+			return Token{Kind: Arrow, Val: "->", Line: line}, nil
+		}
+		s.Consume()
+		return Next(s, identStart, scanIdent)
+	case c == '"':
+		return s.ScanString(line)
+	case identStart(c):
+		return scanIdent(s, line)
+	default:
+		s.Consume()
+		return Next(s, identStart, scanIdent)
+	}
+}
+
 // ScanString scans a double-quoted string starting at the current position
 // (the opening quote), handling \", \\, and \n escapes; any other escaped
 // character is passed through literally including its backslash.
@@ -328,4 +392,61 @@ func (p *Parser) CollectArgs() []string {
 		}
 	}
 	return args
+}
+
+// ParseAllStmts parses a full top-level statement list using the shared
+// "[var =] keyword args {body}" / "[from] -> to args {body}" statement
+// grammar common to Structurizr- and LikeC4-style DSLs.
+func ParseAllStmts(p *Parser) ([]Stmt, error) {
+	return p.ParseAll(ParseOneStmt)
+}
+
+// ParseOneStmt parses a single statement using the shared
+// "[var =] keyword args {body}" / "[from] -> to args {body}" grammar common
+// to Structurizr- and LikeC4-style DSLs. Both languages' tokenizers only
+// ever differ in how they produce Ident/String tokens (see Next), not in
+// how those tokens combine into statements, so this needs no per-language
+// hook.
+func ParseOneStmt(p *Parser) (*Stmt, error) {
+	tok := p.Peek()
+	if tok.Kind == EOF || tok.Kind == RBrace {
+		return nil, nil
+	}
+
+	line := tok.Line
+
+	if tok.Kind == Arrow {
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&Stmt{Line: line, IsRel: true, RelTo: to.Val, Args: p.CollectArgs()}, ParseOneStmt)
+	}
+
+	if tok.Kind == LBrace {
+		if _, err := p.ParseBlock(ParseOneStmt); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	if tok.Kind != Ident && tok.Kind != String {
+		p.Advance()
+		return nil, nil
+	}
+
+	p.Advance()
+
+	switch p.Peek().Kind {
+	case Assign:
+		p.Advance()
+		kw := p.Advance()
+		return p.FinishStmt(&Stmt{Line: line, VarName: tok.Val, Keyword: kw.Val, Args: p.CollectArgs()}, ParseOneStmt)
+
+	case Arrow:
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&Stmt{Line: line, IsRel: true, RelFrom: tok.Val, RelTo: to.Val, Args: p.CollectArgs()}, ParseOneStmt)
+
+	default:
+		return p.FinishStmt(&Stmt{Line: line, Keyword: tok.Val, Args: p.CollectArgs()}, ParseOneStmt)
+	}
 }

--- a/internal/importer/dsl/dsl.go
+++ b/internal/importer/dsl/dsl.go
@@ -10,6 +10,7 @@ package dsl
 import (
 	"fmt"
 	"strings"
+	"unicode"
 )
 
 // TokKind classifies a Token.
@@ -179,6 +180,74 @@ type IdentStartFunc func(c rune) bool
 // current position (the character identStart matched on is not yet
 // consumed).
 type ScanIdentFunc func(*Scanner, int) (Token, error)
+
+// Tokenize scans src into a full token stream (ending in an EOF token),
+// using identStart/scanIdent for language-specific identifier handling.
+func Tokenize(src string, identStart IdentStartFunc, scanIdent ScanIdentFunc) ([]Token, error) {
+	s := NewScanner(src)
+	var toks []Token
+	for {
+		tok, err := Next(s, identStart, scanIdent)
+		if err != nil {
+			return nil, err
+		}
+		toks = append(toks, tok)
+		if tok.Kind == EOF {
+			break
+		}
+	}
+	return toks, nil
+}
+
+// ScanIdentBody consumes the shared identifier continuation grammar —
+// letters, digits, '_', '.', '/', ':', stopping before "->" — common to
+// Structurizr- and LikeC4-style DSL identifiers, appending consumed runes to
+// sb. Callers handle their own identifier-start logic (prefixes, wildcards)
+// before calling this for the rest of the token.
+func ScanIdentBody(s *Scanner, sb *strings.Builder) {
+	for {
+		c, ok := s.At(0)
+		if !ok {
+			return
+		}
+		if c == '-' {
+			if n, _ := s.At(1); n == '>' {
+				return
+			}
+			sb.WriteRune(s.Consume())
+			continue
+		}
+		if unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_' || c == '.' || c == '/' || c == ':' {
+			sb.WriteRune(s.Consume())
+			continue
+		}
+		return
+	}
+}
+
+// Slugify converts a title to a lowercase, underscore-separated identifier
+// fallback (used when a DSL element has no explicit variable name), common
+// to Structurizr- and LikeC4-style DSL importers. Returns "element" if the
+// result would otherwise be empty.
+func Slugify(s string) string {
+	s = strings.ToLower(s)
+	var sb strings.Builder
+	prevUnderscore := false
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			sb.WriteRune(r)
+			prevUnderscore = false
+		} else if !prevUnderscore && sb.Len() > 0 {
+			sb.WriteRune('_')
+			prevUnderscore = true
+		}
+	}
+	result := strings.TrimRight(sb.String(), "_")
+	if result == "" {
+		return "element"
+	}
+	return result
+}
 
 // Next scans the next token using the shared grammar common to Structurizr-
 // and LikeC4-style DSLs: {}/=/-> punctuation, "quoted strings", C-style

--- a/internal/importer/dsl/dsl.go
+++ b/internal/importer/dsl/dsl.go
@@ -1,0 +1,331 @@
+// Package dsl provides shared tokenizer and parser primitives for
+// Bausteinsicht's hand-written DSL importers (structurizr, likec4). Both
+// DSLs share the same underlying grammar shape — brace-delimited,
+// newline-terminated statements, C-style comments, "quoted strings", and
+// "var = keyword args {...}" / "from -> to args {...}" statement forms —
+// differing only in a handful of language-specific tokenizing/parsing
+// details, which callers implement themselves on top of these primitives.
+package dsl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TokKind classifies a Token.
+type TokKind int
+
+const (
+	EOF     TokKind = iota
+	Newline         // statement separator — emitted for each (group of) newline(s)
+	String
+	Ident
+	LBrace
+	RBrace
+	Assign
+	Arrow
+)
+
+// Token is one lexical token produced by Scanner.
+type Token struct {
+	Kind TokKind
+	Val  string
+	Line int
+}
+
+// Stmt represents one parsed statement in a brace-delimited,
+// newline-terminated DSL: "[var =] keyword arg1 arg2 {body}" or
+// "[from] -> to arg1 {body}".
+type Stmt struct {
+	Line    int
+	VarName string
+	Keyword string
+	Args    []string
+	IsRel   bool
+	RelFrom string
+	RelTo   string
+	Body    []Stmt
+}
+
+// Scanner tokenizes a rune stream shared by Structurizr- and LikeC4-style
+// DSLs: C-style // and /* */ comments, newline-as-statement-separator,
+// {}/=/-> punctuation, "quoted strings", and bare identifiers. Src/Pos/Line
+// are exported so callers can implement their own language-specific token
+// dispatch (e.g. wildcard or prefix characters) directly against the cursor.
+type Scanner struct {
+	Src  []rune
+	Pos  int
+	Line int
+}
+
+// NewScanner creates a Scanner positioned at the start of src.
+func NewScanner(src string) *Scanner {
+	return &Scanner{Src: []rune(src), Line: 1}
+}
+
+// At returns the rune at the given offset from the current position, and
+// whether it exists (false at end of input).
+func (s *Scanner) At(offset int) (rune, bool) {
+	i := s.Pos + offset
+	if i >= len(s.Src) {
+		return 0, false
+	}
+	return s.Src[i], true
+}
+
+// Consume returns the rune at the current position and advances past it,
+// tracking line number on newlines.
+func (s *Scanner) Consume() rune {
+	r := s.Src[s.Pos]
+	s.Pos++
+	if r == '\n' {
+		s.Line++
+	}
+	return r
+}
+
+// SkipWhitespaceAndComments advances past horizontal whitespace and // and
+// /* */ comments. Newlines are NOT skipped — callers emit them as Newline
+// tokens.
+func (s *Scanner) SkipWhitespaceAndComments() error {
+	for {
+		c, ok := s.At(0)
+		if !ok {
+			return nil
+		}
+		if c == ' ' || c == '\t' || c == '\r' {
+			s.Consume()
+			continue
+		}
+		if c == '/' {
+			consumed, err := s.skipComment()
+			if err != nil {
+				return err
+			}
+			if consumed {
+				continue
+			}
+		}
+		return nil
+	}
+}
+
+// skipComment consumes a // or /* */ comment starting at the current
+// position (c == '/'), if any, and reports whether one was consumed.
+func (s *Scanner) skipComment() (bool, error) {
+	switch n, _ := s.At(1); n {
+	case '/':
+		s.skipLineComment()
+		return true, nil
+	case '*':
+		if err := s.skipBlockComment(); err != nil {
+			return false, err
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// skipLineComment consumes to end of line (leaving \n for the caller).
+func (s *Scanner) skipLineComment() {
+	for {
+		ch, ok := s.At(0)
+		if !ok || ch == '\n' {
+			return
+		}
+		s.Consume()
+	}
+}
+
+// skipBlockComment consumes a /* ... */ block comment starting at the
+// current position (the leading "/*").
+func (s *Scanner) skipBlockComment() error {
+	s.Consume()
+	s.Consume()
+	for {
+		ch, ok := s.At(0)
+		if !ok {
+			return fmt.Errorf("unterminated block comment")
+		}
+		s.Consume()
+		if ch == '*' {
+			if nn, _ := s.At(0); nn == '/' {
+				s.Consume()
+				return nil
+			}
+		}
+	}
+}
+
+// SkipNewlines consumes consecutive '\n' characters.
+func (s *Scanner) SkipNewlines() {
+	for {
+		ch, ok := s.At(0)
+		if !ok || ch != '\n' {
+			return
+		}
+		s.Consume()
+	}
+}
+
+// ScanString scans a double-quoted string starting at the current position
+// (the opening quote), handling \", \\, and \n escapes; any other escaped
+// character is passed through literally including its backslash.
+func (s *Scanner) ScanString(line int) (Token, error) {
+	s.Consume()
+	var sb strings.Builder
+	for {
+		c, ok := s.At(0)
+		if !ok {
+			return Token{}, fmt.Errorf("line %d: unterminated string", line)
+		}
+		if c == '"' {
+			s.Consume()
+			break
+		}
+		if c == '\\' {
+			s.Consume()
+			esc, ok := s.At(0)
+			if !ok {
+				return Token{}, fmt.Errorf("line %d: EOF in string escape", line)
+			}
+			s.Consume()
+			switch esc {
+			case '"', '\\':
+				sb.WriteRune(esc)
+			case 'n':
+				sb.WriteRune('\n')
+			default:
+				sb.WriteRune('\\')
+				sb.WriteRune(esc)
+			}
+			continue
+		}
+		sb.WriteRune(s.Consume())
+	}
+	return Token{Kind: String, Val: sb.String(), Line: line}, nil
+}
+
+// ParseOneFunc parses a single statement from p, returning nil (not an
+// error) for tokens that don't produce a Stmt (e.g. a bare block or a
+// skipped token) — the same convention as Parser.ParseStmts' loop.
+type ParseOneFunc func(*Parser) (*Stmt, error)
+
+// Parser holds a token stream and cursor for parsing brace-delimited,
+// newline-terminated statement lists shared by Structurizr- and
+// LikeC4-style DSLs. The per-language statement grammar is supplied by
+// callers as a ParseOneFunc.
+type Parser struct {
+	Toks []Token
+	Pos  int
+}
+
+// Peek returns the current token without consuming it (EOF past the end).
+func (p *Parser) Peek() Token {
+	if p.Pos >= len(p.Toks) {
+		return Token{Kind: EOF}
+	}
+	return p.Toks[p.Pos]
+}
+
+// Advance returns the current token and moves past it (a no-op at EOF).
+func (p *Parser) Advance() Token {
+	t := p.Peek()
+	if t.Kind != EOF {
+		p.Pos++
+	}
+	return t
+}
+
+// SkipNewlines consumes consecutive Newline tokens.
+func (p *Parser) SkipNewlines() {
+	for p.Peek().Kind == Newline {
+		p.Advance()
+	}
+}
+
+// ParseAll parses a full top-level statement list.
+func (p *Parser) ParseAll(parseOne ParseOneFunc) ([]Stmt, error) {
+	return p.ParseStmts(false, parseOne)
+}
+
+// ParseStmts parses statements until EOF, or until a closing '}' when
+// inBlock is true.
+func (p *Parser) ParseStmts(inBlock bool, parseOne ParseOneFunc) ([]Stmt, error) {
+	var stmts []Stmt
+	for {
+		p.SkipNewlines()
+		tok := p.Peek()
+		if tok.Kind == EOF {
+			break
+		}
+		if inBlock && tok.Kind == RBrace {
+			break
+		}
+		s, err := parseOne(p)
+		if err != nil {
+			return nil, err
+		}
+		if s != nil {
+			stmts = append(stmts, *s)
+		}
+	}
+	return stmts, nil
+}
+
+// ParseBlock parses a "{ stmt* }" block, or returns (nil, nil) if the
+// current token isn't '{'.
+func (p *Parser) ParseBlock(parseOne ParseOneFunc) ([]Stmt, error) {
+	if p.Peek().Kind != LBrace {
+		return nil, nil
+	}
+	p.Advance() // {
+	p.SkipNewlines()
+	stmts, err := p.ParseStmts(true, parseOne)
+	if err != nil {
+		return nil, err
+	}
+	if p.Peek().Kind == RBrace {
+		p.Advance()
+	}
+	return stmts, nil
+}
+
+// OptBlock skips newlines then reads a block into s.Body if the next token
+// is '{'.
+func (p *Parser) OptBlock(s *Stmt, parseOne ParseOneFunc) error {
+	p.SkipNewlines()
+	if p.Peek().Kind == LBrace {
+		body, err := p.ParseBlock(parseOne)
+		if err != nil {
+			return err
+		}
+		s.Body = body
+	}
+	return nil
+}
+
+// FinishStmt parses s's optional trailing "{ ... }" block, if present, and
+// returns s (or the error from parsing the block).
+func (p *Parser) FinishStmt(s *Stmt, parseOne ParseOneFunc) (*Stmt, error) {
+	if err := p.OptBlock(s, parseOne); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// CollectArgs consumes consecutive String/Ident tokens as statement
+// arguments.
+func (p *Parser) CollectArgs() []string {
+	var args []string
+	for {
+		k := p.Peek().Kind
+		if k == String || k == Ident {
+			args = append(args, p.Advance().Val)
+		} else {
+			break
+		}
+	}
+	return args
+}

--- a/internal/importer/dsl/dsl_test.go
+++ b/internal/importer/dsl/dsl_test.go
@@ -203,6 +203,156 @@ func TestParser_PeekAdvance_EOF(t *testing.T) {
 	}
 }
 
+// testIdentStart/testScanIdent form a minimal identifier grammar (bare
+// letters/digits/underscore) used to exercise Next and ParseOneStmt/
+// ParseAllStmts without depending on either real DSL importer.
+func testIdentStart(c rune) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func testScanIdent(s *Scanner, line int) (Token, error) {
+	start := s.Pos
+	for {
+		c, ok := s.At(0)
+		if !ok || !(testIdentStart(c) || (c >= '0' && c <= '9')) {
+			break
+		}
+		s.Consume()
+	}
+	return Token{Kind: Ident, Val: string(s.Src[start:s.Pos]), Line: line}, nil
+}
+
+func testTokenize(t *testing.T, src string) []Token {
+	t.Helper()
+	s := NewScanner(src)
+	var toks []Token
+	for {
+		tok, err := Next(s, testIdentStart, testScanIdent)
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		toks = append(toks, tok)
+		if tok.Kind == EOF {
+			return toks
+		}
+	}
+}
+
+func TestNext_Symbols(t *testing.T) {
+	toks := testTokenize(t, `a = b { c -> d "e" }`)
+	var kinds []TokKind
+	for _, tok := range toks {
+		kinds = append(kinds, tok.Kind)
+	}
+	want := []TokKind{Ident, Assign, Ident, LBrace, Ident, Arrow, Ident, String, RBrace, EOF}
+	if len(kinds) != len(want) {
+		t.Fatalf("got %d tokens %v, want %d %v", len(kinds), kinds, len(want), want)
+	}
+	for i, k := range want {
+		if kinds[i] != k {
+			t.Errorf("token %d: kind = %v, want %v", i, kinds[i], k)
+		}
+	}
+}
+
+func TestNext_CommentsAndNewlines(t *testing.T) {
+	toks := testTokenize(t, "a // comment\n\n\nb")
+	var vals []string
+	for _, tok := range toks {
+		if tok.Kind == Ident {
+			vals = append(vals, tok.Val)
+		}
+	}
+	if len(vals) != 2 || vals[0] != "a" || vals[1] != "b" {
+		t.Errorf("got idents %v, want [a b]", vals)
+	}
+	if toks[1].Kind != Newline {
+		t.Errorf("expected a single collapsed Newline token between idents, got %v", toks[1].Kind)
+	}
+}
+
+func TestNext_UnterminatedBlockComment(t *testing.T) {
+	s := NewScanner("/* oops")
+	if _, err := Next(s, testIdentStart, testScanIdent); err == nil {
+		t.Error("expected error for unterminated block comment")
+	}
+}
+
+func TestNext_DashNotArrow_SkipsSingleDash(t *testing.T) {
+	// A lone '-' (not followed by '>') isn't a token in this shared grammar
+	// and is silently skipped, same as any other unrecognized character.
+	toks := testTokenize(t, "a - b")
+	var vals []string
+	for _, tok := range toks {
+		if tok.Kind == Ident {
+			vals = append(vals, tok.Val)
+		}
+	}
+	if len(vals) != 2 || vals[0] != "a" || vals[1] != "b" {
+		t.Errorf("got idents %v, want [a b]", vals)
+	}
+}
+
+func TestParseAllStmts_VarAssignAndRelationship(t *testing.T) {
+	toks := testTokenize(t, `x = person "Alice"
+x -> y "uses"
+`)
+	p := &Parser{Toks: toks}
+	stmts, err := ParseAllStmts(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d: %+v", len(stmts), stmts)
+	}
+
+	elem := stmts[0]
+	if elem.VarName != "x" || elem.Keyword != "person" || len(elem.Args) != 1 || elem.Args[0] != "Alice" {
+		t.Errorf("element stmt = %+v, want VarName=x Keyword=person Args=[Alice]", elem)
+	}
+
+	rel := stmts[1]
+	if !rel.IsRel || rel.RelFrom != "x" || rel.RelTo != "y" || len(rel.Args) != 1 || rel.Args[0] != "uses" {
+		t.Errorf("relationship stmt = %+v, want IsRel RelFrom=x RelTo=y Args=[uses]", rel)
+	}
+}
+
+func TestParseAllStmts_NestedBlockAndBareRelationship(t *testing.T) {
+	// group { a -> b } — a relationship with no explicit source nested
+	// inside a block; the grammar itself doesn't fill in the source (that's
+	// each importer's own responsibility), so RelFrom is empty here.
+	toks := testTokenize(t, "group {\na -> b\n}")
+	p := &Parser{Toks: toks}
+	stmts, err := ParseAllStmts(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 1 || stmts[0].Keyword != "group" {
+		t.Fatalf("expected 1 top-level 'group' statement, got %+v", stmts)
+	}
+	body := stmts[0].Body
+	if len(body) != 1 || !body[0].IsRel || body[0].RelFrom != "a" || body[0].RelTo != "b" {
+		t.Errorf("nested body = %+v, want a single a->b relationship", body)
+	}
+}
+
+func TestParseOneStmt_SkipsUnrecognizedToken(t *testing.T) {
+	// A token that's neither Ident/String nor Arrow (here: a bare RBrace at
+	// the top level, which ParseOneStmt doesn't otherwise special-case) is
+	// consumed and produces no statement.
+	p := &Parser{Toks: []Token{{Kind: Assign}, {Kind: EOF}}}
+	stmts, err := ParseAllStmts(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 0 {
+		t.Errorf("expected no statements, got %+v", stmts)
+	}
+	if p.Pos != 1 {
+		t.Errorf("expected the unrecognized token to be consumed, Pos = %d, want 1", p.Pos)
+	}
+}
+
 func TestParser_CollectArgs(t *testing.T) {
 	p := &Parser{Toks: []Token{
 		{Kind: String, Val: "a"},

--- a/internal/importer/dsl/dsl_test.go
+++ b/internal/importer/dsl/dsl_test.go
@@ -1,0 +1,216 @@
+package dsl
+
+import "testing"
+
+func TestScanner_SkipWhitespaceAndComments(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantPos int
+	}{
+		{"spaces and tabs", "  \t\t x", 5},
+		{"line comment", "// comment\nrest", 10},
+		{"block comment", "/* comment */x", 13},
+		{"multiline block comment", "/* a\nb */x", 9},
+		{"mixed", " // c\n", 5}, // trailing newline is intentionally not skipped
+		{"bare slash not a comment", "/x", 0},
+		{"no whitespace", "x", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(tt.src)
+			if err := s.SkipWhitespaceAndComments(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s.Pos != tt.wantPos {
+				t.Errorf("Pos = %d, want %d", s.Pos, tt.wantPos)
+			}
+		})
+	}
+}
+
+func TestScanner_SkipWhitespaceAndComments_UnterminatedBlockComment(t *testing.T) {
+	s := NewScanner("/* never closes")
+	if err := s.SkipWhitespaceAndComments(); err == nil {
+		t.Error("expected error for unterminated block comment")
+	}
+}
+
+func TestScanner_SkipNewlines(t *testing.T) {
+	s := NewScanner("\n\n\nx")
+	s.SkipNewlines()
+	if s.Pos != 3 {
+		t.Errorf("Pos = %d, want 3", s.Pos)
+	}
+	if s.Line != 4 {
+		t.Errorf("Line = %d, want 4", s.Line)
+	}
+}
+
+func TestScanner_ScanString(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantVal string
+	}{
+		{"simple", `"hello"`, "hello"},
+		{"escaped quote", `"a\"b"`, `a"b`},
+		{"escaped backslash", `"a\\b"`, `a\b`},
+		{"escaped newline", `"a\nb"`, "a\nb"},
+		{"unknown escape passed through", `"a\qb"`, `a\qb`},
+		{"empty", `""`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(tt.src)
+			tok, err := s.ScanString(1)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tok.Val != tt.wantVal {
+				t.Errorf("Val = %q, want %q", tok.Val, tt.wantVal)
+			}
+			if tok.Kind != String {
+				t.Errorf("Kind = %v, want String", tok.Kind)
+			}
+		})
+	}
+}
+
+func TestScanner_ScanString_Unterminated(t *testing.T) {
+	s := NewScanner(`"no closing quote`)
+	if _, err := s.ScanString(1); err == nil {
+		t.Error("expected error for unterminated string")
+	}
+}
+
+func TestScanner_ScanString_EOFInEscape(t *testing.T) {
+	s := NewScanner(`"trailing\`)
+	if _, err := s.ScanString(1); err == nil {
+		t.Error("expected error for EOF in string escape")
+	}
+}
+
+func TestScanner_AtAndConsume(t *testing.T) {
+	s := NewScanner("ab")
+	if c, ok := s.At(0); !ok || c != 'a' {
+		t.Errorf("At(0) = %q, %v; want 'a', true", c, ok)
+	}
+	if c, ok := s.At(2); ok {
+		t.Errorf("At(2) = %q, %v; want _, false", c, ok)
+	}
+	if r := s.Consume(); r != 'a' {
+		t.Errorf("Consume() = %q, want 'a'", r)
+	}
+	if s.Pos != 1 {
+		t.Errorf("Pos = %d, want 1", s.Pos)
+	}
+}
+
+func TestScanner_Consume_TracksLine(t *testing.T) {
+	s := NewScanner("a\nb")
+	s.Consume() // 'a'
+	s.Consume() // '\n'
+	if s.Line != 2 {
+		t.Errorf("Line = %d, want 2", s.Line)
+	}
+}
+
+// parseSimple is a minimal ParseOneFunc for testing the Parser: it treats
+// every Ident/String token as a Keyword-only Stmt with an optional block.
+func parseSimple(p *Parser) (*Stmt, error) {
+	tok := p.Peek()
+	if tok.Kind == EOF || tok.Kind == RBrace {
+		return nil, nil
+	}
+	if tok.Kind == LBrace {
+		if _, err := p.ParseBlock(parseSimple); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	if tok.Kind != Ident && tok.Kind != String {
+		p.Advance()
+		return nil, nil
+	}
+	p.Advance()
+	return p.FinishStmt(&Stmt{Line: tok.Line, Keyword: tok.Val}, parseSimple)
+}
+
+func TestParser_ParseAll_FlatStatements(t *testing.T) {
+	toks := []Token{
+		{Kind: Ident, Val: "a", Line: 1},
+		{Kind: Newline, Line: 1},
+		{Kind: Ident, Val: "b", Line: 2},
+		{Kind: EOF},
+	}
+	p := &Parser{Toks: toks}
+	stmts, err := p.ParseAll(parseSimple)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d", len(stmts))
+	}
+	if stmts[0].Keyword != "a" || stmts[1].Keyword != "b" {
+		t.Errorf("got keywords %q, %q; want \"a\", \"b\"", stmts[0].Keyword, stmts[1].Keyword)
+	}
+}
+
+func TestParser_ParseAll_NestedBlock(t *testing.T) {
+	// a { b }
+	toks := []Token{
+		{Kind: Ident, Val: "a", Line: 1},
+		{Kind: LBrace, Line: 1},
+		{Kind: Ident, Val: "b", Line: 1},
+		{Kind: RBrace, Line: 1},
+		{Kind: EOF},
+	}
+	p := &Parser{Toks: toks}
+	stmts, err := p.ParseAll(parseSimple)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 top-level statement, got %d", len(stmts))
+	}
+	if len(stmts[0].Body) != 1 || stmts[0].Body[0].Keyword != "b" {
+		t.Errorf("expected nested body [b], got %+v", stmts[0].Body)
+	}
+}
+
+func TestParser_ParseBlock_NotABlock(t *testing.T) {
+	p := &Parser{Toks: []Token{{Kind: Ident, Val: "x"}}}
+	stmts, err := p.ParseBlock(parseSimple)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stmts != nil {
+		t.Errorf("expected nil stmts for non-block, got %v", stmts)
+	}
+}
+
+func TestParser_PeekAdvance_EOF(t *testing.T) {
+	p := &Parser{Toks: []Token{{Kind: Ident, Val: "x"}}}
+	p.Advance()
+	if p.Peek().Kind != EOF {
+		t.Errorf("Peek() past end = %v, want EOF", p.Peek().Kind)
+	}
+	// Advance past EOF should be a no-op, not panic or move Pos further.
+	p.Advance()
+	if p.Pos != 1 {
+		t.Errorf("Pos after advancing past EOF = %d, want 1", p.Pos)
+	}
+}
+
+func TestParser_CollectArgs(t *testing.T) {
+	p := &Parser{Toks: []Token{
+		{Kind: String, Val: "a"},
+		{Kind: Ident, Val: "b"},
+		{Kind: Newline},
+	}}
+	args := p.CollectArgs()
+	if len(args) != 2 || args[0] != "a" || args[1] != "b" {
+		t.Errorf("CollectArgs() = %v, want [a b]", args)
+	}
+}

--- a/internal/importer/dsl/dsl_test.go
+++ b/internal/importer/dsl/dsl_test.go
@@ -1,6 +1,9 @@
 package dsl
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestScanner_SkipWhitespaceAndComments(t *testing.T) {
 	tests := []struct {
@@ -214,7 +217,7 @@ func testScanIdent(s *Scanner, line int) (Token, error) {
 	start := s.Pos
 	for {
 		c, ok := s.At(0)
-		if !ok || !(testIdentStart(c) || (c >= '0' && c <= '9')) {
+		if !ok || (!testIdentStart(c) && !(c >= '0' && c <= '9')) {
 			break
 		}
 		s.Consume()
@@ -350,6 +353,74 @@ func TestParseOneStmt_SkipsUnrecognizedToken(t *testing.T) {
 	}
 	if p.Pos != 1 {
 		t.Errorf("expected the unrecognized token to be consumed, Pos = %d, want 1", p.Pos)
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	toks, err := Tokenize(`a = b "c"`, testIdentStart, testScanIdent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []TokKind{Ident, Assign, Ident, String, EOF}
+	if len(toks) != len(want) {
+		t.Fatalf("got %d tokens, want %d: %+v", len(toks), len(want), toks)
+	}
+	for i, k := range want {
+		if toks[i].Kind != k {
+			t.Errorf("token %d: kind = %v, want %v", i, toks[i].Kind, k)
+		}
+	}
+}
+
+func TestTokenize_Error(t *testing.T) {
+	if _, err := Tokenize("/* unterminated", testIdentStart, testScanIdent); err == nil {
+		t.Error("expected error for unterminated block comment")
+	}
+}
+
+func TestScanIdentBody(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"plain", "abc123 rest", "abc123"},
+		{"dotted path with dash", "a.b.c-x", "a.b.c-x"}, // '-' only stops before "->"
+		{"stops before arrow", "a->b", "a"},
+		{"slash and colon", "a/b:c d", "a/b:c"},
+		{"empty at eof", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewScanner(tt.src)
+			var sb strings.Builder
+			ScanIdentBody(s, &sb)
+			if sb.String() != tt.want {
+				t.Errorf("got %q, want %q", sb.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "Hello World", "hello_world"},
+		{"already lower", "already_ok", "already_ok"},
+		{"punctuation collapsed", "A!!!B", "a_b"},
+		{"trailing punctuation trimmed", "Trailing!!!", "trailing"},
+		{"empty falls back", "!!!", "element"},
+		{"fully empty falls back", "", "element"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Slugify(tt.in); got != tt.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/importer/dsl/dsl_test.go
+++ b/internal/importer/dsl/dsl_test.go
@@ -217,7 +217,8 @@ func testScanIdent(s *Scanner, line int) (Token, error) {
 	start := s.Pos
 	for {
 		c, ok := s.At(0)
-		if !ok || (!testIdentStart(c) && !(c >= '0' && c <= '9')) {
+		isDigit := c >= '0' && c <= '9'
+		if !ok || (!testIdentStart(c) && !isDigit) {
 			break
 		}
 		s.Consume()

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -43,7 +43,7 @@ func tokenize(src string) ([]token, error) {
 	s := dsl.NewScanner(src)
 	var toks []token
 	for {
-		tok, err := next(s)
+		tok, err := dsl.Next(s, identStart, scanIdent)
 		if err != nil {
 			return nil, err
 		}
@@ -55,60 +55,10 @@ func tokenize(src string) ([]token, error) {
 	return toks, nil
 }
 
-// next scans the next token on top of the shared whitespace/comment/
-// newline/string scanning in the dsl package. Unlike Structurizr, LikeC4
-// has no "*" wildcard or "!" prefix identifiers.
-func next(s *scanner) (token, error) {
-	// Skip horizontal whitespace and handle comments.
-	// Newlines are NOT skipped here — they are emitted as tokNewline.
-	if err := s.SkipWhitespaceAndComments(); err != nil {
-		return token{}, err
-	}
-
-	c, ok := s.At(0)
-	if !ok {
-		return token{Kind: tokEOF, Line: s.Line}, nil
-	}
-	line := s.Line
-
-	// Collapse consecutive newlines into a single tokNewline.
-	if c == '\n' {
-		s.SkipNewlines()
-		return token{Kind: tokNewline, Line: line}, nil
-	}
-
-	return nextSymbolOrIdent(s, c, line)
-}
-
-// nextSymbolOrIdent scans the next symbol, string, or identifier token,
-// given the already-peeked lookahead character c at line.
-func nextSymbolOrIdent(s *scanner, c rune, line int) (token, error) {
-	switch {
-	case c == '{':
-		s.Consume()
-		return token{Kind: tokLBrace, Val: "{", Line: line}, nil
-	case c == '}':
-		s.Consume()
-		return token{Kind: tokRBrace, Val: "}", Line: line}, nil
-	case c == '=':
-		s.Consume()
-		return token{Kind: tokAssign, Val: "=", Line: line}, nil
-	case c == '-':
-		if n, _ := s.At(1); n == '>' {
-			s.Consume()
-			s.Consume()
-			return token{Kind: tokArrow, Val: "->", Line: line}, nil
-		}
-		s.Consume()
-		return next(s)
-	case c == '"':
-		return s.ScanString(line)
-	case unicode.IsLetter(c) || c == '_':
-		return scanIdent(s, line)
-	default:
-		s.Consume()
-		return next(s)
-	}
+// identStart reports whether c can start a LikeC4 identifier. Unlike
+// Structurizr, LikeC4 has no "*" wildcard or "!" prefix identifiers.
+func identStart(c rune) bool {
+	return unicode.IsLetter(c) || c == '_'
 }
 
 func scanIdent(s *scanner, line int) (token, error) {
@@ -135,54 +85,10 @@ func scanIdent(s *scanner, line int) (token, error) {
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
-
-func parseAll(p *dslParser) ([]stmt, error) {
-	return p.ParseAll(parseOneStmt)
-}
-
-func parseOneStmt(p *dslParser) (*stmt, error) {
-	tok := p.Peek()
-	if tok.Kind == tokEOF || tok.Kind == tokRBrace {
-		return nil, nil
-	}
-
-	line := tok.Line
-
-	if tok.Kind == tokArrow {
-		p.Advance()
-		to := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
-	}
-
-	if tok.Kind == tokLBrace {
-		if _, err := p.ParseBlock(parseOneStmt); err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
-
-	if tok.Kind != tokIdent && tok.Kind != tokString {
-		p.Advance()
-		return nil, nil
-	}
-
-	p.Advance()
-
-	switch p.Peek().Kind {
-	case tokAssign:
-		p.Advance()
-		kw := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, VarName: tok.Val, Keyword: kw.Val, Args: p.CollectArgs()}, parseOneStmt)
-
-	case tokArrow:
-		p.Advance()
-		to := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelFrom: tok.Val, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
-
-	default:
-		return p.FinishStmt(&stmt{Line: line, Keyword: tok.Val, Args: p.CollectArgs()}, parseOneStmt)
-	}
-}
+//
+// LikeC4's statement grammar is identical to Structurizr's — both are
+// "[var =] keyword args {body}" / "[from] -> to args {body}" — so parsing
+// itself lives entirely in the dsl package (dsl.ParseAllStmts).
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 
@@ -501,7 +407,7 @@ func importSource(src string) (*importer.ImportResult, error) {
 	}
 
 	p := &dslParser{Toks: toks}
-	stmts, err := parseAll(p)
+	stmts, err := dsl.ParseAllStmts(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -74,47 +74,10 @@ func (s *scanner) consume() rune {
 }
 
 func (s *scanner) next() (token, error) {
-	for {
-		c, ok := s.at(0)
-		if !ok {
-			return token{kind: tokEOF, line: s.line}, nil
-		}
-		if c == ' ' || c == '\t' || c == '\r' {
-			s.consume()
-			continue
-		}
-		if c == '/' {
-			n, _ := s.at(1)
-			if n == '/' {
-				for {
-					ch, ok := s.at(0)
-					if !ok || ch == '\n' {
-						break
-					}
-					s.consume()
-				}
-				continue
-			}
-			if n == '*' {
-				s.consume()
-				s.consume()
-				for {
-					ch, ok := s.at(0)
-					if !ok {
-						return token{}, fmt.Errorf("unterminated block comment")
-					}
-					s.consume()
-					if ch == '*' {
-						if nn, _ := s.at(0); nn == '/' {
-							s.consume()
-							break
-						}
-					}
-				}
-				continue
-			}
-		}
-		break
+	// Skip horizontal whitespace and handle comments.
+	// Newlines are NOT skipped here — they are emitted as tokNewline.
+	if err := s.skipWhitespaceAndComments(); err != nil {
+		return token{}, err
 	}
 
 	c, ok := s.at(0)
@@ -123,17 +86,102 @@ func (s *scanner) next() (token, error) {
 	}
 	line := s.line
 
+	// Collapse consecutive newlines into a single tokNewline.
 	if c == '\n' {
-		for {
-			ch, ok := s.at(0)
-			if !ok || ch != '\n' {
-				break
-			}
-			s.consume()
-		}
+		s.skipNewlines()
 		return token{kind: tokNewline, line: line}, nil
 	}
 
+	return s.nextSymbolOrIdent(c, line)
+}
+
+// skipWhitespaceAndComments advances past horizontal whitespace and // and
+// /* */ comments. Newlines are NOT skipped — next emits them as tokNewline.
+func (s *scanner) skipWhitespaceAndComments() error {
+	for {
+		c, ok := s.at(0)
+		if !ok {
+			return nil
+		}
+		if c == ' ' || c == '\t' || c == '\r' {
+			s.consume()
+			continue
+		}
+		if c == '/' {
+			consumed, err := s.skipComment()
+			if err != nil {
+				return err
+			}
+			if consumed {
+				continue
+			}
+		}
+		return nil
+	}
+}
+
+// skipComment consumes a // or /* */ comment starting at the current
+// position (c == '/'), if any, and reports whether one was consumed.
+func (s *scanner) skipComment() (bool, error) {
+	switch n, _ := s.at(1); n {
+	case '/':
+		s.skipLineComment()
+		return true, nil
+	case '*':
+		if err := s.skipBlockComment(); err != nil {
+			return false, err
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// skipLineComment consumes to end of line (leaving \n for next call).
+func (s *scanner) skipLineComment() {
+	for {
+		ch, ok := s.at(0)
+		if !ok || ch == '\n' {
+			return
+		}
+		s.consume()
+	}
+}
+
+// skipBlockComment consumes a /* ... */ block comment starting at the
+// current position (the leading "/*").
+func (s *scanner) skipBlockComment() error {
+	s.consume()
+	s.consume()
+	for {
+		ch, ok := s.at(0)
+		if !ok {
+			return fmt.Errorf("unterminated block comment")
+		}
+		s.consume()
+		if ch == '*' {
+			if nn, _ := s.at(0); nn == '/' {
+				s.consume()
+				return nil
+			}
+		}
+	}
+}
+
+// skipNewlines consumes consecutive '\n' characters.
+func (s *scanner) skipNewlines() {
+	for {
+		ch, ok := s.at(0)
+		if !ok || ch != '\n' {
+			return
+		}
+		s.consume()
+	}
+}
+
+// nextSymbolOrIdent scans the next symbol, string, or identifier token,
+// given the already-peeked lookahead character c at line.
+func (s *scanner) nextSymbolOrIdent(c rune, line int) (token, error) {
 	switch {
 	case c == '{':
 		s.consume()
@@ -324,11 +372,7 @@ func (p *dslParser) parseOneStmt() (*stmt, error) {
 	if tok.kind == tokArrow {
 		p.advance()
 		to := p.advance()
-		s := &stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()})
 	}
 
 	if tok.kind == tokLBrace {
@@ -349,28 +393,25 @@ func (p *dslParser) parseOneStmt() (*stmt, error) {
 	case tokAssign:
 		p.advance()
 		kw := p.advance()
-		s := &stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()})
 
 	case tokArrow:
 		p.advance()
 		to := p.advance()
-		s := &stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()})
 
 	default:
-		s := &stmt{line: line, keyword: tok.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, keyword: tok.val, args: p.collectArgs()})
 	}
+}
+
+// finishStmt parses s's optional trailing "{ ... }" block, if present, and
+// returns s (or the error from parsing the block).
+func (p *dslParser) finishStmt(s *stmt) (*stmt, error) {
+	if err := p.optBlock(s); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (p *dslParser) collectArgs() []string {
@@ -451,15 +492,7 @@ func (ls *lc4State) processModelStmts(stmts []stmt, parentPath, parentVar string
 
 func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	if s.isRel {
-		from := s.relFrom
-		if from == "" {
-			from = parentVar
-		}
-		label := ""
-		if len(s.args) > 0 {
-			label = s.args[0]
-		}
-		ls.pendingRels = append(ls.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+		ls.addPendingRel(s, parentVar)
 		return
 	}
 
@@ -468,16 +501,7 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 		return
 	}
 
-	key := s.varName
-	if key == "" {
-		if len(s.args) > 0 {
-			key = slugify(s.args[0])
-		} else {
-			key = s.keyword
-		}
-		ls.warnings = append(ls.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
-	}
-
+	key := ls.resolveElementKey(s)
 	path := key
 	if parentPath != "" {
 		path = parentPath + "." + key
@@ -491,28 +515,7 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 
 	children := make(map[string]model.Element)
 	for _, child := range s.body {
-		switch {
-		case child.isRel:
-			from := child.relFrom
-			if from == "" {
-				from = key
-			}
-			label := ""
-			if len(child.args) > 0 {
-				label = child.args[0]
-			}
-			ls.pendingRels = append(ls.pendingRels, pendingRel{from: from, to: child.relTo, label: label, line: child.line})
-		case ls.kinds[child.keyword]:
-			ls.processModelStmt(child, path, key, children)
-		case child.keyword == "description" && len(child.args) > 0:
-			el.Description = child.args[0]
-		case child.keyword == "technology" && len(child.args) > 0:
-			el.Technology = child.args[0]
-		case child.keyword == "title" && len(child.args) > 0:
-			el.Title = child.args[0]
-		case child.keyword == "tags":
-			el.Tags = child.args
-		}
+		ls.processModelChild(child, path, key, &el, children)
 	}
 
 	if len(children) > 0 {
@@ -523,81 +526,152 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 	dest[key] = el
 }
 
+// addPendingRel records a relationship statement for later resolution once
+// all elements have been discovered, defaulting its source to parentVar
+// when the statement omitted an explicit source (e.g. a nested "-> b" inside
+// element a's body).
+func (ls *lc4State) addPendingRel(s stmt, parentVar string) {
+	from := s.relFrom
+	if from == "" {
+		from = parentVar
+	}
+	label := ""
+	if len(s.args) > 0 {
+		label = s.args[0]
+	}
+	ls.pendingRels = append(ls.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+}
+
+// resolveElementKey returns s's variable name, or a slugified fallback
+// derived from its title (or keyword if untitled), warning when no variable
+// name was given in the DSL.
+func (ls *lc4State) resolveElementKey(s stmt) string {
+	if s.varName != "" {
+		return s.varName
+	}
+	key := s.keyword
+	if len(s.args) > 0 {
+		key = slugify(s.args[0])
+	}
+	ls.warnings = append(ls.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
+	return key
+}
+
+// processModelChild applies a single child statement of an element's body:
+// a nested relationship, a nested element, or one of the description/
+// technology/title/tags fields.
+func (ls *lc4State) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
+	switch {
+	case child.isRel:
+		ls.addPendingRel(child, key)
+	case ls.kinds[child.keyword]:
+		ls.processModelStmt(child, path, key, children)
+	case child.keyword == "description" && len(child.args) > 0:
+		el.Description = child.args[0]
+	case child.keyword == "technology" && len(child.args) > 0:
+		el.Technology = child.args[0]
+	case child.keyword == "title" && len(child.args) > 0:
+		el.Title = child.args[0]
+	case child.keyword == "tags":
+		el.Tags = child.args
+	}
+}
+
 func (ls *lc4State) processViews(stmts []stmt) {
 	for _, s := range stmts {
 		if s.keyword != "view" {
 			continue
 		}
 
-		// LikeC4: view <key> [of <element>] { ... }
-		// args can be: ["key"], ["key", "of", "element"], or ["key", "of", "element", "title"]
-		viewKey := ""
-		scope := ""
-		title := ""
-
-		args := s.args
-		if len(args) > 0 {
-			viewKey = args[0]
-			args = args[1:]
-		}
-
-		// Check for "of" keyword
-		if len(args) >= 2 && args[0] == "of" {
-			scope = ls.resolveVar(args[1])
-			args = args[2:]
-		}
-
-		title = strings.Join(args, " ")
-
-		if viewKey == "" {
-			baseKey := "view"
-			if scope != "" {
-				baseKey = scope
-			}
-			viewKey = baseKey
-			if ls.viewKeys[baseKey] > 0 {
-				viewKey = fmt.Sprintf("%s_%d", baseKey, ls.viewKeys[baseKey])
-			}
-		}
-		ls.viewKeys[viewKey]++
-
+		viewKey, scope, title := ls.parseViewHeader(s)
 		if title == "" {
 			title = viewKey
 		}
 
 		v := model.View{Title: title, Scope: scope, Include: []string{"*"}}
-
-		for _, bs := range s.body {
-			switch bs.keyword {
-			case "title":
-				if len(bs.args) > 0 {
-					v.Title = bs.args[0]
-				}
-			case "description":
-				if len(bs.args) > 0 {
-					v.Description = bs.args[0]
-				}
-			case "include":
-				if len(bs.args) == 1 && bs.args[0] == "*" {
-					v.Include = []string{"*"}
-				} else {
-					v.Include = nil
-					for _, arg := range bs.args {
-						if arg == "*" {
-							v.Include = []string{"*"}
-							break
-						}
-						v.Include = append(v.Include, ls.resolveVar(arg))
-					}
-				}
-			case "exclude":
-				for _, arg := range bs.args {
-					v.Exclude = append(v.Exclude, ls.resolveVar(arg))
-				}
-			}
-		}
+		ls.applyViewBody(&v, s.body)
 
 		ls.views[viewKey] = v
+	}
+}
+
+// parseViewHeader parses a "view <key> [of <element>] [title]" statement's
+// header arguments and computes its (deduplicated) view key.
+func (ls *lc4State) parseViewHeader(s stmt) (viewKey, scope, title string) {
+	// LikeC4: view <key> [of <element>] { ... }
+	// args can be: ["key"], ["key", "of", "element"], or ["key", "of", "element", "title"]
+	args := s.args
+	if len(args) > 0 {
+		viewKey = args[0]
+		args = args[1:]
+	}
+
+	// Check for "of" keyword
+	if len(args) >= 2 && args[0] == "of" {
+		scope = ls.resolveVar(args[1])
+		args = args[2:]
+	}
+
+	title = strings.Join(args, " ")
+
+	if viewKey == "" {
+		viewKey = ls.nextAnonymousViewKey(scope)
+	}
+	ls.viewKeys[viewKey]++
+
+	return viewKey, scope, title
+}
+
+// nextAnonymousViewKey computes a deduplicated view key for a view statement
+// with no explicit key, based on its scope (or "view" if unscoped).
+func (ls *lc4State) nextAnonymousViewKey(scope string) string {
+	baseKey := "view"
+	if scope != "" {
+		baseKey = scope
+	}
+	viewKey := baseKey
+	if ls.viewKeys[baseKey] > 0 {
+		viewKey = fmt.Sprintf("%s_%d", baseKey, ls.viewKeys[baseKey])
+	}
+	return viewKey
+}
+
+// applyViewBody applies a view's body statements (title, description,
+// include, exclude) to v.
+func (ls *lc4State) applyViewBody(v *model.View, body []stmt) {
+	for _, bs := range body {
+		switch bs.keyword {
+		case "title":
+			if len(bs.args) > 0 {
+				v.Title = bs.args[0]
+			}
+		case "description":
+			if len(bs.args) > 0 {
+				v.Description = bs.args[0]
+			}
+		case "include":
+			ls.applyViewInclude(v, bs.args)
+		case "exclude":
+			for _, arg := range bs.args {
+				v.Exclude = append(v.Exclude, ls.resolveVar(arg))
+			}
+		}
+	}
+}
+
+// applyViewInclude sets v.Include from an "include" statement's arguments.
+func (ls *lc4State) applyViewInclude(v *model.View, args []string) {
+	if len(args) == 1 && args[0] == "*" {
+		v.Include = []string{"*"}
+		return
+	}
+	v.Include = nil
+	for _, arg := range args {
+		if arg == "*" {
+			v.Include = []string{"*"}
+			return
+		}
+		v.Include = append(v.Include, ls.resolveVar(arg))
 	}
 }
 

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -20,25 +20,7 @@ import (
 // grammar live in internal/importer/dsl; only the language-specific token
 // and statement dispatch stay here.
 
-type (
-	token     = dsl.Token
-	stmt      = dsl.Stmt
-	scanner   = dsl.Scanner
-	dslParser = dsl.Parser
-)
-
-const (
-	tokEOF     = dsl.EOF
-	tokNewline = dsl.Newline
-	tokString  = dsl.String
-	tokIdent   = dsl.Ident
-	tokLBrace  = dsl.LBrace
-	tokRBrace  = dsl.RBrace
-	tokAssign  = dsl.Assign
-	tokArrow   = dsl.Arrow
-)
-
-func tokenize(src string) ([]token, error) {
+func tokenize(src string) ([]dsl.Token, error) {
 	return dsl.Tokenize(src, identStart, scanIdent)
 }
 
@@ -48,10 +30,10 @@ func identStart(c rune) bool {
 	return unicode.IsLetter(c) || c == '_'
 }
 
-func scanIdent(s *scanner, line int) (token, error) {
+func scanIdent(s *dsl.Scanner, line int) (dsl.Token, error) {
 	var sb strings.Builder
 	dsl.ScanIdentBody(s, &sb)
-	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
+	return dsl.Token{Kind: dsl.Ident, Val: sb.String(), Line: line}, nil
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
@@ -93,7 +75,7 @@ func newLC4State() *lc4State {
 	}
 }
 
-func (ls *lc4State) processSpecification(stmts []stmt) {
+func (ls *lc4State) processSpecification(stmts []dsl.Stmt) {
 	for _, s := range stmts {
 		switch s.Keyword {
 		case "element":
@@ -117,13 +99,13 @@ func (ls *lc4State) resolveVar(v string) string {
 	return v
 }
 
-func (ls *lc4State) processModelStmts(stmts []stmt, parentPath, parentVar string, dest map[string]model.Element) {
+func (ls *lc4State) processModelStmts(stmts []dsl.Stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	for _, s := range stmts {
 		ls.processModelStmt(s, parentPath, parentVar, dest)
 	}
 }
 
-func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
+func (ls *lc4State) processModelStmt(s dsl.Stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	if s.IsRel {
 		ls.addPendingRel(s, parentVar)
 		return
@@ -163,7 +145,7 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 // all elements have been discovered, defaulting its source to parentVar
 // when the statement omitted an explicit source (e.g. a nested "-> b" inside
 // element a's body).
-func (ls *lc4State) addPendingRel(s stmt, parentVar string) {
+func (ls *lc4State) addPendingRel(s dsl.Stmt, parentVar string) {
 	from := s.RelFrom
 	if from == "" {
 		from = parentVar
@@ -178,7 +160,7 @@ func (ls *lc4State) addPendingRel(s stmt, parentVar string) {
 // resolveElementKey returns s's variable name, or a slugified fallback
 // derived from its title (or keyword if untitled), warning when no variable
 // name was given in the DSL.
-func (ls *lc4State) resolveElementKey(s stmt) string {
+func (ls *lc4State) resolveElementKey(s dsl.Stmt) string {
 	if s.VarName != "" {
 		return s.VarName
 	}
@@ -193,7 +175,7 @@ func (ls *lc4State) resolveElementKey(s stmt) string {
 // processModelChild applies a single child statement of an element's body:
 // a nested relationship, a nested element, or one of the description/
 // technology/title/tags fields.
-func (ls *lc4State) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
+func (ls *lc4State) processModelChild(child dsl.Stmt, path, key string, el *model.Element, children map[string]model.Element) {
 	switch {
 	case child.IsRel:
 		ls.addPendingRel(child, key)
@@ -210,7 +192,7 @@ func (ls *lc4State) processModelChild(child stmt, path, key string, el *model.El
 	}
 }
 
-func (ls *lc4State) processViews(stmts []stmt) {
+func (ls *lc4State) processViews(stmts []dsl.Stmt) {
 	for _, s := range stmts {
 		if s.Keyword != "view" {
 			continue
@@ -230,7 +212,7 @@ func (ls *lc4State) processViews(stmts []stmt) {
 
 // parseViewHeader parses a "view <key> [of <element>] [title]" statement's
 // header arguments and computes its (deduplicated) view key.
-func (ls *lc4State) parseViewHeader(s stmt) (viewKey, scope, title string) {
+func (ls *lc4State) parseViewHeader(s dsl.Stmt) (viewKey, scope, title string) {
 	// LikeC4: view <key> [of <element>] { ... }
 	// args can be: ["key"], ["key", "of", "element"], or ["key", "of", "element", "title"]
 	args := s.Args
@@ -271,7 +253,7 @@ func (ls *lc4State) nextAnonymousViewKey(scope string) string {
 
 // applyViewBody applies a view's body statements (title, description,
 // include, exclude) to v.
-func (ls *lc4State) applyViewBody(v *model.View, body []stmt) {
+func (ls *lc4State) applyViewBody(v *model.View, body []dsl.Stmt) {
 	for _, bs := range body {
 		switch bs.Keyword {
 		case "title":
@@ -356,7 +338,7 @@ func importSource(src string) (*importer.ImportResult, error) {
 		return nil, fmt.Errorf("tokenize: %w", err)
 	}
 
-	p := &dslParser{Toks: toks}
+	p := &dsl.Parser{Toks: toks}
 	stmts, err := dsl.ParseAllStmts(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -10,421 +10,178 @@ import (
 	"unicode"
 
 	"github.com/docToolchain/Bausteinsicht/internal/importer"
+	"github.com/docToolchain/Bausteinsicht/internal/importer/dsl"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
 
 // ─── Tokenizer (identical grammar to Structurizr) ────────────────────────────
+//
+// The scanner/parser primitives shared with Structurizr's near-identical DSL
+// grammar live in internal/importer/dsl; only the language-specific token
+// and statement dispatch stay here.
 
-type tokKind int
-
-const (
-	tokEOF tokKind = iota
-	tokNewline
-	tokString
-	tokIdent
-	tokLBrace
-	tokRBrace
-	tokAssign
-	tokArrow
+type (
+	tokKind   = dsl.TokKind
+	token     = dsl.Token
+	stmt      = dsl.Stmt
+	scanner   = dsl.Scanner
+	dslParser = dsl.Parser
 )
 
-type token struct {
-	kind tokKind
-	val  string
-	line int
-}
-
-type scanner struct {
-	src  []rune
-	pos  int
-	line int
-}
+const (
+	tokEOF     = dsl.EOF
+	tokNewline = dsl.Newline
+	tokString  = dsl.String
+	tokIdent   = dsl.Ident
+	tokLBrace  = dsl.LBrace
+	tokRBrace  = dsl.RBrace
+	tokAssign  = dsl.Assign
+	tokArrow   = dsl.Arrow
+)
 
 func tokenize(src string) ([]token, error) {
-	s := &scanner{src: []rune(src), line: 1}
+	s := dsl.NewScanner(src)
 	var toks []token
 	for {
-		tok, err := s.next()
+		tok, err := next(s)
 		if err != nil {
 			return nil, err
 		}
 		toks = append(toks, tok)
-		if tok.kind == tokEOF {
+		if tok.Kind == tokEOF {
 			break
 		}
 	}
 	return toks, nil
 }
 
-func (s *scanner) at(offset int) (rune, bool) {
-	i := s.pos + offset
-	if i >= len(s.src) {
-		return 0, false
-	}
-	return s.src[i], true
-}
-
-func (s *scanner) consume() rune {
-	r := s.src[s.pos]
-	s.pos++
-	if r == '\n' {
-		s.line++
-	}
-	return r
-}
-
-func (s *scanner) next() (token, error) {
+// next scans the next token on top of the shared whitespace/comment/
+// newline/string scanning in the dsl package. Unlike Structurizr, LikeC4
+// has no "*" wildcard or "!" prefix identifiers.
+func next(s *scanner) (token, error) {
 	// Skip horizontal whitespace and handle comments.
 	// Newlines are NOT skipped here — they are emitted as tokNewline.
-	if err := s.skipWhitespaceAndComments(); err != nil {
+	if err := s.SkipWhitespaceAndComments(); err != nil {
 		return token{}, err
 	}
 
-	c, ok := s.at(0)
+	c, ok := s.At(0)
 	if !ok {
-		return token{kind: tokEOF, line: s.line}, nil
+		return token{Kind: tokEOF, Line: s.Line}, nil
 	}
-	line := s.line
+	line := s.Line
 
 	// Collapse consecutive newlines into a single tokNewline.
 	if c == '\n' {
-		s.skipNewlines()
-		return token{kind: tokNewline, line: line}, nil
+		s.SkipNewlines()
+		return token{Kind: tokNewline, Line: line}, nil
 	}
 
-	return s.nextSymbolOrIdent(c, line)
-}
-
-// skipWhitespaceAndComments advances past horizontal whitespace and // and
-// /* */ comments. Newlines are NOT skipped — next emits them as tokNewline.
-func (s *scanner) skipWhitespaceAndComments() error {
-	for {
-		c, ok := s.at(0)
-		if !ok {
-			return nil
-		}
-		if c == ' ' || c == '\t' || c == '\r' {
-			s.consume()
-			continue
-		}
-		if c == '/' {
-			consumed, err := s.skipComment()
-			if err != nil {
-				return err
-			}
-			if consumed {
-				continue
-			}
-		}
-		return nil
-	}
-}
-
-// skipComment consumes a // or /* */ comment starting at the current
-// position (c == '/'), if any, and reports whether one was consumed.
-func (s *scanner) skipComment() (bool, error) {
-	switch n, _ := s.at(1); n {
-	case '/':
-		s.skipLineComment()
-		return true, nil
-	case '*':
-		if err := s.skipBlockComment(); err != nil {
-			return false, err
-		}
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
-// skipLineComment consumes to end of line (leaving \n for next call).
-func (s *scanner) skipLineComment() {
-	for {
-		ch, ok := s.at(0)
-		if !ok || ch == '\n' {
-			return
-		}
-		s.consume()
-	}
-}
-
-// skipBlockComment consumes a /* ... */ block comment starting at the
-// current position (the leading "/*").
-func (s *scanner) skipBlockComment() error {
-	s.consume()
-	s.consume()
-	for {
-		ch, ok := s.at(0)
-		if !ok {
-			return fmt.Errorf("unterminated block comment")
-		}
-		s.consume()
-		if ch == '*' {
-			if nn, _ := s.at(0); nn == '/' {
-				s.consume()
-				return nil
-			}
-		}
-	}
-}
-
-// skipNewlines consumes consecutive '\n' characters.
-func (s *scanner) skipNewlines() {
-	for {
-		ch, ok := s.at(0)
-		if !ok || ch != '\n' {
-			return
-		}
-		s.consume()
-	}
+	return nextSymbolOrIdent(s, c, line)
 }
 
 // nextSymbolOrIdent scans the next symbol, string, or identifier token,
 // given the already-peeked lookahead character c at line.
-func (s *scanner) nextSymbolOrIdent(c rune, line int) (token, error) {
+func nextSymbolOrIdent(s *scanner, c rune, line int) (token, error) {
 	switch {
 	case c == '{':
-		s.consume()
-		return token{kind: tokLBrace, val: "{", line: line}, nil
+		s.Consume()
+		return token{Kind: tokLBrace, Val: "{", Line: line}, nil
 	case c == '}':
-		s.consume()
-		return token{kind: tokRBrace, val: "}", line: line}, nil
+		s.Consume()
+		return token{Kind: tokRBrace, Val: "}", Line: line}, nil
 	case c == '=':
-		s.consume()
-		return token{kind: tokAssign, val: "=", line: line}, nil
+		s.Consume()
+		return token{Kind: tokAssign, Val: "=", Line: line}, nil
 	case c == '-':
-		if n, _ := s.at(1); n == '>' {
-			s.consume()
-			s.consume()
-			return token{kind: tokArrow, val: "->", line: line}, nil
+		if n, _ := s.At(1); n == '>' {
+			s.Consume()
+			s.Consume()
+			return token{Kind: tokArrow, Val: "->", Line: line}, nil
 		}
-		s.consume()
-		return s.next()
+		s.Consume()
+		return next(s)
 	case c == '"':
-		return s.scanString(line)
+		return s.ScanString(line)
 	case unicode.IsLetter(c) || c == '_':
-		return s.scanIdent(line)
+		return scanIdent(s, line)
 	default:
-		s.consume()
-		return s.next()
+		s.Consume()
+		return next(s)
 	}
 }
 
-func (s *scanner) scanString(line int) (token, error) {
-	s.consume()
+func scanIdent(s *scanner, line int) (token, error) {
 	var sb strings.Builder
 	for {
-		c, ok := s.at(0)
-		if !ok {
-			return token{}, fmt.Errorf("line %d: unterminated string", line)
-		}
-		if c == '"' {
-			s.consume()
-			break
-		}
-		if c == '\\' {
-			s.consume()
-			esc, ok := s.at(0)
-			if !ok {
-				return token{}, fmt.Errorf("line %d: EOF in string escape", line)
-			}
-			s.consume()
-			switch esc {
-			case '"', '\\':
-				sb.WriteRune(esc)
-			case 'n':
-				sb.WriteRune('\n')
-			default:
-				sb.WriteRune('\\')
-				sb.WriteRune(esc)
-			}
-			continue
-		}
-		sb.WriteRune(s.consume())
-	}
-	return token{kind: tokString, val: sb.String(), line: line}, nil
-}
-
-func (s *scanner) scanIdent(line int) (token, error) {
-	var sb strings.Builder
-	for {
-		c, ok := s.at(0)
+		c, ok := s.At(0)
 		if !ok {
 			break
 		}
 		if c == '-' {
-			if n, _ := s.at(1); n == '>' {
+			if n, _ := s.At(1); n == '>' {
 				break
 			}
-			sb.WriteRune(s.consume())
+			sb.WriteRune(s.Consume())
 			continue
 		}
 		if unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_' || c == '.' || c == '/' || c == ':' {
-			sb.WriteRune(s.consume())
+			sb.WriteRune(s.Consume())
 			continue
 		}
 		break
 	}
-	return token{kind: tokIdent, val: sb.String(), line: line}, nil
+	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
 
-type stmt struct {
-	line    int
-	varName string
-	keyword string
-	args    []string
-	isRel   bool
-	relFrom string
-	relTo   string
-	body    []stmt
+func parseAll(p *dslParser) ([]stmt, error) {
+	return p.ParseAll(parseOneStmt)
 }
 
-type dslParser struct {
-	toks []token
-	pos  int
-}
-
-func (p *dslParser) peek() token {
-	if p.pos >= len(p.toks) {
-		return token{kind: tokEOF}
-	}
-	return p.toks[p.pos]
-}
-
-func (p *dslParser) advance() token {
-	t := p.peek()
-	if t.kind != tokEOF {
-		p.pos++
-	}
-	return t
-}
-
-func (p *dslParser) skipNewlines() {
-	for p.peek().kind == tokNewline {
-		p.advance()
-	}
-}
-
-func (p *dslParser) parseAll() ([]stmt, error) {
-	return p.parseStmts(false)
-}
-
-func (p *dslParser) parseStmts(inBlock bool) ([]stmt, error) {
-	var stmts []stmt
-	for {
-		p.skipNewlines()
-		tok := p.peek()
-		if tok.kind == tokEOF {
-			break
-		}
-		if inBlock && tok.kind == tokRBrace {
-			break
-		}
-		s, err := p.parseOneStmt()
-		if err != nil {
-			return nil, err
-		}
-		if s != nil {
-			stmts = append(stmts, *s)
-		}
-	}
-	return stmts, nil
-}
-
-func (p *dslParser) parseBlock() ([]stmt, error) {
-	if p.peek().kind != tokLBrace {
-		return nil, nil
-	}
-	p.advance()
-	p.skipNewlines()
-	stmts, err := p.parseStmts(true)
-	if err != nil {
-		return nil, err
-	}
-	if p.peek().kind == tokRBrace {
-		p.advance()
-	}
-	return stmts, nil
-}
-
-func (p *dslParser) optBlock(s *stmt) error {
-	p.skipNewlines()
-	if p.peek().kind == tokLBrace {
-		body, err := p.parseBlock()
-		if err != nil {
-			return err
-		}
-		s.body = body
-	}
-	return nil
-}
-
-func (p *dslParser) parseOneStmt() (*stmt, error) {
-	tok := p.peek()
-	if tok.kind == tokEOF || tok.kind == tokRBrace {
+func parseOneStmt(p *dslParser) (*stmt, error) {
+	tok := p.Peek()
+	if tok.Kind == tokEOF || tok.Kind == tokRBrace {
 		return nil, nil
 	}
 
-	line := tok.line
+	line := tok.Line
 
-	if tok.kind == tokArrow {
-		p.advance()
-		to := p.advance()
-		return p.finishStmt(&stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()})
+	if tok.Kind == tokArrow {
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
 	}
 
-	if tok.kind == tokLBrace {
-		if _, err := p.parseBlock(); err != nil {
+	if tok.Kind == tokLBrace {
+		if _, err := p.ParseBlock(parseOneStmt); err != nil {
 			return nil, err
 		}
 		return nil, nil
 	}
 
-	if tok.kind != tokIdent && tok.kind != tokString {
-		p.advance()
+	if tok.Kind != tokIdent && tok.Kind != tokString {
+		p.Advance()
 		return nil, nil
 	}
 
-	p.advance()
+	p.Advance()
 
-	switch p.peek().kind {
+	switch p.Peek().Kind {
 	case tokAssign:
-		p.advance()
-		kw := p.advance()
-		return p.finishStmt(&stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()})
+		p.Advance()
+		kw := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, VarName: tok.Val, Keyword: kw.Val, Args: p.CollectArgs()}, parseOneStmt)
 
 	case tokArrow:
-		p.advance()
-		to := p.advance()
-		return p.finishStmt(&stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()})
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelFrom: tok.Val, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
 
 	default:
-		return p.finishStmt(&stmt{line: line, keyword: tok.val, args: p.collectArgs()})
+		return p.FinishStmt(&stmt{Line: line, Keyword: tok.Val, Args: p.CollectArgs()}, parseOneStmt)
 	}
-}
-
-// finishStmt parses s's optional trailing "{ ... }" block, if present, and
-// returns s (or the error from parsing the block).
-func (p *dslParser) finishStmt(s *stmt) (*stmt, error) {
-	if err := p.optBlock(s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func (p *dslParser) collectArgs() []string {
-	var args []string
-	for {
-		k := p.peek().kind
-		if k == tokString || k == tokIdent {
-			args = append(args, p.advance().val)
-		} else {
-			break
-		}
-	}
-	return args
 }
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
@@ -462,12 +219,12 @@ func newLC4State() *lc4State {
 
 func (ls *lc4State) processSpecification(stmts []stmt) {
 	for _, s := range stmts {
-		switch s.keyword {
+		switch s.Keyword {
 		case "element":
-			if len(s.args) == 0 {
+			if len(s.Args) == 0 {
 				continue
 			}
-			kindName := s.args[0]
+			kindName := s.Args[0]
 			ls.kinds[kindName] = true
 			notation := strings.ToUpper(kindName[:1]) + kindName[1:]
 			ls.spec[kindName] = model.ElementKind{Notation: notation}
@@ -491,12 +248,12 @@ func (ls *lc4State) processModelStmts(stmts []stmt, parentPath, parentVar string
 }
 
 func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
-	if s.isRel {
+	if s.IsRel {
 		ls.addPendingRel(s, parentVar)
 		return
 	}
 
-	if !ls.kinds[s.keyword] {
+	if !ls.kinds[s.Keyword] {
 		// Not a known kind — treat as property inside element body
 		return
 	}
@@ -508,19 +265,19 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 	}
 	ls.varToPath[key] = path
 
-	el := model.Element{Kind: s.keyword}
-	if len(s.args) > 0 {
-		el.Title = s.args[0]
+	el := model.Element{Kind: s.Keyword}
+	if len(s.Args) > 0 {
+		el.Title = s.Args[0]
 	}
 
 	children := make(map[string]model.Element)
-	for _, child := range s.body {
+	for _, child := range s.Body {
 		ls.processModelChild(child, path, key, &el, children)
 	}
 
 	if len(children) > 0 {
 		el.Children = children
-		ls.kindsContainer[s.keyword] = true
+		ls.kindsContainer[s.Keyword] = true
 	}
 
 	dest[key] = el
@@ -531,29 +288,29 @@ func (ls *lc4State) processModelStmt(s stmt, parentPath, parentVar string, dest 
 // when the statement omitted an explicit source (e.g. a nested "-> b" inside
 // element a's body).
 func (ls *lc4State) addPendingRel(s stmt, parentVar string) {
-	from := s.relFrom
+	from := s.RelFrom
 	if from == "" {
 		from = parentVar
 	}
 	label := ""
-	if len(s.args) > 0 {
-		label = s.args[0]
+	if len(s.Args) > 0 {
+		label = s.Args[0]
 	}
-	ls.pendingRels = append(ls.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+	ls.pendingRels = append(ls.pendingRels, pendingRel{from: from, to: s.RelTo, label: label, line: s.Line})
 }
 
 // resolveElementKey returns s's variable name, or a slugified fallback
 // derived from its title (or keyword if untitled), warning when no variable
 // name was given in the DSL.
 func (ls *lc4State) resolveElementKey(s stmt) string {
-	if s.varName != "" {
-		return s.varName
+	if s.VarName != "" {
+		return s.VarName
 	}
-	key := s.keyword
-	if len(s.args) > 0 {
-		key = slugify(s.args[0])
+	key := s.Keyword
+	if len(s.Args) > 0 {
+		key = slugify(s.Args[0])
 	}
-	ls.warnings = append(ls.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
+	ls.warnings = append(ls.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.Line, key))
 	return key
 }
 
@@ -562,24 +319,24 @@ func (ls *lc4State) resolveElementKey(s stmt) string {
 // technology/title/tags fields.
 func (ls *lc4State) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
 	switch {
-	case child.isRel:
+	case child.IsRel:
 		ls.addPendingRel(child, key)
-	case ls.kinds[child.keyword]:
+	case ls.kinds[child.Keyword]:
 		ls.processModelStmt(child, path, key, children)
-	case child.keyword == "description" && len(child.args) > 0:
-		el.Description = child.args[0]
-	case child.keyword == "technology" && len(child.args) > 0:
-		el.Technology = child.args[0]
-	case child.keyword == "title" && len(child.args) > 0:
-		el.Title = child.args[0]
-	case child.keyword == "tags":
-		el.Tags = child.args
+	case child.Keyword == "description" && len(child.Args) > 0:
+		el.Description = child.Args[0]
+	case child.Keyword == "technology" && len(child.Args) > 0:
+		el.Technology = child.Args[0]
+	case child.Keyword == "title" && len(child.Args) > 0:
+		el.Title = child.Args[0]
+	case child.Keyword == "tags":
+		el.Tags = child.Args
 	}
 }
 
 func (ls *lc4State) processViews(stmts []stmt) {
 	for _, s := range stmts {
-		if s.keyword != "view" {
+		if s.Keyword != "view" {
 			continue
 		}
 
@@ -589,7 +346,7 @@ func (ls *lc4State) processViews(stmts []stmt) {
 		}
 
 		v := model.View{Title: title, Scope: scope, Include: []string{"*"}}
-		ls.applyViewBody(&v, s.body)
+		ls.applyViewBody(&v, s.Body)
 
 		ls.views[viewKey] = v
 	}
@@ -600,7 +357,7 @@ func (ls *lc4State) processViews(stmts []stmt) {
 func (ls *lc4State) parseViewHeader(s stmt) (viewKey, scope, title string) {
 	// LikeC4: view <key> [of <element>] { ... }
 	// args can be: ["key"], ["key", "of", "element"], or ["key", "of", "element", "title"]
-	args := s.args
+	args := s.Args
 	if len(args) > 0 {
 		viewKey = args[0]
 		args = args[1:]
@@ -640,19 +397,19 @@ func (ls *lc4State) nextAnonymousViewKey(scope string) string {
 // include, exclude) to v.
 func (ls *lc4State) applyViewBody(v *model.View, body []stmt) {
 	for _, bs := range body {
-		switch bs.keyword {
+		switch bs.Keyword {
 		case "title":
-			if len(bs.args) > 0 {
-				v.Title = bs.args[0]
+			if len(bs.Args) > 0 {
+				v.Title = bs.Args[0]
 			}
 		case "description":
-			if len(bs.args) > 0 {
-				v.Description = bs.args[0]
+			if len(bs.Args) > 0 {
+				v.Description = bs.Args[0]
 			}
 		case "include":
-			ls.applyViewInclude(v, bs.args)
+			ls.applyViewInclude(v, bs.Args)
 		case "exclude":
-			for _, arg := range bs.args {
+			for _, arg := range bs.Args {
 				v.Exclude = append(v.Exclude, ls.resolveVar(arg))
 			}
 		}
@@ -743,8 +500,8 @@ func importSource(src string) (*importer.ImportResult, error) {
 		return nil, fmt.Errorf("tokenize: %w", err)
 	}
 
-	p := &dslParser{toks: toks}
-	stmts, err := p.parseAll()
+	p := &dslParser{Toks: toks}
+	stmts, err := parseAll(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
@@ -752,13 +509,13 @@ func importSource(src string) (*importer.ImportResult, error) {
 	ls := newLC4State()
 
 	for _, s := range stmts {
-		switch s.keyword {
+		switch s.Keyword {
 		case "specification":
-			ls.processSpecification(s.body)
+			ls.processSpecification(s.Body)
 		case "model":
-			ls.processModelStmts(s.body, "", "", ls.elements)
+			ls.processModelStmts(s.Body, "", "", ls.elements)
 		case "views":
-			ls.processViews(s.body)
+			ls.processViews(s.Body)
 		}
 	}
 

--- a/internal/importer/likec4/likec4.go
+++ b/internal/importer/likec4/likec4.go
@@ -21,7 +21,6 @@ import (
 // and statement dispatch stay here.
 
 type (
-	tokKind   = dsl.TokKind
 	token     = dsl.Token
 	stmt      = dsl.Stmt
 	scanner   = dsl.Scanner
@@ -40,19 +39,7 @@ const (
 )
 
 func tokenize(src string) ([]token, error) {
-	s := dsl.NewScanner(src)
-	var toks []token
-	for {
-		tok, err := dsl.Next(s, identStart, scanIdent)
-		if err != nil {
-			return nil, err
-		}
-		toks = append(toks, tok)
-		if tok.Kind == tokEOF {
-			break
-		}
-	}
-	return toks, nil
+	return dsl.Tokenize(src, identStart, scanIdent)
 }
 
 // identStart reports whether c can start a LikeC4 identifier. Unlike
@@ -63,24 +50,7 @@ func identStart(c rune) bool {
 
 func scanIdent(s *scanner, line int) (token, error) {
 	var sb strings.Builder
-	for {
-		c, ok := s.At(0)
-		if !ok {
-			break
-		}
-		if c == '-' {
-			if n, _ := s.At(1); n == '>' {
-				break
-			}
-			sb.WriteRune(s.Consume())
-			continue
-		}
-		if unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_' || c == '.' || c == '/' || c == ':' {
-			sb.WriteRune(s.Consume())
-			continue
-		}
-		break
-	}
+	dsl.ScanIdentBody(s, &sb)
 	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
 }
 
@@ -214,7 +184,7 @@ func (ls *lc4State) resolveElementKey(s stmt) string {
 	}
 	key := s.Keyword
 	if len(s.Args) > 0 {
-		key = slugify(s.Args[0])
+		key = dsl.Slugify(s.Args[0])
 	}
 	ls.warnings = append(ls.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.Line, key))
 	return key
@@ -359,26 +329,6 @@ func (ls *lc4State) updateSpecWithContainers() {
 			ls.spec[kind] = ek
 		}
 	}
-}
-
-func slugify(s string) string {
-	s = strings.ToLower(s)
-	var sb strings.Builder
-	prevUnderscore := false
-	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			sb.WriteRune(r)
-			prevUnderscore = false
-		} else if !prevUnderscore && sb.Len() > 0 {
-			sb.WriteRune('_')
-			prevUnderscore = true
-		}
-	}
-	result := strings.TrimRight(sb.String(), "_")
-	if result == "" {
-		return "element"
-	}
-	return result
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -21,7 +21,6 @@ import (
 // and statement dispatch stay here.
 
 type (
-	tokKind   = dsl.TokKind
 	token     = dsl.Token
 	stmt      = dsl.Stmt
 	scanner   = dsl.Scanner
@@ -40,19 +39,7 @@ const (
 )
 
 func tokenize(src string) ([]token, error) {
-	s := dsl.NewScanner(src)
-	var toks []token
-	for {
-		tok, err := dsl.Next(s, identStart, scanIdent)
-		if err != nil {
-			return nil, err
-		}
-		toks = append(toks, tok)
-		if tok.Kind == tokEOF {
-			break
-		}
-	}
-	return toks, nil
+	return dsl.Tokenize(src, identStart, scanIdent)
 }
 
 // identStart reports whether c can start a Structurizr identifier: a "*" or
@@ -78,24 +65,7 @@ func scanIdent(s *scanner, line int) (token, error) {
 	if c, _ := s.At(0); c == '!' {
 		sb.WriteRune(s.Consume())
 	}
-	for {
-		c, ok := s.At(0)
-		if !ok {
-			break
-		}
-		if c == '-' {
-			if n, _ := s.At(1); n == '>' {
-				break
-			}
-			sb.WriteRune(s.Consume())
-			continue
-		}
-		if unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_' || c == '.' || c == '/' || c == ':' {
-			sb.WriteRune(s.Consume())
-			continue
-		}
-		break
-	}
+	dsl.ScanIdentBody(s, &sb)
 	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
 }
 
@@ -242,7 +212,7 @@ func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
 	}
 	key := kd.kind
 	if len(s.Args) > 0 {
-		key = slugify(s.Args[0])
+		key = dsl.Slugify(s.Args[0])
 	}
 	is.warnings = append(is.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.Line, key))
 	return key
@@ -445,26 +415,6 @@ func parseProperties(body []stmt) map[string]string {
 		}
 	}
 	return m
-}
-
-func slugify(s string) string {
-	s = strings.ToLower(s)
-	var sb strings.Builder
-	prevUnderscore := false
-	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			sb.WriteRune(r)
-			prevUnderscore = false
-		} else if !prevUnderscore && sb.Len() > 0 {
-			sb.WriteRune('_')
-			prevUnderscore = true
-		}
-	}
-	result := strings.TrimRight(sb.String(), "_")
-	if result == "" {
-		return "element"
-	}
-	return result
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -43,7 +43,7 @@ func tokenize(src string) ([]token, error) {
 	s := dsl.NewScanner(src)
 	var toks []token
 	for {
-		tok, err := next(s)
+		tok, err := dsl.Next(s, identStart, scanIdent)
 		if err != nil {
 			return nil, err
 		}
@@ -55,56 +55,15 @@ func tokenize(src string) ([]token, error) {
 	return toks, nil
 }
 
-// next scans the next token, handling Structurizr-specific dispatch (the
-// "*"/"**" wildcard identifiers used by "include *", and the "!" prefix on
-// identifiers) on top of the shared whitespace/comment/newline/string
-// scanning in the dsl package.
-func next(s *scanner) (token, error) {
-	// Skip horizontal whitespace and handle comments.
-	// Newlines are NOT skipped here — they are emitted as tokNewline.
-	if err := s.SkipWhitespaceAndComments(); err != nil {
-		return token{}, err
-	}
-
-	c, ok := s.At(0)
-	if !ok {
-		return token{Kind: tokEOF, Line: s.Line}, nil
-	}
-	line := s.Line
-
-	// Collapse consecutive newlines into a single tokNewline.
-	if c == '\n' {
-		s.SkipNewlines()
-		return token{Kind: tokNewline, Line: line}, nil
-	}
-
-	return nextSymbolOrIdent(s, c, line)
+// identStart reports whether c can start a Structurizr identifier: a "*" or
+// "**" wildcard (so "include *"/"include **" parse correctly), a "!"-prefixed
+// reference, or an ordinary identifier.
+func identStart(c rune) bool {
+	return c == '*' || c == '!' || unicode.IsLetter(c) || c == '_'
 }
 
-// nextSymbolOrIdent scans the next symbol, string, or identifier token,
-// given the already-peeked lookahead character c at line.
-func nextSymbolOrIdent(s *scanner, c rune, line int) (token, error) {
-	switch {
-	case c == '{':
-		s.Consume()
-		return token{Kind: tokLBrace, Val: "{", Line: line}, nil
-	case c == '}':
-		s.Consume()
-		return token{Kind: tokRBrace, Val: "}", Line: line}, nil
-	case c == '=':
-		s.Consume()
-		return token{Kind: tokAssign, Val: "=", Line: line}, nil
-	case c == '-':
-		if n, _ := s.At(1); n == '>' {
-			s.Consume()
-			s.Consume()
-			return token{Kind: tokArrow, Val: "->", Line: line}, nil
-		}
-		s.Consume()
-		return next(s)
-	case c == '"':
-		return s.ScanString(line)
-	case c == '*':
+func scanIdent(s *scanner, line int) (token, error) {
+	if c, _ := s.At(0); c == '*' {
 		// Consume one or two '*' and return as a single identifier token
 		// so that "include *" and "include **" are parsed correctly.
 		s.Consume()
@@ -113,15 +72,8 @@ func nextSymbolOrIdent(s *scanner, c rune, line int) (token, error) {
 			return token{Kind: tokIdent, Val: "**", Line: line}, nil
 		}
 		return token{Kind: tokIdent, Val: "*", Line: line}, nil
-	case c == '!' || unicode.IsLetter(c) || c == '_':
-		return scanIdent(s, line)
-	default:
-		s.Consume()
-		return next(s)
 	}
-}
 
-func scanIdent(s *scanner, line int) (token, error) {
 	var sb strings.Builder
 	if c, _ := s.At(0); c == '!' {
 		sb.WriteRune(s.Consume())
@@ -148,54 +100,10 @@ func scanIdent(s *scanner, line int) (token, error) {
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
-
-func parseAll(p *dslParser) ([]stmt, error) {
-	return p.ParseAll(parseOneStmt)
-}
-
-func parseOneStmt(p *dslParser) (*stmt, error) {
-	tok := p.Peek()
-	if tok.Kind == tokEOF || tok.Kind == tokRBrace {
-		return nil, nil
-	}
-
-	line := tok.Line
-
-	if tok.Kind == tokArrow {
-		p.Advance()
-		to := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
-	}
-
-	if tok.Kind == tokLBrace {
-		if _, err := p.ParseBlock(parseOneStmt); err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
-
-	if tok.Kind != tokIdent && tok.Kind != tokString {
-		p.Advance()
-		return nil, nil
-	}
-
-	p.Advance()
-
-	switch p.Peek().Kind {
-	case tokAssign:
-		p.Advance()
-		kw := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, VarName: tok.Val, Keyword: kw.Val, Args: p.CollectArgs()}, parseOneStmt)
-
-	case tokArrow:
-		p.Advance()
-		to := p.Advance()
-		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelFrom: tok.Val, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
-
-	default:
-		return p.FinishStmt(&stmt{Line: line, Keyword: tok.Val, Args: p.CollectArgs()}, parseOneStmt)
-	}
-}
+//
+// Structurizr's statement grammar is identical to LikeC4's — both are
+// "[var =] keyword args {body}" / "[from] -> to args {body}" — so parsing
+// itself lives entirely in the dsl package (dsl.ParseAllStmts).
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 
@@ -649,7 +557,7 @@ func importSource(src string) (*importer.ImportResult, error) {
 	}
 
 	p := &dslParser{Toks: toks}
-	stmts, err := parseAll(p)
+	stmts, err := dsl.ParseAllStmts(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -10,435 +10,191 @@ import (
 	"unicode"
 
 	"github.com/docToolchain/Bausteinsicht/internal/importer"
+	"github.com/docToolchain/Bausteinsicht/internal/importer/dsl"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 )
 
 // ─── Tokenizer ───────────────────────────────────────────────────────────────
+//
+// The scanner/parser primitives shared with LikeC4's near-identical DSL
+// grammar live in internal/importer/dsl; only the language-specific token
+// and statement dispatch stay here.
 
-type tokKind int
-
-const (
-	tokEOF     tokKind = iota
-	tokNewline         // statement separator — emitted for each (group of) newline(s)
-	tokString
-	tokIdent
-	tokLBrace
-	tokRBrace
-	tokAssign
-	tokArrow
+type (
+	tokKind   = dsl.TokKind
+	token     = dsl.Token
+	stmt      = dsl.Stmt
+	scanner   = dsl.Scanner
+	dslParser = dsl.Parser
 )
 
-type token struct {
-	kind tokKind
-	val  string
-	line int
-}
-
-type scanner struct {
-	src  []rune
-	pos  int
-	line int
-}
+const (
+	tokEOF     = dsl.EOF
+	tokNewline = dsl.Newline
+	tokString  = dsl.String
+	tokIdent   = dsl.Ident
+	tokLBrace  = dsl.LBrace
+	tokRBrace  = dsl.RBrace
+	tokAssign  = dsl.Assign
+	tokArrow   = dsl.Arrow
+)
 
 func tokenize(src string) ([]token, error) {
-	s := &scanner{src: []rune(src), line: 1}
+	s := dsl.NewScanner(src)
 	var toks []token
 	for {
-		tok, err := s.next()
+		tok, err := next(s)
 		if err != nil {
 			return nil, err
 		}
 		toks = append(toks, tok)
-		if tok.kind == tokEOF {
+		if tok.Kind == tokEOF {
 			break
 		}
 	}
 	return toks, nil
 }
 
-func (s *scanner) at(offset int) (rune, bool) {
-	i := s.pos + offset
-	if i >= len(s.src) {
-		return 0, false
-	}
-	return s.src[i], true
-}
-
-func (s *scanner) consume() rune {
-	r := s.src[s.pos]
-	s.pos++
-	if r == '\n' {
-		s.line++
-	}
-	return r
-}
-
-func (s *scanner) next() (token, error) {
+// next scans the next token, handling Structurizr-specific dispatch (the
+// "*"/"**" wildcard identifiers used by "include *", and the "!" prefix on
+// identifiers) on top of the shared whitespace/comment/newline/string
+// scanning in the dsl package.
+func next(s *scanner) (token, error) {
 	// Skip horizontal whitespace and handle comments.
 	// Newlines are NOT skipped here — they are emitted as tokNewline.
-	if err := s.skipWhitespaceAndComments(); err != nil {
+	if err := s.SkipWhitespaceAndComments(); err != nil {
 		return token{}, err
 	}
 
-	c, ok := s.at(0)
+	c, ok := s.At(0)
 	if !ok {
-		return token{kind: tokEOF, line: s.line}, nil
+		return token{Kind: tokEOF, Line: s.Line}, nil
 	}
-	line := s.line
+	line := s.Line
 
 	// Collapse consecutive newlines into a single tokNewline.
 	if c == '\n' {
-		s.skipNewlines()
-		return token{kind: tokNewline, line: line}, nil
+		s.SkipNewlines()
+		return token{Kind: tokNewline, Line: line}, nil
 	}
 
-	return s.nextSymbolOrIdent(c, line)
-}
-
-// skipWhitespaceAndComments advances past horizontal whitespace and // and
-// /* */ comments. Newlines are NOT skipped — next emits them as tokNewline.
-func (s *scanner) skipWhitespaceAndComments() error {
-	for {
-		c, ok := s.at(0)
-		if !ok {
-			return nil
-		}
-		if c == ' ' || c == '\t' || c == '\r' {
-			s.consume()
-			continue
-		}
-		if c == '/' {
-			consumed, err := s.skipComment()
-			if err != nil {
-				return err
-			}
-			if consumed {
-				continue
-			}
-		}
-		return nil
-	}
-}
-
-// skipComment consumes a // or /* */ comment starting at the current
-// position (c == '/'), if any, and reports whether one was consumed.
-func (s *scanner) skipComment() (bool, error) {
-	switch n, _ := s.at(1); n {
-	case '/':
-		s.skipLineComment()
-		return true, nil
-	case '*':
-		if err := s.skipBlockComment(); err != nil {
-			return false, err
-		}
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
-// skipLineComment consumes to end of line (leaving \n for next call).
-func (s *scanner) skipLineComment() {
-	for {
-		ch, ok := s.at(0)
-		if !ok || ch == '\n' {
-			return
-		}
-		s.consume()
-	}
-}
-
-// skipBlockComment consumes a /* ... */ block comment starting at the
-// current position (the leading "/*").
-func (s *scanner) skipBlockComment() error {
-	s.consume()
-	s.consume()
-	for {
-		ch, ok := s.at(0)
-		if !ok {
-			return fmt.Errorf("unterminated block comment")
-		}
-		s.consume()
-		if ch == '*' {
-			if nn, _ := s.at(0); nn == '/' {
-				s.consume()
-				return nil
-			}
-		}
-	}
-}
-
-// skipNewlines consumes consecutive '\n' characters.
-func (s *scanner) skipNewlines() {
-	for {
-		ch, ok := s.at(0)
-		if !ok || ch != '\n' {
-			return
-		}
-		s.consume()
-	}
+	return nextSymbolOrIdent(s, c, line)
 }
 
 // nextSymbolOrIdent scans the next symbol, string, or identifier token,
 // given the already-peeked lookahead character c at line.
-func (s *scanner) nextSymbolOrIdent(c rune, line int) (token, error) {
+func nextSymbolOrIdent(s *scanner, c rune, line int) (token, error) {
 	switch {
 	case c == '{':
-		s.consume()
-		return token{kind: tokLBrace, val: "{", line: line}, nil
+		s.Consume()
+		return token{Kind: tokLBrace, Val: "{", Line: line}, nil
 	case c == '}':
-		s.consume()
-		return token{kind: tokRBrace, val: "}", line: line}, nil
+		s.Consume()
+		return token{Kind: tokRBrace, Val: "}", Line: line}, nil
 	case c == '=':
-		s.consume()
-		return token{kind: tokAssign, val: "=", line: line}, nil
+		s.Consume()
+		return token{Kind: tokAssign, Val: "=", Line: line}, nil
 	case c == '-':
-		if n, _ := s.at(1); n == '>' {
-			s.consume()
-			s.consume()
-			return token{kind: tokArrow, val: "->", line: line}, nil
+		if n, _ := s.At(1); n == '>' {
+			s.Consume()
+			s.Consume()
+			return token{Kind: tokArrow, Val: "->", Line: line}, nil
 		}
-		s.consume()
-		return s.next()
+		s.Consume()
+		return next(s)
 	case c == '"':
-		return s.scanString(line)
+		return s.ScanString(line)
 	case c == '*':
 		// Consume one or two '*' and return as a single identifier token
 		// so that "include *" and "include **" are parsed correctly.
-		s.consume()
-		if n, _ := s.at(0); n == '*' {
-			s.consume()
-			return token{kind: tokIdent, val: "**", line: line}, nil
+		s.Consume()
+		if n, _ := s.At(0); n == '*' {
+			s.Consume()
+			return token{Kind: tokIdent, Val: "**", Line: line}, nil
 		}
-		return token{kind: tokIdent, val: "*", line: line}, nil
+		return token{Kind: tokIdent, Val: "*", Line: line}, nil
 	case c == '!' || unicode.IsLetter(c) || c == '_':
-		return s.scanIdent(line)
+		return scanIdent(s, line)
 	default:
-		s.consume()
-		return s.next()
+		s.Consume()
+		return next(s)
 	}
 }
 
-func (s *scanner) scanString(line int) (token, error) {
-	s.consume()
+func scanIdent(s *scanner, line int) (token, error) {
 	var sb strings.Builder
-	for {
-		c, ok := s.at(0)
-		if !ok {
-			return token{}, fmt.Errorf("line %d: unterminated string", line)
-		}
-		if c == '"' {
-			s.consume()
-			break
-		}
-		if c == '\\' {
-			s.consume()
-			esc, ok := s.at(0)
-			if !ok {
-				return token{}, fmt.Errorf("line %d: EOF in string escape", line)
-			}
-			s.consume()
-			switch esc {
-			case '"', '\\':
-				sb.WriteRune(esc)
-			case 'n':
-				sb.WriteRune('\n')
-			default:
-				sb.WriteRune('\\')
-				sb.WriteRune(esc)
-			}
-			continue
-		}
-		sb.WriteRune(s.consume())
-	}
-	return token{kind: tokString, val: sb.String(), line: line}, nil
-}
-
-func (s *scanner) scanIdent(line int) (token, error) {
-	var sb strings.Builder
-	if c, _ := s.at(0); c == '!' {
-		sb.WriteRune(s.consume())
+	if c, _ := s.At(0); c == '!' {
+		sb.WriteRune(s.Consume())
 	}
 	for {
-		c, ok := s.at(0)
+		c, ok := s.At(0)
 		if !ok {
 			break
 		}
 		if c == '-' {
-			if n, _ := s.at(1); n == '>' {
+			if n, _ := s.At(1); n == '>' {
 				break
 			}
-			sb.WriteRune(s.consume())
+			sb.WriteRune(s.Consume())
 			continue
 		}
 		if unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_' || c == '.' || c == '/' || c == ':' {
-			sb.WriteRune(s.consume())
+			sb.WriteRune(s.Consume())
 			continue
 		}
 		break
 	}
-	return token{kind: tokIdent, val: sb.String(), line: line}, nil
+	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
 
-// stmt represents one parsed statement in the DSL.
-type stmt struct {
-	line    int
-	varName string
-	keyword string
-	args    []string
-	isRel   bool
-	relFrom string
-	relTo   string
-	body    []stmt
+func parseAll(p *dslParser) ([]stmt, error) {
+	return p.ParseAll(parseOneStmt)
 }
 
-type dslParser struct {
-	toks []token
-	pos  int
-}
-
-func (p *dslParser) peek() token {
-	if p.pos >= len(p.toks) {
-		return token{kind: tokEOF}
-	}
-	return p.toks[p.pos]
-}
-
-func (p *dslParser) advance() token {
-	t := p.peek()
-	if t.kind != tokEOF {
-		p.pos++
-	}
-	return t
-}
-
-func (p *dslParser) skipNewlines() {
-	for p.peek().kind == tokNewline {
-		p.advance()
-	}
-}
-
-func (p *dslParser) parseAll() ([]stmt, error) {
-	return p.parseStmts(false)
-}
-
-func (p *dslParser) parseStmts(inBlock bool) ([]stmt, error) {
-	var stmts []stmt
-	for {
-		p.skipNewlines()
-		tok := p.peek()
-		if tok.kind == tokEOF {
-			break
-		}
-		if inBlock && tok.kind == tokRBrace {
-			break
-		}
-		s, err := p.parseOneStmt()
-		if err != nil {
-			return nil, err
-		}
-		if s != nil {
-			stmts = append(stmts, *s)
-		}
-	}
-	return stmts, nil
-}
-
-func (p *dslParser) parseBlock() ([]stmt, error) {
-	if p.peek().kind != tokLBrace {
-		return nil, nil
-	}
-	p.advance() // {
-	p.skipNewlines()
-	stmts, err := p.parseStmts(true)
-	if err != nil {
-		return nil, err
-	}
-	if p.peek().kind == tokRBrace {
-		p.advance()
-	}
-	return stmts, nil
-}
-
-// optBlock skips newlines then reads a block if the next token is {.
-func (p *dslParser) optBlock(s *stmt) error {
-	p.skipNewlines()
-	if p.peek().kind == tokLBrace {
-		body, err := p.parseBlock()
-		if err != nil {
-			return err
-		}
-		s.body = body
-	}
-	return nil
-}
-
-func (p *dslParser) parseOneStmt() (*stmt, error) {
-	tok := p.peek()
-	if tok.kind == tokEOF || tok.kind == tokRBrace {
+func parseOneStmt(p *dslParser) (*stmt, error) {
+	tok := p.Peek()
+	if tok.Kind == tokEOF || tok.Kind == tokRBrace {
 		return nil, nil
 	}
 
-	line := tok.line
+	line := tok.Line
 
-	if tok.kind == tokArrow {
-		p.advance()
-		to := p.advance()
-		return p.finishStmt(&stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()})
+	if tok.Kind == tokArrow {
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
 	}
 
-	if tok.kind == tokLBrace {
-		if _, err := p.parseBlock(); err != nil {
+	if tok.Kind == tokLBrace {
+		if _, err := p.ParseBlock(parseOneStmt); err != nil {
 			return nil, err
 		}
 		return nil, nil
 	}
 
-	if tok.kind != tokIdent && tok.kind != tokString {
-		p.advance()
+	if tok.Kind != tokIdent && tok.Kind != tokString {
+		p.Advance()
 		return nil, nil
 	}
 
-	p.advance()
+	p.Advance()
 
-	switch p.peek().kind {
+	switch p.Peek().Kind {
 	case tokAssign:
-		p.advance()
-		kw := p.advance()
-		return p.finishStmt(&stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()})
+		p.Advance()
+		kw := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, VarName: tok.Val, Keyword: kw.Val, Args: p.CollectArgs()}, parseOneStmt)
 
 	case tokArrow:
-		p.advance()
-		to := p.advance()
-		return p.finishStmt(&stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()})
+		p.Advance()
+		to := p.Advance()
+		return p.FinishStmt(&stmt{Line: line, IsRel: true, RelFrom: tok.Val, RelTo: to.Val, Args: p.CollectArgs()}, parseOneStmt)
 
 	default:
-		return p.finishStmt(&stmt{line: line, keyword: tok.val, args: p.collectArgs()})
+		return p.FinishStmt(&stmt{Line: line, Keyword: tok.Val, Args: p.CollectArgs()}, parseOneStmt)
 	}
-}
-
-// finishStmt parses s's optional trailing "{ ... }" block, if present, and
-// returns s (or the error from parsing the block).
-func (p *dslParser) finishStmt(s *stmt) (*stmt, error) {
-	if err := p.optBlock(s); err != nil {
-		return nil, err
-	}
-	return s, nil
-}
-
-func (p *dslParser) collectArgs() []string {
-	var args []string
-	for {
-		k := p.peek().kind
-		if k == tokString || k == tokIdent {
-			args = append(args, p.advance().val)
-		} else {
-			break
-		}
-	}
-	return args
 }
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
@@ -518,21 +274,21 @@ func (is *importState) processModelStmts(stmts []stmt, parentPath, parentVar str
 }
 
 func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
-	if s.isRel {
+	if s.IsRel {
 		is.addPendingRel(s, parentVar)
 		return
 	}
 
-	kd, isElement := structurizrKindMap[s.keyword]
+	kd, isElement := structurizrKindMap[s.Keyword]
 	if !isElement {
-		switch s.keyword {
+		switch s.Keyword {
 		case "enterprise", "group":
-			is.processModelStmts(s.body, parentPath, parentVar, dest)
+			is.processModelStmts(s.Body, parentPath, parentVar, dest)
 		}
 		return
 	}
 
-	is.registerKind(s.keyword)
+	is.registerKind(s.Keyword)
 
 	key := is.resolveElementKey(s, kd)
 	path := key
@@ -544,7 +300,7 @@ func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, de
 	el := buildElementFromStmt(s, kd)
 
 	children := make(map[string]model.Element)
-	for _, child := range s.body {
+	for _, child := range s.Body {
 		is.processModelChild(child, path, key, &el, children)
 	}
 	if len(children) > 0 {
@@ -558,29 +314,29 @@ func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, de
 // when the statement omitted an explicit source (e.g. a nested "-> b" inside
 // element a's body).
 func (is *importState) addPendingRel(s stmt, parentVar string) {
-	from := s.relFrom
+	from := s.RelFrom
 	if from == "" {
 		from = parentVar
 	}
 	label := ""
-	if len(s.args) > 0 {
-		label = s.args[0]
+	if len(s.Args) > 0 {
+		label = s.Args[0]
 	}
-	is.pendingRels = append(is.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+	is.pendingRels = append(is.pendingRels, pendingRel{from: from, to: s.RelTo, label: label, line: s.Line})
 }
 
 // resolveElementKey returns s's variable name, or a slugified fallback
 // derived from its title (or kind if untitled), warning when no variable
 // name was given in the DSL.
 func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
-	if s.varName != "" {
-		return s.varName
+	if s.VarName != "" {
+		return s.VarName
 	}
 	key := kd.kind
-	if len(s.args) > 0 {
-		key = slugify(s.args[0])
+	if len(s.Args) > 0 {
+		key = slugify(s.Args[0])
 	}
-	is.warnings = append(is.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
+	is.warnings = append(is.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.Line, key))
 	return key
 }
 
@@ -588,14 +344,14 @@ func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
 // description, and (for containers/components) technology arguments.
 func buildElementFromStmt(s stmt, kd kindDef) model.Element {
 	el := model.Element{Kind: kd.kind}
-	if len(s.args) > 0 {
-		el.Title = s.args[0]
+	if len(s.Args) > 0 {
+		el.Title = s.Args[0]
 	}
-	if len(s.args) > 1 {
-		el.Description = s.args[1]
+	if len(s.Args) > 1 {
+		el.Description = s.Args[1]
 	}
-	if (kd.kind == "container" || kd.kind == "component") && len(s.args) > 2 {
-		el.Technology = s.args[2]
+	if (kd.kind == "container" || kd.kind == "component") && len(s.Args) > 2 {
+		el.Technology = s.Args[2]
 	}
 	return el
 }
@@ -605,18 +361,18 @@ func buildElementFromStmt(s stmt, kd kindDef) model.Element {
 // technology/tags/properties fields.
 func (is *importState) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
 	switch {
-	case child.isRel:
+	case child.IsRel:
 		is.addPendingRel(child, key)
-	case structurizrKindMap[child.keyword].kind != "":
+	case structurizrKindMap[child.Keyword].kind != "":
 		is.processModelStmt(child, path, key, children)
-	case child.keyword == "description" && len(child.args) > 0:
-		el.Description = child.args[0]
-	case child.keyword == "technology" && len(child.args) > 0:
-		el.Technology = child.args[0]
-	case child.keyword == "tags":
-		el.Tags = child.args
-	case child.keyword == "properties":
-		el.Metadata = parseProperties(child.body)
+	case child.Keyword == "description" && len(child.Args) > 0:
+		el.Description = child.Args[0]
+	case child.Keyword == "technology" && len(child.Args) > 0:
+		el.Technology = child.Args[0]
+	case child.Keyword == "tags":
+		el.Tags = child.Args
+	case child.Keyword == "properties":
+		el.Metadata = parseProperties(child.Body)
 	}
 }
 
@@ -627,24 +383,24 @@ func (is *importState) processViewsStmts(stmts []stmt) {
 		}
 
 		scope := ""
-		if s.keyword != "systemLandscape" && len(s.args) > 0 {
-			scope = is.resolveVar(s.args[0])
+		if s.Keyword != "systemLandscape" && len(s.Args) > 0 {
+			scope = is.resolveVar(s.Args[0])
 		}
 
-		titleArgs := s.args
+		titleArgs := s.Args
 		if scope != "" {
-			titleArgs = s.args[1:]
+			titleArgs = s.Args[1:]
 		}
 		title := strings.Join(titleArgs, " ")
 
-		viewKey := is.nextViewKey(s.keyword, scope)
+		viewKey := is.nextViewKey(s.Keyword, scope)
 		if title == "" {
 			title = viewKey
 		}
 
 		v := model.View{Title: title, Scope: scope, Include: []string{"*"}}
-		is.applyViewBodyStmts(&v, s.body, viewKey)
-		expandScopeWildcardInclude(&v, s.keyword, scope)
+		is.applyViewBodyStmts(&v, s.Body, viewKey)
+		expandScopeWildcardInclude(&v, s.Keyword, scope)
 
 		is.views[viewKey] = v
 	}
@@ -653,11 +409,11 @@ func (is *importState) processViewsStmts(stmts []stmt) {
 // isSupportedViewKeyword reports whether s is a supported view statement,
 // warning and returning false for recognized-but-unsupported view types.
 func (is *importState) isSupportedViewKeyword(s stmt) bool {
-	switch s.keyword {
+	switch s.Keyword {
 	case "systemContext", "container", "component", "systemLandscape":
 		return true
 	case "filtered", "dynamic", "deployment":
-		is.warnings = append(is.warnings, fmt.Sprintf("line %d: %s view not supported, skipped", s.line, s.keyword))
+		is.warnings = append(is.warnings, fmt.Sprintf("line %d: %s view not supported, skipped", s.Line, s.Keyword))
 		return false
 	default:
 		return false
@@ -683,20 +439,20 @@ func (is *importState) nextViewKey(keyword, scope string) string {
 // title, description, autoLayout) to v.
 func (is *importState) applyViewBodyStmts(v *model.View, body []stmt, viewKey string) {
 	for _, bs := range body {
-		switch bs.keyword {
+		switch bs.Keyword {
 		case "include":
-			is.applyViewInclude(v, bs.args)
+			is.applyViewInclude(v, bs.Args)
 		case "exclude":
-			for _, arg := range bs.args {
+			for _, arg := range bs.Args {
 				v.Exclude = append(v.Exclude, is.resolveVar(arg))
 			}
 		case "title":
-			if len(bs.args) > 0 {
-				v.Title = bs.args[0]
+			if len(bs.Args) > 0 {
+				v.Title = bs.Args[0]
 			}
 		case "description":
-			if len(bs.args) > 0 {
-				v.Description = bs.args[0]
+			if len(bs.Args) > 0 {
+				v.Description = bs.Args[0]
 			}
 		case "autoLayout":
 			is.applyAutoLayout(v, bs, viewKey)
@@ -730,10 +486,10 @@ func (is *importState) applyViewInclude(v *model.View, args []string) {
 // validation on the very model this importer just wrote.
 func (is *importState) applyAutoLayout(v *model.View, bs stmt, viewKey string) {
 	v.Layout = "layered"
-	if len(bs.args) > 0 {
+	if len(bs.Args) > 0 {
 		is.warnings = append(is.warnings, fmt.Sprintf(
 			"line %d: view %q: autoLayout direction %q not preserved, mapped to layout: \"layered\"",
-			bs.line, viewKey, strings.Join(bs.args, " ")))
+			bs.Line, viewKey, strings.Join(bs.Args, " ")))
 	}
 }
 
@@ -776,8 +532,8 @@ func (is *importState) buildRelationships() []model.Relationship {
 func parseProperties(body []stmt) map[string]string {
 	m := make(map[string]string)
 	for _, s := range body {
-		if s.keyword != "" && len(s.args) > 0 {
-			m[s.keyword] = s.args[0]
+		if s.Keyword != "" && len(s.Args) > 0 {
+			m[s.Keyword] = s.Args[0]
 		}
 	}
 	return m
@@ -892,8 +648,8 @@ func importSource(src string) (*importer.ImportResult, error) {
 		return nil, fmt.Errorf("tokenize: %w", err)
 	}
 
-	p := &dslParser{toks: toks}
-	stmts, err := p.parseAll()
+	p := &dslParser{Toks: toks}
+	stmts, err := parseAll(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
@@ -917,20 +673,20 @@ func importSource(src string) (*importer.ImportResult, error) {
 // appear directly at the top level.
 func extractModelAndViewsStmts(stmts []stmt) (modelStmts, viewsStmts []stmt) {
 	for _, s := range stmts {
-		switch s.keyword {
+		switch s.Keyword {
 		case "workspace":
-			for _, ws := range s.body {
-				switch ws.keyword {
+			for _, ws := range s.Body {
+				switch ws.Keyword {
 				case "model":
-					modelStmts = ws.body
+					modelStmts = ws.Body
 				case "views":
-					viewsStmts = ws.body
+					viewsStmts = ws.Body
 				}
 			}
 		case "model":
-			modelStmts = s.body
+			modelStmts = s.Body
 		case "views":
-			viewsStmts = s.body
+			viewsStmts = s.Body
 		}
 	}
 	return modelStmts, viewsStmts

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -76,48 +76,8 @@ func (s *scanner) consume() rune {
 func (s *scanner) next() (token, error) {
 	// Skip horizontal whitespace and handle comments.
 	// Newlines are NOT skipped here — they are emitted as tokNewline.
-	for {
-		c, ok := s.at(0)
-		if !ok {
-			return token{kind: tokEOF, line: s.line}, nil
-		}
-		if c == ' ' || c == '\t' || c == '\r' {
-			s.consume()
-			continue
-		}
-		if c == '/' {
-			n, _ := s.at(1)
-			if n == '/' {
-				// Line comment: consume to end of line (leave \n for next call)
-				for {
-					ch, ok := s.at(0)
-					if !ok || ch == '\n' {
-						break
-					}
-					s.consume()
-				}
-				continue
-			}
-			if n == '*' {
-				s.consume()
-				s.consume()
-				for {
-					ch, ok := s.at(0)
-					if !ok {
-						return token{}, fmt.Errorf("unterminated block comment")
-					}
-					s.consume()
-					if ch == '*' {
-						if nn, _ := s.at(0); nn == '/' {
-							s.consume()
-							break
-						}
-					}
-				}
-				continue
-			}
-		}
-		break
+	if err := s.skipWhitespaceAndComments(); err != nil {
+		return token{}, err
 	}
 
 	c, ok := s.at(0)
@@ -128,16 +88,100 @@ func (s *scanner) next() (token, error) {
 
 	// Collapse consecutive newlines into a single tokNewline.
 	if c == '\n' {
-		for {
-			ch, ok := s.at(0)
-			if !ok || ch != '\n' {
-				break
-			}
-			s.consume()
-		}
+		s.skipNewlines()
 		return token{kind: tokNewline, line: line}, nil
 	}
 
+	return s.nextSymbolOrIdent(c, line)
+}
+
+// skipWhitespaceAndComments advances past horizontal whitespace and // and
+// /* */ comments. Newlines are NOT skipped — next emits them as tokNewline.
+func (s *scanner) skipWhitespaceAndComments() error {
+	for {
+		c, ok := s.at(0)
+		if !ok {
+			return nil
+		}
+		if c == ' ' || c == '\t' || c == '\r' {
+			s.consume()
+			continue
+		}
+		if c == '/' {
+			consumed, err := s.skipComment()
+			if err != nil {
+				return err
+			}
+			if consumed {
+				continue
+			}
+		}
+		return nil
+	}
+}
+
+// skipComment consumes a // or /* */ comment starting at the current
+// position (c == '/'), if any, and reports whether one was consumed.
+func (s *scanner) skipComment() (bool, error) {
+	switch n, _ := s.at(1); n {
+	case '/':
+		s.skipLineComment()
+		return true, nil
+	case '*':
+		if err := s.skipBlockComment(); err != nil {
+			return false, err
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// skipLineComment consumes to end of line (leaving \n for next call).
+func (s *scanner) skipLineComment() {
+	for {
+		ch, ok := s.at(0)
+		if !ok || ch == '\n' {
+			return
+		}
+		s.consume()
+	}
+}
+
+// skipBlockComment consumes a /* ... */ block comment starting at the
+// current position (the leading "/*").
+func (s *scanner) skipBlockComment() error {
+	s.consume()
+	s.consume()
+	for {
+		ch, ok := s.at(0)
+		if !ok {
+			return fmt.Errorf("unterminated block comment")
+		}
+		s.consume()
+		if ch == '*' {
+			if nn, _ := s.at(0); nn == '/' {
+				s.consume()
+				return nil
+			}
+		}
+	}
+}
+
+// skipNewlines consumes consecutive '\n' characters.
+func (s *scanner) skipNewlines() {
+	for {
+		ch, ok := s.at(0)
+		if !ok || ch != '\n' {
+			return
+		}
+		s.consume()
+	}
+}
+
+// nextSymbolOrIdent scans the next symbol, string, or identifier token,
+// given the already-peeked lookahead character c at line.
+func (s *scanner) nextSymbolOrIdent(c rune, line int) (token, error) {
 	switch {
 	case c == '{':
 		s.consume()
@@ -342,11 +386,7 @@ func (p *dslParser) parseOneStmt() (*stmt, error) {
 	if tok.kind == tokArrow {
 		p.advance()
 		to := p.advance()
-		s := &stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, isRel: true, relTo: to.val, args: p.collectArgs()})
 	}
 
 	if tok.kind == tokLBrace {
@@ -367,28 +407,25 @@ func (p *dslParser) parseOneStmt() (*stmt, error) {
 	case tokAssign:
 		p.advance()
 		kw := p.advance()
-		s := &stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, varName: tok.val, keyword: kw.val, args: p.collectArgs()})
 
 	case tokArrow:
 		p.advance()
 		to := p.advance()
-		s := &stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, isRel: true, relFrom: tok.val, relTo: to.val, args: p.collectArgs()})
 
 	default:
-		s := &stmt{line: line, keyword: tok.val, args: p.collectArgs()}
-		if err := p.optBlock(s); err != nil {
-			return nil, err
-		}
-		return s, nil
+		return p.finishStmt(&stmt{line: line, keyword: tok.val, args: p.collectArgs()})
 	}
+}
+
+// finishStmt parses s's optional trailing "{ ... }" block, if present, and
+// returns s (or the error from parsing the block).
+func (p *dslParser) finishStmt(s *stmt) (*stmt, error) {
+	if err := p.optBlock(s); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 func (p *dslParser) collectArgs() []string {
@@ -482,15 +519,7 @@ func (is *importState) processModelStmts(stmts []stmt, parentPath, parentVar str
 
 func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	if s.isRel {
-		from := s.relFrom
-		if from == "" {
-			from = parentVar
-		}
-		label := ""
-		if len(s.args) > 0 {
-			label = s.args[0]
-		}
-		is.pendingRels = append(is.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+		is.addPendingRel(s, parentVar)
 		return
 	}
 
@@ -505,22 +534,59 @@ func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, de
 
 	is.registerKind(s.keyword)
 
-	key := s.varName
-	if key == "" {
-		if len(s.args) > 0 {
-			key = slugify(s.args[0])
-		} else {
-			key = kd.kind
-		}
-		is.warnings = append(is.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
-	}
-
+	key := is.resolveElementKey(s, kd)
 	path := key
 	if parentPath != "" {
 		path = parentPath + "." + key
 	}
 	is.varToPath[key] = path
 
+	el := buildElementFromStmt(s, kd)
+
+	children := make(map[string]model.Element)
+	for _, child := range s.body {
+		is.processModelChild(child, path, key, &el, children)
+	}
+	if len(children) > 0 {
+		el.Children = children
+	}
+	dest[key] = el
+}
+
+// addPendingRel records a relationship statement for later resolution once
+// all elements have been discovered, defaulting its source to parentVar
+// when the statement omitted an explicit source (e.g. a nested "-> b" inside
+// element a's body).
+func (is *importState) addPendingRel(s stmt, parentVar string) {
+	from := s.relFrom
+	if from == "" {
+		from = parentVar
+	}
+	label := ""
+	if len(s.args) > 0 {
+		label = s.args[0]
+	}
+	is.pendingRels = append(is.pendingRels, pendingRel{from: from, to: s.relTo, label: label, line: s.line})
+}
+
+// resolveElementKey returns s's variable name, or a slugified fallback
+// derived from its title (or kind if untitled), warning when no variable
+// name was given in the DSL.
+func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
+	if s.varName != "" {
+		return s.varName
+	}
+	key := kd.kind
+	if len(s.args) > 0 {
+		key = slugify(s.args[0])
+	}
+	is.warnings = append(is.warnings, fmt.Sprintf("line %d: element has no variable name, using %q", s.line, key))
+	return key
+}
+
+// buildElementFromStmt constructs the base model.Element from s's title,
+// description, and (for containers/components) technology arguments.
+func buildElementFromStmt(s stmt, kd kindDef) model.Element {
 	el := model.Element{Kind: kd.kind}
 	if len(s.args) > 0 {
 		el.Title = s.args[0]
@@ -531,47 +597,32 @@ func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, de
 	if (kd.kind == "container" || kd.kind == "component") && len(s.args) > 2 {
 		el.Technology = s.args[2]
 	}
+	return el
+}
 
-	children := make(map[string]model.Element)
-	for _, child := range s.body {
-		switch {
-		case child.isRel:
-			from := child.relFrom
-			if from == "" {
-				from = key
-			}
-			label := ""
-			if len(child.args) > 0 {
-				label = child.args[0]
-			}
-			is.pendingRels = append(is.pendingRels, pendingRel{from: from, to: child.relTo, label: label, line: child.line})
-		case structurizrKindMap[child.keyword].kind != "":
-			is.processModelStmt(child, path, key, children)
-		case child.keyword == "description" && len(child.args) > 0:
-			el.Description = child.args[0]
-		case child.keyword == "technology" && len(child.args) > 0:
-			el.Technology = child.args[0]
-		case child.keyword == "tags":
-			el.Tags = child.args
-		case child.keyword == "properties":
-			el.Metadata = parseProperties(child.body)
-		}
+// processModelChild applies a single child statement of an element's body:
+// a nested relationship, a nested element, or one of the description/
+// technology/tags/properties fields.
+func (is *importState) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
+	switch {
+	case child.isRel:
+		is.addPendingRel(child, key)
+	case structurizrKindMap[child.keyword].kind != "":
+		is.processModelStmt(child, path, key, children)
+	case child.keyword == "description" && len(child.args) > 0:
+		el.Description = child.args[0]
+	case child.keyword == "technology" && len(child.args) > 0:
+		el.Technology = child.args[0]
+	case child.keyword == "tags":
+		el.Tags = child.args
+	case child.keyword == "properties":
+		el.Metadata = parseProperties(child.body)
 	}
-
-	if len(children) > 0 {
-		el.Children = children
-	}
-	dest[key] = el
 }
 
 func (is *importState) processViewsStmts(stmts []stmt) {
 	for _, s := range stmts {
-		switch s.keyword {
-		case "systemContext", "container", "component", "systemLandscape":
-		case "filtered", "dynamic", "deployment":
-			is.warnings = append(is.warnings, fmt.Sprintf("line %d: %s view not supported, skipped", s.line, s.keyword))
-			continue
-		default:
+		if !is.isSupportedViewKeyword(s) {
 			continue
 		}
 
@@ -586,85 +637,125 @@ func (is *importState) processViewsStmts(stmts []stmt) {
 		}
 		title := strings.Join(titleArgs, " ")
 
-		baseKey := s.keyword
-		if scope != "" {
-			baseKey = scope
-		}
-		viewKey := baseKey
-		if is.viewKeys[baseKey] > 0 {
-			viewKey = fmt.Sprintf("%s_%d", baseKey, is.viewKeys[baseKey])
-		}
-		is.viewKeys[baseKey]++
-
+		viewKey := is.nextViewKey(s.keyword, scope)
 		if title == "" {
 			title = viewKey
 		}
 
 		v := model.View{Title: title, Scope: scope, Include: []string{"*"}}
-
-		for _, bs := range s.body {
-			switch bs.keyword {
-			case "include":
-				if len(bs.args) == 1 && bs.args[0] == "*" {
-					v.Include = []string{"*"}
-				} else {
-					v.Include = nil
-					for _, arg := range bs.args {
-						if arg != "*" {
-							v.Include = append(v.Include, is.resolveVar(arg))
-						} else {
-							v.Include = []string{"*"}
-							break
-						}
-					}
-				}
-			case "exclude":
-				for _, arg := range bs.args {
-					v.Exclude = append(v.Exclude, is.resolveVar(arg))
-				}
-			case "title":
-				if len(bs.args) > 0 {
-					v.Title = bs.args[0]
-				}
-			case "description":
-				if len(bs.args) > 0 {
-					v.Description = bs.args[0]
-				}
-			case "autoLayout":
-				// Structurizr's autoLayout has no direct Bausteinsicht equivalent
-				// (no direction-aware layout engine); map it to "layered", the
-				// closest match and Bausteinsicht's own default. "auto" is not
-				// a valid Layout value (see model.validate) and would fail
-				// validation on the very model this importer just wrote.
-				v.Layout = "layered"
-				if len(bs.args) > 0 {
-					is.warnings = append(is.warnings, fmt.Sprintf(
-						"line %d: view %q: autoLayout direction %q not preserved, mapped to layout: \"layered\"",
-						bs.line, viewKey, strings.Join(bs.args, " ")))
-				}
-			}
-		}
-
-		// Structurizr's "include *" on a scoped view means all elements visible
-		// in that scope, but Bausteinsicht's "*" pattern only matches top-level
-		// IDs (no dots). Expand the pattern to explicitly include scope children
-		// so containers/components are placed inside their boundary.
-		if scope != "" && len(v.Include) == 1 && v.Include[0] == "*" {
-			switch s.keyword {
-			case "container":
-				v.Include = []string{"*", scope + ".*"}
-			case "component":
-				parts := strings.Split(scope, ".")
-				if len(parts) > 1 {
-					parentScope := strings.Join(parts[:len(parts)-1], ".")
-					v.Include = []string{"*", parentScope + ".*", scope + ".*"}
-				} else {
-					v.Include = []string{"*", scope + ".*"}
-				}
-			}
-		}
+		is.applyViewBodyStmts(&v, s.body, viewKey)
+		expandScopeWildcardInclude(&v, s.keyword, scope)
 
 		is.views[viewKey] = v
+	}
+}
+
+// isSupportedViewKeyword reports whether s is a supported view statement,
+// warning and returning false for recognized-but-unsupported view types.
+func (is *importState) isSupportedViewKeyword(s stmt) bool {
+	switch s.keyword {
+	case "systemContext", "container", "component", "systemLandscape":
+		return true
+	case "filtered", "dynamic", "deployment":
+		is.warnings = append(is.warnings, fmt.Sprintf("line %d: %s view not supported, skipped", s.line, s.keyword))
+		return false
+	default:
+		return false
+	}
+}
+
+// nextViewKey computes a view's map key from its keyword/scope, deduplicating
+// repeated combinations with a numeric suffix.
+func (is *importState) nextViewKey(keyword, scope string) string {
+	baseKey := keyword
+	if scope != "" {
+		baseKey = scope
+	}
+	viewKey := baseKey
+	if is.viewKeys[baseKey] > 0 {
+		viewKey = fmt.Sprintf("%s_%d", baseKey, is.viewKeys[baseKey])
+	}
+	is.viewKeys[baseKey]++
+	return viewKey
+}
+
+// applyViewBodyStmts applies a view's body statements (include, exclude,
+// title, description, autoLayout) to v.
+func (is *importState) applyViewBodyStmts(v *model.View, body []stmt, viewKey string) {
+	for _, bs := range body {
+		switch bs.keyword {
+		case "include":
+			is.applyViewInclude(v, bs.args)
+		case "exclude":
+			for _, arg := range bs.args {
+				v.Exclude = append(v.Exclude, is.resolveVar(arg))
+			}
+		case "title":
+			if len(bs.args) > 0 {
+				v.Title = bs.args[0]
+			}
+		case "description":
+			if len(bs.args) > 0 {
+				v.Description = bs.args[0]
+			}
+		case "autoLayout":
+			is.applyAutoLayout(v, bs, viewKey)
+		}
+	}
+}
+
+// applyViewInclude sets v.Include from an "include" statement's arguments,
+// resolving variables and treating "*" as a wildcard that overrides any
+// prior explicit includes.
+func (is *importState) applyViewInclude(v *model.View, args []string) {
+	if len(args) == 1 && args[0] == "*" {
+		v.Include = []string{"*"}
+		return
+	}
+	v.Include = nil
+	for _, arg := range args {
+		if arg != "*" {
+			v.Include = append(v.Include, is.resolveVar(arg))
+			continue
+		}
+		v.Include = []string{"*"}
+		return
+	}
+}
+
+// applyAutoLayout maps Structurizr's autoLayout to Bausteinsicht's "layered"
+// layout, since there is no direct equivalent (no direction-aware layout
+// engine); "layered" is the closest match and Bausteinsicht's own default.
+// "auto" is not a valid Layout value (see model.validate) and would fail
+// validation on the very model this importer just wrote.
+func (is *importState) applyAutoLayout(v *model.View, bs stmt, viewKey string) {
+	v.Layout = "layered"
+	if len(bs.args) > 0 {
+		is.warnings = append(is.warnings, fmt.Sprintf(
+			"line %d: view %q: autoLayout direction %q not preserved, mapped to layout: \"layered\"",
+			bs.line, viewKey, strings.Join(bs.args, " ")))
+	}
+}
+
+// expandScopeWildcardInclude expands a scoped view's "include *" pattern to
+// explicitly include scope children, since Bausteinsicht's "*" only matches
+// top-level IDs (no dots) while Structurizr's "include *" on a scoped view
+// means all elements visible in that scope.
+func expandScopeWildcardInclude(v *model.View, keyword, scope string) {
+	if scope == "" || len(v.Include) != 1 || v.Include[0] != "*" {
+		return
+	}
+	switch keyword {
+	case "container":
+		v.Include = []string{"*", scope + ".*"}
+	case "component":
+		parts := strings.Split(scope, ".")
+		if len(parts) > 1 {
+			parentScope := strings.Join(parts[:len(parts)-1], ".")
+			v.Include = []string{"*", parentScope + ".*", scope + ".*"}
+		} else {
+			v.Include = []string{"*", scope + ".*"}
+		}
 	}
 }
 
@@ -743,52 +834,56 @@ func resolveIncludes(src, baseDir string, visited map[string]bool) (string, []st
 	absDirBase, _ := filepath.Abs(baseDir)
 	for _, line := range strings.Split(src, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "!include ") {
-			includePath := strings.TrimSpace(trimmed[len("!include "):])
-			if strings.HasPrefix(includePath, "http://") || strings.HasPrefix(includePath, "https://") {
-				warnings = append(warnings, "!include: HTTP includes not supported, skipped: "+includePath)
-				out.WriteByte('\n')
-				continue
-			}
-			cleanedPath := filepath.Clean(includePath)
-			fullPath := filepath.Join(baseDir, cleanedPath)
-			absFullPath, _ := filepath.Abs(fullPath)
-
-			// Verify that the resolved path is within baseDir (prevent path traversal).
-			// Use filepath.Rel to check if the path escapes the base directory via .. sequences.
-			relPath, err := filepath.Rel(absDirBase, absFullPath)
-			if err != nil || strings.HasPrefix(relPath, "..") {
-				warnings = append(warnings, "!include: path traversal rejected: "+includePath)
-				out.WriteByte('\n')
-				continue
-			}
-
-			if visited[absFullPath] {
-				warnings = append(warnings, "!include: circular include ignored: "+includePath)
-				out.WriteByte('\n')
-				continue
-			}
-			data, err := os.ReadFile(absFullPath)
-			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("!include: cannot read %s: %v", includePath, err))
-				out.WriteByte('\n')
-				continue
-			}
-			newVisited := make(map[string]bool, len(visited)+1)
-			for k, v := range visited {
-				newVisited[k] = v
-			}
-			newVisited[absFullPath] = true
-			included, w := resolveIncludes(string(data), filepath.Dir(absFullPath), newVisited)
-			warnings = append(warnings, w...)
-			out.WriteString(included)
+		if !strings.HasPrefix(trimmed, "!include ") {
+			out.WriteString(line)
 			out.WriteByte('\n')
 			continue
 		}
-		out.WriteString(line)
+		includePath := strings.TrimSpace(trimmed[len("!include "):])
+		content, w := resolveOneInclude(includePath, baseDir, absDirBase, visited)
+		warnings = append(warnings, w...)
+		out.WriteString(content)
 		out.WriteByte('\n')
 	}
 	return out.String(), warnings
+}
+
+// resolveOneInclude resolves a single "!include <path>" directive, returning
+// its expanded content (recursively resolving nested includes) — or an
+// empty string plus a single warning if the include could not be honored
+// (HTTP URL, path traversal, circular include, or unreadable file).
+func resolveOneInclude(includePath, baseDir, absDirBase string, visited map[string]bool) (content string, warnings []string) {
+	if strings.HasPrefix(includePath, "http://") || strings.HasPrefix(includePath, "https://") {
+		return "", []string{"!include: HTTP includes not supported, skipped: " + includePath}
+	}
+
+	cleanedPath := filepath.Clean(includePath)
+	fullPath := filepath.Join(baseDir, cleanedPath)
+	absFullPath, _ := filepath.Abs(fullPath)
+
+	// Verify that the resolved path is within baseDir (prevent path traversal).
+	// Use filepath.Rel to check if the path escapes the base directory via .. sequences.
+	relPath, err := filepath.Rel(absDirBase, absFullPath)
+	if err != nil || strings.HasPrefix(relPath, "..") {
+		return "", []string{"!include: path traversal rejected: " + includePath}
+	}
+
+	if visited[absFullPath] {
+		return "", []string{"!include: circular include ignored: " + includePath}
+	}
+
+	data, err := os.ReadFile(absFullPath)
+	if err != nil {
+		return "", []string{fmt.Sprintf("!include: cannot read %s: %v", includePath, err)}
+	}
+
+	newVisited := make(map[string]bool, len(visited)+1)
+	for k, v := range visited {
+		newVisited[k] = v
+	}
+	newVisited[absFullPath] = true
+
+	return resolveIncludes(string(data), filepath.Dir(absFullPath), newVisited)
 }
 
 func importSource(src string) (*importer.ImportResult, error) {
@@ -805,7 +900,22 @@ func importSource(src string) (*importer.ImportResult, error) {
 
 	is := newImportState()
 
-	var modelStmts, viewsStmts []stmt
+	modelStmts, viewsStmts := extractModelAndViewsStmts(stmts)
+	is.processModelStmts(modelStmts, "", "", is.elements)
+	if len(viewsStmts) > 0 {
+		is.processViewsStmts(viewsStmts)
+	}
+
+	rels := is.buildRelationships()
+	m := is.buildResultModel(rels)
+
+	return &importer.ImportResult{Model: m, Warnings: is.warnings}, nil
+}
+
+// extractModelAndViewsStmts finds the top-level "model" and "views" blocks
+// among stmts, which may either be nested inside a "workspace" block or
+// appear directly at the top level.
+func extractModelAndViewsStmts(stmts []stmt) (modelStmts, viewsStmts []stmt) {
 	for _, s := range stmts {
 		switch s.keyword {
 		case "workspace":
@@ -823,14 +933,12 @@ func importSource(src string) (*importer.ImportResult, error) {
 			viewsStmts = s.body
 		}
 	}
+	return modelStmts, viewsStmts
+}
 
-	is.processModelStmts(modelStmts, "", "", is.elements)
-	if len(viewsStmts) > 0 {
-		is.processViewsStmts(viewsStmts)
-	}
-
-	rels := is.buildRelationships()
-
+// buildResultModel assembles the final BausteinsichtModel from accumulated
+// import state and resolved relationships.
+func (is *importState) buildResultModel(rels []model.Relationship) *model.BausteinsichtModel {
 	spec := model.Specification{Elements: make(map[string]model.ElementKind)}
 	for _, kd := range elementKindOrder {
 		if ek, ok := is.spec[kd.kind]; ok {
@@ -851,6 +959,5 @@ func importSource(src string) (*importer.ImportResult, error) {
 	if m.Views == nil {
 		m.Views = make(map[string]model.View)
 	}
-
-	return &importer.ImportResult{Model: m, Warnings: is.warnings}, nil
+	return m
 }

--- a/internal/importer/structurizr/structurizr.go
+++ b/internal/importer/structurizr/structurizr.go
@@ -20,25 +20,7 @@ import (
 // grammar live in internal/importer/dsl; only the language-specific token
 // and statement dispatch stay here.
 
-type (
-	token     = dsl.Token
-	stmt      = dsl.Stmt
-	scanner   = dsl.Scanner
-	dslParser = dsl.Parser
-)
-
-const (
-	tokEOF     = dsl.EOF
-	tokNewline = dsl.Newline
-	tokString  = dsl.String
-	tokIdent   = dsl.Ident
-	tokLBrace  = dsl.LBrace
-	tokRBrace  = dsl.RBrace
-	tokAssign  = dsl.Assign
-	tokArrow   = dsl.Arrow
-)
-
-func tokenize(src string) ([]token, error) {
+func tokenize(src string) ([]dsl.Token, error) {
 	return dsl.Tokenize(src, identStart, scanIdent)
 }
 
@@ -49,16 +31,16 @@ func identStart(c rune) bool {
 	return c == '*' || c == '!' || unicode.IsLetter(c) || c == '_'
 }
 
-func scanIdent(s *scanner, line int) (token, error) {
+func scanIdent(s *dsl.Scanner, line int) (dsl.Token, error) {
 	if c, _ := s.At(0); c == '*' {
 		// Consume one or two '*' and return as a single identifier token
 		// so that "include *" and "include **" are parsed correctly.
 		s.Consume()
 		if n, _ := s.At(0); n == '*' {
 			s.Consume()
-			return token{Kind: tokIdent, Val: "**", Line: line}, nil
+			return dsl.Token{Kind: dsl.Ident, Val: "**", Line: line}, nil
 		}
-		return token{Kind: tokIdent, Val: "*", Line: line}, nil
+		return dsl.Token{Kind: dsl.Ident, Val: "*", Line: line}, nil
 	}
 
 	var sb strings.Builder
@@ -66,7 +48,7 @@ func scanIdent(s *scanner, line int) (token, error) {
 		sb.WriteRune(s.Consume())
 	}
 	dsl.ScanIdentBody(s, &sb)
-	return token{Kind: tokIdent, Val: sb.String(), Line: line}, nil
+	return dsl.Token{Kind: dsl.Ident, Val: sb.String(), Line: line}, nil
 }
 
 // ─── Parser ──────────────────────────────────────────────────────────────────
@@ -145,13 +127,13 @@ func (is *importState) resolveVar(v string) string {
 	return v
 }
 
-func (is *importState) processModelStmts(stmts []stmt, parentPath, parentVar string, dest map[string]model.Element) {
+func (is *importState) processModelStmts(stmts []dsl.Stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	for _, s := range stmts {
 		is.processModelStmt(s, parentPath, parentVar, dest)
 	}
 }
 
-func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, dest map[string]model.Element) {
+func (is *importState) processModelStmt(s dsl.Stmt, parentPath, parentVar string, dest map[string]model.Element) {
 	if s.IsRel {
 		is.addPendingRel(s, parentVar)
 		return
@@ -191,7 +173,7 @@ func (is *importState) processModelStmt(s stmt, parentPath, parentVar string, de
 // all elements have been discovered, defaulting its source to parentVar
 // when the statement omitted an explicit source (e.g. a nested "-> b" inside
 // element a's body).
-func (is *importState) addPendingRel(s stmt, parentVar string) {
+func (is *importState) addPendingRel(s dsl.Stmt, parentVar string) {
 	from := s.RelFrom
 	if from == "" {
 		from = parentVar
@@ -206,7 +188,7 @@ func (is *importState) addPendingRel(s stmt, parentVar string) {
 // resolveElementKey returns s's variable name, or a slugified fallback
 // derived from its title (or kind if untitled), warning when no variable
 // name was given in the DSL.
-func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
+func (is *importState) resolveElementKey(s dsl.Stmt, kd kindDef) string {
 	if s.VarName != "" {
 		return s.VarName
 	}
@@ -220,7 +202,7 @@ func (is *importState) resolveElementKey(s stmt, kd kindDef) string {
 
 // buildElementFromStmt constructs the base model.Element from s's title,
 // description, and (for containers/components) technology arguments.
-func buildElementFromStmt(s stmt, kd kindDef) model.Element {
+func buildElementFromStmt(s dsl.Stmt, kd kindDef) model.Element {
 	el := model.Element{Kind: kd.kind}
 	if len(s.Args) > 0 {
 		el.Title = s.Args[0]
@@ -237,7 +219,7 @@ func buildElementFromStmt(s stmt, kd kindDef) model.Element {
 // processModelChild applies a single child statement of an element's body:
 // a nested relationship, a nested element, or one of the description/
 // technology/tags/properties fields.
-func (is *importState) processModelChild(child stmt, path, key string, el *model.Element, children map[string]model.Element) {
+func (is *importState) processModelChild(child dsl.Stmt, path, key string, el *model.Element, children map[string]model.Element) {
 	switch {
 	case child.IsRel:
 		is.addPendingRel(child, key)
@@ -254,7 +236,7 @@ func (is *importState) processModelChild(child stmt, path, key string, el *model
 	}
 }
 
-func (is *importState) processViewsStmts(stmts []stmt) {
+func (is *importState) processViewsStmts(stmts []dsl.Stmt) {
 	for _, s := range stmts {
 		if !is.isSupportedViewKeyword(s) {
 			continue
@@ -286,7 +268,7 @@ func (is *importState) processViewsStmts(stmts []stmt) {
 
 // isSupportedViewKeyword reports whether s is a supported view statement,
 // warning and returning false for recognized-but-unsupported view types.
-func (is *importState) isSupportedViewKeyword(s stmt) bool {
+func (is *importState) isSupportedViewKeyword(s dsl.Stmt) bool {
 	switch s.Keyword {
 	case "systemContext", "container", "component", "systemLandscape":
 		return true
@@ -315,7 +297,7 @@ func (is *importState) nextViewKey(keyword, scope string) string {
 
 // applyViewBodyStmts applies a view's body statements (include, exclude,
 // title, description, autoLayout) to v.
-func (is *importState) applyViewBodyStmts(v *model.View, body []stmt, viewKey string) {
+func (is *importState) applyViewBodyStmts(v *model.View, body []dsl.Stmt, viewKey string) {
 	for _, bs := range body {
 		switch bs.Keyword {
 		case "include":
@@ -362,7 +344,7 @@ func (is *importState) applyViewInclude(v *model.View, args []string) {
 // engine); "layered" is the closest match and Bausteinsicht's own default.
 // "auto" is not a valid Layout value (see model.validate) and would fail
 // validation on the very model this importer just wrote.
-func (is *importState) applyAutoLayout(v *model.View, bs stmt, viewKey string) {
+func (is *importState) applyAutoLayout(v *model.View, bs dsl.Stmt, viewKey string) {
 	v.Layout = "layered"
 	if len(bs.Args) > 0 {
 		is.warnings = append(is.warnings, fmt.Sprintf(
@@ -407,7 +389,7 @@ func (is *importState) buildRelationships() []model.Relationship {
 	return rels
 }
 
-func parseProperties(body []stmt) map[string]string {
+func parseProperties(body []dsl.Stmt) map[string]string {
 	m := make(map[string]string)
 	for _, s := range body {
 		if s.Keyword != "" && len(s.Args) > 0 {
@@ -506,7 +488,7 @@ func importSource(src string) (*importer.ImportResult, error) {
 		return nil, fmt.Errorf("tokenize: %w", err)
 	}
 
-	p := &dslParser{Toks: toks}
+	p := &dsl.Parser{Toks: toks}
 	stmts, err := dsl.ParseAllStmts(p)
 	if err != nil {
 		return nil, fmt.Errorf("parse: %w", err)
@@ -529,7 +511,7 @@ func importSource(src string) (*importer.ImportResult, error) {
 // extractModelAndViewsStmts finds the top-level "model" and "views" blocks
 // among stmts, which may either be nested inside a "workspace" block or
 // appear directly at the top level.
-func extractModelAndViewsStmts(stmts []stmt) (modelStmts, viewsStmts []stmt) {
+func extractModelAndViewsStmts(stmts []dsl.Stmt) (modelStmts, viewsStmts []dsl.Stmt) {
 	for _, s := range stmts {
 		switch s.Keyword {
 		case "workspace":

--- a/internal/importer/xmi/xmi.go
+++ b/internal/importer/xmi/xmi.go
@@ -204,41 +204,49 @@ func parseElem(dec *xml.Decoder, se xml.StartElement, depth int) (*xmiElem, erro
 		}
 		switch t := tok.(type) {
 		case xml.StartElement:
-			// xmi:Extension wraps EA-specific data; extract stereotype, then skip the block
-			if t.Name.Local == "Extension" {
-				stereo, err := extractStereotype(dec)
-				if err != nil {
-					return nil, err
-				}
-				if stereo != "" && e.Stereotype == "" {
-					e.Stereotype = stereo
-				}
-				continue
-			}
-			// Direct stereotype element (outside Extension, less common)
-			if t.Name.Local == "stereotype" {
-				// EA XMI 2.1 uses stereotype="…"; other tools use name="…"
-				name := attrVal(t.Attr, "name")
-				if name == "" {
-					name = attrVal(t.Attr, "stereotype")
-				}
-				if name != "" && e.Stereotype == "" {
-					e.Stereotype = name
-				}
-				if err := dec.Skip(); err != nil {
-					return nil, err
-				}
-				continue
-			}
-			child, err := parseElem(dec, t, depth+1)
-			if err != nil {
+			if err := handleElemStartElement(dec, e, t, depth); err != nil {
 				return nil, err
 			}
-			e.Children = append(e.Children, child)
 		case xml.EndElement:
 			return e, nil
 		}
 	}
+}
+
+// handleElemStartElement processes a single child StartElement token within
+// parseElem's loop: an Extension or stereotype tag sets e.Stereotype and is
+// otherwise skipped; anything else is recursively parsed as a child element
+// and appended to e.Children.
+func handleElemStartElement(dec *xml.Decoder, e *xmiElem, t xml.StartElement, depth int) error {
+	// xmi:Extension wraps EA-specific data; extract stereotype, then skip the block
+	if t.Name.Local == "Extension" {
+		stereo, err := extractStereotype(dec)
+		if err != nil {
+			return err
+		}
+		if stereo != "" && e.Stereotype == "" {
+			e.Stereotype = stereo
+		}
+		return nil
+	}
+	// Direct stereotype element (outside Extension, less common)
+	if t.Name.Local == "stereotype" {
+		// EA XMI 2.1 uses stereotype="…"; other tools use name="…"
+		name := attrVal(t.Attr, "name")
+		if name == "" {
+			name = attrVal(t.Attr, "stereotype")
+		}
+		if name != "" && e.Stereotype == "" {
+			e.Stereotype = name
+		}
+		return dec.Skip()
+	}
+	child, err := parseElem(dec, t, depth+1)
+	if err != nil {
+		return err
+	}
+	e.Children = append(e.Children, child)
+	return nil
 }
 
 // extractStereotype reads the content of an already-opened xmi:Extension element
@@ -254,11 +262,8 @@ func extractStereotype(dec *xml.Decoder) (string, error) {
 		switch t := tok.(type) {
 		case xml.StartElement:
 			depth++
-			if t.Name.Local == "stereotype" && stereo == "" {
-				stereo = attrVal(t.Attr, "name")
-				if stereo == "" {
-					stereo = attrVal(t.Attr, "stereotype") // EA XMI 2.1 variant
-				}
+			if stereo == "" {
+				stereo = stereotypeAttr(t)
 			}
 		case xml.EndElement:
 			if depth == 0 {
@@ -267,6 +272,19 @@ func extractStereotype(dec *xml.Decoder) (string, error) {
 			depth--
 		}
 	}
+}
+
+// stereotypeAttr returns t's stereotype name if t is a "stereotype" element,
+// checking both the "name" attribute and the EA XMI 2.1 "stereotype" variant.
+// Returns "" if t is not a stereotype element or has neither attribute.
+func stereotypeAttr(t xml.StartElement) string {
+	if t.Name.Local != "stereotype" {
+		return ""
+	}
+	if name := attrVal(t.Attr, "name"); name != "" {
+		return name
+	}
+	return attrVal(t.Attr, "stereotype")
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -421,11 +439,7 @@ func (s *convState) collectElem(
 	}
 
 	// Add kind to specification if new
-	if _, exists := bsModel.Specification.Elements[kind]; !exists {
-		bsModel.Specification.Elements[kind] = model.ElementKind{
-			Notation: titleCase(kind),
-		}
-	}
+	s.registerSpecKind(bsModel, kind)
 
 	// Build element
 	elem := model.Element{
@@ -440,11 +454,7 @@ func (s *convState) collectElem(
 	}
 	if len(childMap) > 0 {
 		elem.Children = childMap
-		// Mark this kind as a container in the specification — derived from the XMI hierarchy.
-		if ks, ok := bsModel.Specification.Elements[kind]; ok && !ks.Container {
-			ks.Container = true
-			bsModel.Specification.Elements[kind] = ks
-		}
+		markSpecKindAsContainer(bsModel, kind)
 	}
 
 	// Store in target map with local key only
@@ -453,6 +463,25 @@ func (s *convState) collectElem(
 		mapKey = bsPath[len(parentPath)+1:]
 	}
 	target[mapKey] = elem
+}
+
+// registerSpecKind adds kind to the specification if it hasn't been seen yet.
+func (s *convState) registerSpecKind(bsModel *model.BausteinsichtModel, kind string) {
+	if _, exists := bsModel.Specification.Elements[kind]; !exists {
+		bsModel.Specification.Elements[kind] = model.ElementKind{
+			Notation: titleCase(kind),
+		}
+	}
+}
+
+// markSpecKindAsContainer marks kind as a container in the specification —
+// derived from the XMI hierarchy (an element of this kind was found to have
+// children).
+func markSpecKindAsContainer(bsModel *model.BausteinsichtModel, kind string) {
+	if ks, ok := bsModel.Specification.Elements[kind]; ok && !ks.Container {
+		ks.Container = true
+		bsModel.Specification.Elements[kind] = ks
+	}
 }
 
 // collectRel converts one XMI relationship to a Bausteinsicht Relationship.


### PR DESCRIPTION
## Summary
- Cognitive Complexity batch 3 of #585 (SonarCloud go:S3776): `internal/importer/{structurizr,likec4,xmi}`.
- Split the 14 flagged functions across the three importer packages into smaller, single-purpose helpers. Worst offenders: `scanner.next` in both DSL tokenizers (58/56), `processViewsStmts`/`processViews` (62/50), `parseElem` (38).
- `structurizr` and `likec4` share near-identical hand-written tokenizer and recursive-descent parser architectures, so several extractions mirror each other across the two packages (`skipWhitespaceAndComments`/`skipComment`/`skipLineComment`/`skipBlockComment`/`skipNewlines`, `finishStmt`, `resolveElementKey`, `processModelChild`, `addPendingRel`).
- **Purely structural — no logic changes.** Conditional logic preserved exactly; a few nested `if`/`switch` chains became early-return helper functions (behaviorally identical, verified by inspection and tests).

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green (including XMI's synthetic big-data and charset edge-case tests)
- [x] `gofmt` clean
- [x] `gocognit -over 15` on all three files — zero findings (was 6/4/3)
- [x] Per-package coverage essentially unchanged: likec4 70.7%→69.1%, structurizr 71.4%→74.1%, xmi 86.6%→87.4%

## Notes
- Per CLAUDE.md's Quality Gate Override Policy: qualifies for admin merge if the SonarCloud new-code coverage gate trips despite no new logic — all functional CI green, behavior-preserving refactor only, noted here per policy.