### PR TITLE
refactor(template): group sub-cell geometry into a struct (#585)

### DIFF
--- a/internal/template/generator.go
+++ b/internal/template/generator.go
@@ -152,17 +152,22 @@ func (g *Generator) addElementTemplate(parent *etree.Element, kind string, x, y 
 	kindTitle := strings.ToUpper(kind[:1]) + kind[1:]
 	g.addSubCell(parent, objID, "title", kindTitle,
 		fmt.Sprintf("text;html=1;fontSize=13;fontStyle=1;fontColor=%s;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;", colors.Stroke),
-		0, 0, cfg.Width, titleH)
+		cellGeometry{X: 0, Y: 0, W: cfg.Width, H: titleH})
 	g.addSubCell(parent, objID, "tech", "[Technology]",
 		"text;html=1;fontSize=10;fontStyle=2;fontColor=#666666;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;",
-		0, titleH, cfg.Width, techH)
+		cellGeometry{X: 0, Y: titleH, W: cfg.Width, H: techH})
 	g.addSubCell(parent, objID, "desc", "Description",
 		"text;html=1;whiteSpace=wrap;fontSize=10;fontColor=#555555;fillColor=none;strokeColor=none;align=center;verticalAlign=middle;",
-		0, titleH+techH, cfg.Width, descH)
+		cellGeometry{X: 0, Y: titleH + techH, W: cfg.Width, H: descH})
+}
+
+// cellGeometry holds the x/y/width/height of an mxGeometry element.
+type cellGeometry struct {
+	X, Y, W, H int
 }
 
 // addSubCell writes a "-title"/"-tech"/"-desc" text sub-cell parented to objID.
-func (g *Generator) addSubCell(parent *etree.Element, objID, role, value, style string, x, y, w, h int) {
+func (g *Generator) addSubCell(parent *etree.Element, objID, role, value, style string, geo cellGeometry) {
 	cell := parent.CreateElement("mxCell")
 	cell.CreateAttr("id", objID+"-"+role)
 	cell.CreateAttr("parent", objID)
@@ -170,12 +175,12 @@ func (g *Generator) addSubCell(parent *etree.Element, objID, role, value, style 
 	cell.CreateAttr("value", value)
 	cell.CreateAttr("vertex", "1")
 
-	geo := cell.CreateElement("mxGeometry")
-	geo.CreateAttr("x", fmt.Sprintf("%d", x))
-	geo.CreateAttr("y", fmt.Sprintf("%d", y))
-	geo.CreateAttr("width", fmt.Sprintf("%d", w))
-	geo.CreateAttr("height", fmt.Sprintf("%d", h))
-	geo.CreateAttr("as", "geometry")
+	geoElem := cell.CreateElement("mxGeometry")
+	geoElem.CreateAttr("x", fmt.Sprintf("%d", geo.X))
+	geoElem.CreateAttr("y", fmt.Sprintf("%d", geo.Y))
+	geoElem.CreateAttr("width", fmt.Sprintf("%d", geo.W))
+	geoElem.CreateAttr("height", fmt.Sprintf("%d", geo.H))
+	geoElem.CreateAttr("as", "geometry")
 }
 
 // addBoundaryTemplates writes a "<kind>_boundary" template for every container


### PR DESCRIPTION
## Summary
- Partial pass on the too-many-parameters batch of #585 (SonarCloud go:S107 + godre:S8209, 14 findings total).
- `addSubCell` in `internal/template/generator.go` took 9 parameters, the last four (`x, y, w, h int`) being a single geometry concept passed positionally. Grouped into a `cellGeometry` struct.
- Purely mechanical, no logic change — all three call sites updated.

## Scope note
Checked the whole non-test codebase for functions with >7 parameters: outside `internal/sync`, this was the only one. `internal/sync` has ~18 such functions, but nearly all live in `internal/sync/{forward,layout,diff}.go` — files already restructured by the still-open cognitive-complexity PR (#588). That PR's own extractions are what pushed several of these over the parameter threshold while fixing cognitive complexity. Bundling those into shared context structs (e.g. a `page`/`templates`/`flat`/`spec` render-context struct threaded through the forward-sync helpers) is better done as a **follow-up once #588 merges**, rather than stacking another large restructuring of the same files while #588 is still in review — that would multiply conflict risk and review burden for limited benefit.

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green
- [x] `gofmt` clean