### PR TITLE
docs(templates): explain blank embed import (#585)

### DIFF
--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,6 +1,6 @@
 package templates
 
-import _ "embed"
+import _ "embed" // enables the //go:embed directives below; targets are []byte, not embed.FS, so no named import is used
 
 //go:embed default.drawio
 var DefaultTemplate []byte


### PR DESCRIPTION
## Summary
- Last item of #585 (SonarCloud godre:S8184): blank imports are usually a code smell, so the rule wants an explanatory comment when one is intentional.
- `templates/embed.go`'s `import _ "embed"` is idiomatic — it enables the two `//go:embed` directives below without needing the `embed.FS` type, since both targets are `[]byte`. Added an inline comment documenting that.

## Verification
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `gofmt` clean