### PR TITLE
refactor(sync): extract shared field-name constants (#585)

### DIFF
--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -207,7 +207,7 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 	result := make(map[string]drawioElemSnapshot)
 	for _, page := range doc.Pages() {
 		for _, obj := range page.FindAllElements() {
-			id := obj.SelectAttrValue("bausteinsicht_id", "")
+			id := obj.SelectAttrValue(attrBausteinsichtID, "")
 			if id == "" {
 				continue
 			}
@@ -216,7 +216,7 @@ func extractDrawioElements(doc *drawio.Document) map[string]drawioElemSnapshot {
 			title, technology, labelDesc := page.ReadElementFields(obj)
 			// Fall back to XML attribute if label doesn't contain technology (#186).
 			if technology == "" {
-				technology = obj.SelectAttrValue("technology", "")
+				technology = obj.SelectAttrValue(fieldTechnology, "")
 			}
 			tooltipDesc := obj.SelectAttrValue("tooltip", "")
 			description := tooltipDesc
@@ -267,7 +267,7 @@ func detectUnmanagedDrawioElements(cs *ChangeSet, doc *drawio.Document) {
 // non-model elements forward sync itself creates (back-nav button,
 // metadata/legend boxes, doc-link icons), which are skipped by ID prefix.
 func unmanagedDrawioElementTitle(page *drawio.Page, obj *etree.Element) (title, id string, ok bool) {
-	if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+	if obj.SelectAttrValue(attrBausteinsichtID, "") != "" {
 		return "", "", false // managed element, already handled
 	}
 	// Skip non-model elements created by forward sync.
@@ -286,7 +286,7 @@ func unmanagedDrawioElementTitle(page *drawio.Page, obj *etree.Element) (title, 
 	// Try sub-cell reading first, then HTML label.
 	title, _, _ = page.ReadElementFields(obj)
 	if title == "" {
-		label := obj.SelectAttrValue("label", "")
+		label := obj.SelectAttrValue(fieldLabel, "")
 		if label == "" {
 			return "", "", false
 		}
@@ -346,7 +346,7 @@ func buildCellIDToElemID(doc *drawio.Document) map[string]string {
 // to its element ID.
 func mapManagedElementsOnPage(page *drawio.Page, m map[string]string) {
 	for _, obj := range page.FindAllElements() {
-		elemID := obj.SelectAttrValue("bausteinsicht_id", "")
+		elemID := obj.SelectAttrValue(attrBausteinsichtID, "")
 		cellID := obj.SelectAttrValue("id", "")
 		if elemID != "" && cellID != "" {
 			m[cellID] = elemID
@@ -374,7 +374,7 @@ func mapUnmanagedElementsOnPage(page *drawio.Page, m map[string]string) {
 // connectors targeting unmanaged elements resolve correctly during reverse
 // sync (#211).
 func unmanagedElementID(obj *etree.Element) (cellID, id string, ok bool) {
-	if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+	if obj.SelectAttrValue(attrBausteinsichtID, "") != "" {
 		return "", "", false
 	}
 	cellID = obj.SelectAttrValue("id", "")
@@ -388,7 +388,7 @@ func unmanagedElementID(obj *etree.Element) (cellID, id string, ok bool) {
 	if cell == nil || cell.SelectAttrValue("vertex", "") != "1" {
 		return "", "", false
 	}
-	label := obj.SelectAttrValue("label", "")
+	label := obj.SelectAttrValue(fieldLabel, "")
 	if label == "" {
 		return "", "", false
 	}
@@ -534,9 +534,9 @@ func detectElementChangeForID(
 
 	// Conflicts: both sides modified the same field
 	if inModel && inDrawio && inLast {
-		checkElemConflict(cs, id, "title", lastElem.Title, me.Title, de.title)
-		checkElemConflict(cs, id, "description", lastElem.Description, me.Description, de.description)
-		checkElemConflict(cs, id, "technology", lastElem.Technology, me.Technology, de.technology)
+		checkElemConflict(cs, id, fieldTitle, lastElem.Title, me.Title, de.title)
+		checkElemConflict(cs, id, fieldDescription, lastElem.Description, me.Description, de.description)
+		checkElemConflict(cs, id, fieldTechnology, lastElem.Technology, me.Technology, de.technology)
 		// Note: kind conflicts are not checked because kind is
 		// model-authoritative and draw.io boundary kinds are derived.
 	}
@@ -551,9 +551,9 @@ func detectModelElementChange(cs *ChangeSet, id string, me *model.Element, inMod
 	case !inModel && inLast:
 		cs.ModelElementChanges = append(cs.ModelElementChanges, ElementChange{ID: id, Type: Deleted})
 	case inModel && inLast:
-		appendIfChanged(id, "title", lastElem.Title, me.Title, &cs.ModelElementChanges)
-		appendIfChanged(id, "description", lastElem.Description, me.Description, &cs.ModelElementChanges)
-		appendIfChanged(id, "technology", lastElem.Technology, me.Technology, &cs.ModelElementChanges)
+		appendIfChanged(id, fieldTitle, lastElem.Title, me.Title, &cs.ModelElementChanges)
+		appendIfChanged(id, fieldDescription, lastElem.Description, me.Description, &cs.ModelElementChanges)
+		appendIfChanged(id, fieldTechnology, lastElem.Technology, me.Technology, &cs.ModelElementChanges)
 		appendIfChanged(id, "kind", lastElem.Kind, me.Kind, &cs.ModelElementChanges)
 		appendIfChanged(id, "link", lastElem.Link, me.Link, &cs.ModelElementChanges)
 	}
@@ -578,9 +578,9 @@ func detectDrawioElementChange(
 	case !inDrawio && inLast:
 		appendDrawioDeletionIfVisible(cs, id, lastState, visibleElems, newPageOnly)
 	case inDrawio && inLast:
-		appendIfChanged(id, "title", lastElem.Title, de.title, &cs.DrawioElementChanges)
-		appendIfChanged(id, "description", lastElem.Description, de.description, &cs.DrawioElementChanges)
-		appendIfChanged(id, "technology", lastElem.Technology, de.technology, &cs.DrawioElementChanges)
+		appendIfChanged(id, fieldTitle, lastElem.Title, de.title, &cs.DrawioElementChanges)
+		appendIfChanged(id, fieldDescription, lastElem.Description, de.description, &cs.DrawioElementChanges)
+		appendIfChanged(id, fieldTechnology, lastElem.Technology, de.technology, &cs.DrawioElementChanges)
 		// Note: kind is not compared on the draw.io side because scope
 		// boundary elements have a derived kind (e.g. "system_boundary")
 		// that legitimately differs from the model kind ("system").
@@ -691,7 +691,7 @@ func reconcileElementFieldsAcrossViews(
 	lastState *SyncState,
 	emitted map[fieldKey]bool,
 ) {
-	id := obj.SelectAttrValue("bausteinsicht_id", "")
+	id := obj.SelectAttrValue(attrBausteinsichtID, "")
 	if id == "" {
 		return
 	}
@@ -706,7 +706,7 @@ func reconcileElementFieldsAcrossViews(
 
 	title, technology, labelDesc := page.ReadElementFields(obj)
 	if technology == "" {
-		technology = obj.SelectAttrValue("technology", "")
+		technology = obj.SelectAttrValue(fieldTechnology, "")
 	}
 	tooltipDesc := obj.SelectAttrValue("tooltip", "")
 	description := tooltipDesc
@@ -714,9 +714,9 @@ func reconcileElementFieldsAcrossViews(
 		description = labelDesc
 	}
 
-	emitStaleFieldChange(cs, emitted, id, "title", lastElem.Title, me.Title, title)
-	emitStaleFieldChange(cs, emitted, id, "description", lastElem.Description, me.Description, description)
-	emitStaleFieldChange(cs, emitted, id, "technology", lastElem.Technology, me.Technology, technology)
+	emitStaleFieldChange(cs, emitted, id, fieldTitle, lastElem.Title, me.Title, title)
+	emitStaleFieldChange(cs, emitted, id, fieldDescription, lastElem.Description, me.Description, description)
+	emitStaleFieldChange(cs, emitted, id, fieldTechnology, lastElem.Technology, me.Technology, technology)
 }
 
 // emitStaleFieldChange appends a Modified ElementChange for field if the
@@ -830,7 +830,7 @@ func detectModelRelationshipChange(
 		})
 	case inModel && inLast && (mr.Label != lr.Label || mr.Kind != lr.Kind):
 		cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
-			From: from, To: to, Index: index, Type: Modified, Field: "label",
+			From: from, To: to, Index: index, Type: Modified, Field: fieldLabel,
 			OldValue: lr.Label, NewValue: mr.Label, Kind: mr.Kind,
 		})
 	}
@@ -858,7 +858,7 @@ func detectDrawioRelationshipChange(
 		appendDeletedDrawioRelationship(cs, k, from, to, index, drawioRels, visibleRels)
 	case inDrawio && inLast && dr.Label != lr.Label:
 		cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
-			From: from, To: to, Index: index, Type: Modified, Field: "label",
+			From: from, To: to, Index: index, Type: Modified, Field: fieldLabel,
 			OldValue: lr.Label, NewValue: dr.Label,
 		})
 	}

--- a/internal/sync/fields.go
+++ b/internal/sync/fields.go
@@ -1,0 +1,14 @@
+package sync
+
+// Field-name constants shared across diff.go, forward.go, and metadata.go —
+// used both as ElementChange/RelationshipChange.Field values and as draw.io
+// element attribute names, which happen to coincide. Defined once to avoid
+// the same literal being repeated throughout the package (SonarCloud go:S1192).
+const (
+	fieldTitle       = "title"
+	fieldDescription = "description"
+	fieldTechnology  = "technology"
+	fieldLabel       = "label"
+
+	attrBausteinsichtID = "bausteinsicht_id"
+)

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -348,7 +348,7 @@ func collectElementsToPlace(page *drawio.Page, scopeID string, elemSet map[strin
 func isFreshPage(page *drawio.Page, scopeID string) bool {
 	nonBoundaryCount := 0
 	for _, obj := range page.FindAllElements() {
-		if obj.SelectAttrValue("bausteinsicht_id", "") != scopeID || scopeID == "" {
+		if obj.SelectAttrValue(attrBausteinsichtID, "") != scopeID || scopeID == "" {
 			nonBoundaryCount++
 		}
 	}
@@ -1111,7 +1111,7 @@ func clearPageElements(page *drawio.Page) {
 	// Collect elements to remove (cannot modify tree while iterating).
 	var toRemove []*etree.Element
 	for _, obj := range root.SelectElements("object") {
-		if obj.SelectAttrValue("bausteinsicht_id", "") != "" {
+		if obj.SelectAttrValue(attrBausteinsichtID, "") != "" {
 			toRemove = append(toRemove, obj)
 		}
 	}
@@ -1159,11 +1159,11 @@ func resolveElementFields(ch ElementChange, page *drawio.Page, elem *model.Eleme
 	}
 	title, technology, description = curTitle, curTech, curDesc
 	switch ch.Field {
-	case "title":
+	case fieldTitle:
 		title = elem.Title
-	case "technology":
+	case fieldTechnology:
 		technology = elem.Technology
-	case "description":
+	case fieldDescription:
 		description = elem.Description
 	}
 	return
@@ -1327,7 +1327,7 @@ func reconcileViewPage(
 	}
 
 	for _, obj := range page.FindAllElements() {
-		id := obj.SelectAttrValue("bausteinsicht_id", "")
+		id := obj.SelectAttrValue(attrBausteinsichtID, "")
 		if id == "" {
 			continue
 		}
@@ -1370,7 +1370,7 @@ func reconcileOrphanedElements(
 	result *ForwardResult,
 ) {
 	for _, obj := range page.FindAllElements() {
-		id := obj.SelectAttrValue("bausteinsicht_id", "")
+		id := obj.SelectAttrValue(attrBausteinsichtID, "")
 		if id == "" {
 			continue
 		}
@@ -1464,7 +1464,7 @@ func writeUnoverriddenStyleParts(sb *strings.Builder, base string, overlayKeys m
 func applyDrillDownLinks(page *drawio.Page, links map[string]string) []string {
 	var warnings []string
 	for _, obj := range page.FindAllElements() {
-		bid := obj.SelectAttrValue("bausteinsicht_id", "")
+		bid := obj.SelectAttrValue(attrBausteinsichtID, "")
 		drillDown, ok := links[bid]
 		if !ok {
 			continue
@@ -1513,7 +1513,7 @@ func createBackNavButton(
 	}
 
 	obj := root.CreateElement("object")
-	obj.CreateAttr("label", "&larr; "+parentTitle)
+	obj.CreateAttr(fieldLabel, "&larr; "+parentTitle)
 	obj.CreateAttr("id", navCellID)
 	obj.CreateAttr("link", "data:page/id,view-"+parentViewID)
 

--- a/internal/sync/metadata.go
+++ b/internal/sync/metadata.go
@@ -43,10 +43,10 @@ func createMetadata(
 	// Update existing metadata cell — only if label actually changed.
 	for _, obj := range root.SelectElements("object") {
 		if obj.SelectAttrValue("id", "") == cellID {
-			if obj.SelectAttrValue("label", "") == label {
+			if obj.SelectAttrValue(fieldLabel, "") == label {
 				return false
 			}
-			obj.CreateAttr("label", label)
+			obj.CreateAttr(fieldLabel, label)
 			return true
 		}
 	}
@@ -84,10 +84,10 @@ func createLegend(
 	// Update existing legend cell — only if label actually changed.
 	for _, obj := range root.SelectElements("object") {
 		if obj.SelectAttrValue("id", "") == cellID {
-			if obj.SelectAttrValue("label", "") == label {
+			if obj.SelectAttrValue(fieldLabel, "") == label {
 				return false
 			}
-			obj.CreateAttr("label", label)
+			obj.CreateAttr(fieldLabel, label)
 			return true
 		}
 	}
@@ -199,7 +199,7 @@ func extractFillColor(allStyles map[string]drawio.TemplateStyle, kind string) st
 // createInfoBox creates a non-model mxCell info box at the given position.
 func createInfoBox(root *etree.Element, id, label string, x, y, width float64) {
 	obj := root.CreateElement("object")
-	obj.CreateAttr("label", label)
+	obj.CreateAttr(fieldLabel, label)
 	obj.CreateAttr("id", id)
 
 	cell := obj.CreateElement("mxCell")


### PR DESCRIPTION
## Summary
- Partial pass on the duplicated-string-literals batch of #585 (SonarCloud go:S1192, ~30 findings total).
- Extracted the `internal/sync` package's field-name literal cluster into `internal/sync/fields.go`: `"technology"`, `"description"`, `"title"`, `"bausteinsicht_id"`, `"label"` were each repeated across `diff.go`, `forward.go`, and `metadata.go` (used both as `ElementChange`/`RelationshipChange.Field` values and as draw.io attribute names, which happen to coincide).
- **Purely mechanical** — literal-for-literal replacement via script, no logic change. Doc comments mentioning these words as prose were left untouched (not code, don't trip S1192).

## Scope note
I don't have direct SonarCloud dashboard access in this environment, so I identified duplicate clusters via static analysis of the repo rather than the exact flagged-line list. This PR addresses the clearest, highest-value cluster (`internal/sync`, ~25 occurrences). The `internal/drawio` package has a second, smaller cluster (`"title"`/`"tech"`/`"desc"` as sub-cell `as`-attribute values — a **different semantic domain**, not reusable with the `internal/sync` constants) that isn't addressed here; happy to follow up if wanted.

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green (200/200 in `internal/sync`)
- [x] `gofmt` clean