### PR TITLE
fix(diagram): resolve blank canvas in HTML export

### DIFF
--- a/internal/diagram/diagram_test.go
+++ b/internal/diagram/diagram_test.go
@@ -2,6 +2,7 @@ package diagram
 
 import (
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -422,6 +423,57 @@ func TestHTML_ContextView(t *testing.T) {
 	if !strings.Contains(result, "createElementNS") {
 		t.Error("expected SVG creation via JavaScript")
 	}
+}
+
+// TestHTML_CanvasHasResolvedHeight verifies the generated CSS establishes a
+// resolved height chain from html/body down through .grid to #canvas. Without
+// it, #canvas (flex:1 inside .grid) collapses to ~0 height and the diagram
+// area renders blank even though nodes/edges are embedded correctly.
+// Regression test for #555.
+func TestHTML_CanvasHasResolvedHeight(t *testing.T) {
+	m := testModel()
+	result, err := RenderHTML(m, "context")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	styleStart := strings.Index(result, "<style>")
+	styleEnd := strings.Index(result, "</style>")
+	if styleStart < 0 || styleEnd < 0 {
+		t.Fatal("could not find <style> block")
+	}
+	css := result[styleStart:styleEnd]
+
+	bodyRule := extractCSSRule(css, "body")
+	if !strings.Contains(bodyRule, "height:") {
+		t.Errorf("expected body rule to set an explicit height so descendants can resolve theirs, got body rule:\n%s", bodyRule)
+	}
+	if !strings.Contains(bodyRule, "display: flex") || !strings.Contains(bodyRule, "flex-direction: column") {
+		t.Errorf("expected body to be a column flex container so .grid can flex to fill remaining space, got body rule:\n%s", bodyRule)
+	}
+
+	gridRule := extractCSSRule(css, ".grid")
+	if !strings.Contains(gridRule, "flex:") {
+		t.Errorf("expected .grid to grow to fill the body flex container, got .grid rule:\n%s", gridRule)
+	}
+}
+
+// extractCSSRule returns the declaration block (without braces) for the rule
+// whose selector line is exactly the given selector (ignoring leading
+// whitespace), or "" if not found. Anchoring on the line start avoids
+// matching a combined selector like "html, body {" when looking up "body".
+func extractCSSRule(css, selector string) string {
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(selector) + `\s*\{`)
+	loc := re.FindStringIndex(css)
+	if loc == nil {
+		return ""
+	}
+	start := loc[1]
+	end := strings.Index(css[start:], "}")
+	if end < 0 {
+		return ""
+	}
+	return css[start : start+end]
 }
 
 func TestHTML_ValidJSON(t *testing.T) {

--- a/internal/diagram/html.go
+++ b/internal/diagram/html.go
@@ -122,9 +122,18 @@ func generateHTMLTemplate(title, dataJSON string) string {
   <title>Architecture — %s</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; }
+    html, body { height: 100%%; }
+    body {
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+    }
 
     #header {
+      flex-shrink: 0;
       background: white;
       padding: 16px;
       border-bottom: 1px solid #ddd;
@@ -185,8 +194,7 @@ func generateHTMLTemplate(title, dataJSON string) string {
     #details p { margin: 8px 0; font-size: 13px; color: #666; word-break: break-word; }
     #details strong { color: #333; }
 
-    .grid { display: flex; }
-    #canvas { flex: 1; }
+    .grid { display: flex; flex: 1; min-height: 0; }
 
     .node { cursor: pointer; transition: opacity 0.2s; }
     .node:hover { opacity: 0.8; }


### PR DESCRIPTION
## Summary
Fixes #555 — `export-diagram --diagram-format html` produced a page whose diagram canvas stayed blank. Root cause (as diagnosed in the issue): `#canvas { flex: 1 }` sits inside `.grid { display: flex }`, but neither `.grid` nor any ancestor (`body`) had a resolved height, so `#canvas` collapsed to ~0px and the JS-rendered SVG got `width=0 height=0`.

## Fix
- `body` is now a `100vh` column flex container (`display: flex; flex-direction: column`).
- `#header` gets `flex-shrink: 0` so it keeps its content height.
- `.grid` gets `flex: 1; min-height: 0` so it fills the remaining space, giving `#canvas` a real height to lay out into.

The secondary observation in the issue (flat rendering / no C4 boundary drawing, edge label overlap) is a separate, larger layout-engine concern — left out of scope here per the issue author's own suggestion to split it out if needed.

## Test plan
- [x] Added `TestHTML_CanvasHasResolvedHeight` (TDD: confirmed it fails against the unfixed CSS before applying the fix) asserting the generated `<style>` block gives `body`/`.grid` a resolvable height chain.
- [x] `go test ./internal/diagram/...` and full `go test ./...` pass.
- [x] `go vet`, `staticcheck ./internal/diagram/...`, `gofmt -l` all clean.
- [x] Manually generated real HTML output via the built CLI and inspected the rendered `<style>` block — no template artifacts (the CSS `%` needed escaping to `%%` for `fmt.Sprintf`).
- No new command/flag/pipeline added, so no new e2e scenario required per the PR merge policy; `e2e/dot_d2_html_export_test.go` already exercises the html export path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)