### PR TITLE
refactor(diagram): dedupe writePlantUMLElement/writeMermaidElement (#585)

### DIFF
--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -245,6 +245,22 @@ func escapeQuotes(s string) string {
 	return strings.ReplaceAll(s, "\"", "'")
 }
 
+// writeC4Element writes one element as a C4 macro call. PlantUML-C4 and
+// Mermaid's C4 diagram syntax use the same macro-call format, so both
+// writePlantUML and writeMermaid share this.
+func writeC4Element(b *strings.Builder, e elemEntry, indent string) {
+	macro := c4Macro(e.Elem.Kind)
+	if e.Elem.Technology != "" {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Technology), escapeQuotes(e.Elem.Description))
+	} else {
+		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\")\n",
+			indent, macro, sanitizeID(e.ID),
+			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Description))
+	}
+}
+
 // --- PlantUML ---
 
 func writePlantUML(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
@@ -253,7 +269,7 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 
 	// External elements (outside scope boundary).
 	for _, e := range outside {
-		writePlantUMLElement(b, e, "")
+		writeC4Element(b, e, "")
 	}
 
 	// Scope boundary with internal elements.
@@ -269,12 +285,12 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 		}
 		fmt.Fprintf(b, "%s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
 		for _, e := range inside {
-			writePlantUMLElement(b, e, "  ")
+			writeC4Element(b, e, "  ")
 		}
 		b.WriteString("}\n")
 	} else {
 		for _, e := range inside {
-			writePlantUMLElement(b, e, "")
+			writeC4Element(b, e, "")
 		}
 	}
 
@@ -303,19 +319,6 @@ func writePlantUMLRelationships(b *strings.Builder, rels []relEntry) {
 	}
 }
 
-func writePlantUMLElement(b *strings.Builder, e elemEntry, indent string) {
-	macro := c4Macro(e.Elem.Kind)
-	if e.Elem.Technology != "" {
-		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\", \"%s\")\n",
-			indent, macro, sanitizeID(e.ID),
-			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Technology), escapeQuotes(e.Elem.Description))
-	} else {
-		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\")\n",
-			indent, macro, sanitizeID(e.ID),
-			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Description))
-	}
-}
-
 // --- Mermaid ---
 
 func writeMermaid(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
@@ -323,7 +326,7 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 	fmt.Fprintf(b, "    title %s\n\n", view.Title)
 
 	for _, e := range outside {
-		writeMermaidElement(b, e, "    ")
+		writeC4Element(b, e, "    ")
 	}
 
 	if view.Scope != "" {
@@ -338,12 +341,12 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 		}
 		fmt.Fprintf(b, "    %s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
 		for _, e := range inside {
-			writeMermaidElement(b, e, "        ")
+			writeC4Element(b, e, "        ")
 		}
 		b.WriteString("    }\n")
 	} else {
 		for _, e := range inside {
-			writeMermaidElement(b, e, "    ")
+			writeC4Element(b, e, "    ")
 		}
 	}
 
@@ -359,19 +362,6 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 	}
 	for _, r := range rels {
 		fmt.Fprintf(b, "    Rel(%s, %s, \"%s\")\n", sanitizeID(r.From), sanitizeID(r.To), escapeQuotes(r.Label))
-	}
-}
-
-func writeMermaidElement(b *strings.Builder, e elemEntry, indent string) {
-	macro := c4Macro(e.Elem.Kind)
-	if e.Elem.Technology != "" {
-		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\", \"%s\")\n",
-			indent, macro, sanitizeID(e.ID),
-			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Technology), escapeQuotes(e.Elem.Description))
-	} else {
-		fmt.Fprintf(b, "%s%s(%s, \"%s\", \"%s\")\n",
-			indent, macro, sanitizeID(e.ID),
-			escapeQuotes(e.Elem.Title), escapeQuotes(e.Elem.Description))
 	}
 }
 

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -279,6 +279,26 @@ func resolveBoundaryMacro(view model.View, flat map[string]*model.Element) (boun
 	return boundaryMacro, scopeTitle
 }
 
+// writeScopeSection writes a view's scope boundary with its internal
+// elements, or — for unscoped views — just the flat "inside" elements.
+// Shared by writePlantUML and writeMermaid, which differ only in
+// indentation convention (PlantUML: no base indent, 2-space nesting;
+// Mermaid: 4-space base indent, 4-space nesting).
+func writeScopeSection(b *strings.Builder, view model.View, flat map[string]*model.Element, inside []elemEntry, outerIndent, innerIndent string) {
+	if view.Scope == "" {
+		for _, e := range inside {
+			writeC4Element(b, e, outerIndent)
+		}
+		return
+	}
+	boundaryMacro, scopeTitle := resolveBoundaryMacro(view, flat)
+	fmt.Fprintf(b, "%s%s(%s, \"%s\") {\n", outerIndent, boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
+	for _, e := range inside {
+		writeC4Element(b, e, innerIndent)
+	}
+	fmt.Fprintf(b, "%s}\n", outerIndent)
+}
+
 // --- PlantUML ---
 
 func writePlantUML(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
@@ -291,18 +311,7 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 	}
 
 	// Scope boundary with internal elements.
-	if view.Scope != "" {
-		boundaryMacro, scopeTitle := resolveBoundaryMacro(view, flat)
-		fmt.Fprintf(b, "%s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
-		for _, e := range inside {
-			writeC4Element(b, e, "  ")
-		}
-		b.WriteString("}\n")
-	} else {
-		for _, e := range inside {
-			writeC4Element(b, e, "")
-		}
-	}
+	writeScopeSection(b, view, flat, inside, "", "  ")
 
 	writePlantUMLRelationships(b, rels)
 
@@ -339,18 +348,7 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 		writeC4Element(b, e, "    ")
 	}
 
-	if view.Scope != "" {
-		boundaryMacro, scopeTitle := resolveBoundaryMacro(view, flat)
-		fmt.Fprintf(b, "    %s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
-		for _, e := range inside {
-			writeC4Element(b, e, "        ")
-		}
-		b.WriteString("    }\n")
-	} else {
-		for _, e := range inside {
-			writeC4Element(b, e, "    ")
-		}
-	}
+	writeScopeSection(b, view, flat, inside, "    ", "        ")
 
 	// Relationships. r.Dashed is intentionally not applied here: Mermaid's
 	// own C4 diagram docs mark UpdateRelStyle's $lineStyle=DashedLine() as

--- a/internal/diagram/diagram.go
+++ b/internal/diagram/diagram.go
@@ -261,6 +261,24 @@ func writeC4Element(b *strings.Builder, e elemEntry, indent string) {
 	}
 }
 
+// resolveBoundaryMacro determines the C4 boundary macro and display title
+// for a scoped view's boundary box, shared by PlantUML and Mermaid output:
+// System_Boundary by default, Container_Boundary when the scope element's
+// kind is "container". Falls back to the scope's raw ID as the title if the
+// scope element isn't found in flat.
+func resolveBoundaryMacro(view model.View, flat map[string]*model.Element) (boundaryMacro, scopeTitle string) {
+	scopeElem := flat[view.Scope]
+	scopeTitle = view.Scope
+	if scopeElem != nil {
+		scopeTitle = scopeElem.Title
+	}
+	boundaryMacro = "System_Boundary"
+	if scopeElem != nil && scopeElem.Kind == "container" {
+		boundaryMacro = "Container_Boundary"
+	}
+	return boundaryMacro, scopeTitle
+}
+
 // --- PlantUML ---
 
 func writePlantUML(b *strings.Builder, view model.View, level string, inside, outside []elemEntry, rels []relEntry, flat map[string]*model.Element) {
@@ -274,15 +292,7 @@ func writePlantUML(b *strings.Builder, view model.View, level string, inside, ou
 
 	// Scope boundary with internal elements.
 	if view.Scope != "" {
-		scopeElem := flat[view.Scope]
-		scopeTitle := view.Scope
-		if scopeElem != nil {
-			scopeTitle = scopeElem.Title
-		}
-		boundaryMacro := "System_Boundary"
-		if scopeElem != nil && scopeElem.Kind == "container" {
-			boundaryMacro = "Container_Boundary"
-		}
+		boundaryMacro, scopeTitle := resolveBoundaryMacro(view, flat)
 		fmt.Fprintf(b, "%s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
 		for _, e := range inside {
 			writeC4Element(b, e, "  ")
@@ -330,15 +340,7 @@ func writeMermaid(b *strings.Builder, view model.View, level string, inside, out
 	}
 
 	if view.Scope != "" {
-		scopeElem := flat[view.Scope]
-		scopeTitle := view.Scope
-		if scopeElem != nil {
-			scopeTitle = scopeElem.Title
-		}
-		boundaryMacro := "System_Boundary"
-		if scopeElem != nil && scopeElem.Kind == "container" {
-			boundaryMacro = "Container_Boundary"
-		}
+		boundaryMacro, scopeTitle := resolveBoundaryMacro(view, flat)
 		fmt.Fprintf(b, "    %s(%s, \"%s\") {\n", boundaryMacro, sanitizeID(view.Scope), escapeQuotes(scopeTitle))
 		for _, e := range inside {
 			writeC4Element(b, e, "        ")


### PR DESCRIPTION
## Summary
- Fixes the last individually-called-out item of #585 (SonarCloud go:S4144): `writePlantUMLElement` and `writeMermaidElement` in `internal/diagram/diagram.go` had byte-identical bodies.
- PlantUML-C4 and Mermaid's C4 diagram syntax happen to use the same macro-call format in this codebase's usage, so there was no behavioral reason for two copies. Merged into a single `writeC4Element`, called from both `writePlantUML` and `writeMermaid`.
- Purely mechanical, no logic change — all 6 call sites updated.

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — full suite green
- [x] `gofmt` clean