### PR TITLE
fix(model): detect duplicate decision IDs during validation

### DIFF
--- a/internal/model/validate.go
+++ b/internal/model/validate.go
@@ -46,6 +46,7 @@ func ValidateWithWarnings(m *BausteinsichtModel) ValidationResult {
 	result.Errors = append(result.Errors, validateViews(m)...)
 	result.Errors = append(result.Errors, validateDynamicViews(m)...)
 	result.Errors = append(result.Errors, validatePatterns(m)...)
+	result.Errors = append(result.Errors, validateDuplicateDecisionIDs(m)...)
 	result.Errors = append(result.Errors, validateDecisions(m)...)
 	result.Warnings = append(result.Warnings, validateEmptyModel(m)...)
 	result.Warnings = append(result.Warnings, validateLifecycleStatus(m)...)
@@ -486,6 +487,29 @@ func validatePatterns(m *BausteinsichtModel) []ValidationError {
 				}
 			}
 		}
+	}
+
+	return errs
+}
+
+// validateDuplicateDecisionIDs checks that no two entries in specification.decisions
+// share the same id. A silent collision would make knownDecisions (below) and
+// decisionMap (internal/sync/badge.go) pick whichever entry happens to be last,
+// so linked elements/relationships could display the wrong decision's title/status
+// with no indication anything is wrong.
+func validateDuplicateDecisionIDs(m *BausteinsichtModel) []ValidationError {
+	var errs []ValidationError
+
+	seen := make(map[string]bool)
+	for _, decision := range m.Specification.Decisions {
+		if seen[decision.ID] {
+			errs = append(errs, ValidationError{
+				Path:    "specification.decisions",
+				Message: fmt.Sprintf("duplicate decision id %q", decision.ID),
+			})
+			continue
+		}
+		seen[decision.ID] = true
 	}
 
 	return errs

--- a/internal/model/validate_test.go
+++ b/internal/model/validate_test.go
@@ -518,6 +518,37 @@ func TestValidate_ViewValidLayouts(t *testing.T) {
 	}
 }
 
+// TestValidate_DuplicateDecisionID verifies that two decisions sharing the
+// same ID are flagged. Without this check, knownDecisions in validateDecisions
+// (and decisionMap in internal/sync/badge.go) silently let the last entry win,
+// so a linked element/relationship can end up showing the wrong decision's
+// title/status with no warning at all. Regression test for #557.
+func TestValidate_DuplicateDecisionID(t *testing.T) {
+	m := buildValidModel()
+	m.Specification.Decisions = []DecisionRecord{
+		{ID: "decision_0", Title: "Use PostgreSQL", Status: ADRActive},
+		{ID: "decision_0", Title: "Use REST over gRPC", Status: ADRProposed},
+	}
+
+	errs := Validate(m)
+	if !containsMessage(errs, "decision_0") {
+		t.Errorf("expected error mentioning duplicate decision id %q, got %v", "decision_0", errs)
+	}
+}
+
+func TestValidate_UniqueDecisionIDs(t *testing.T) {
+	m := buildValidModel()
+	m.Specification.Decisions = []DecisionRecord{
+		{ID: "decision_0", Title: "Use PostgreSQL", Status: ADRActive},
+		{ID: "decision_1", Title: "Use REST over gRPC", Status: ADRProposed},
+	}
+
+	errs := Validate(m)
+	if containsMessage(errs, "duplicate") {
+		t.Errorf("expected no duplicate-decision error for unique ids, got %v", errs)
+	}
+}
+
 // containsPath checks whether any error has the given path.
 func containsPath(errs []ValidationError, path string) bool {
 	for _, e := range errs {


### PR DESCRIPTION
## Summary
Fixes #557 — `specification.decisions[]` entries were checked for existence when referenced (`validateDecisions`), but never for uniqueness among themselves. If two decisions share the same `id` (e.g. an ADR workflow that always emits `decision_0` instead of counting up), `bausteinsicht validate` reported nothing, while `decisionMap` in `internal/sync/doclinks.go` silently lets the last entry win — so a linked element/relationship can end up showing the wrong decision's title/status (e.g. in the doc-link icon or `bausteinsicht adr show`) with no warning at all.

## Fix
- New `validateDuplicateDecisionIDs` in `internal/model/validate.go`, wired into `ValidateWithWarnings` as an `Error` (consistent with the existing "references unknown decision" check being an error, not a warning — a silent ID collision is a correctness problem, not just a style nit).

Scoped to the validation gap the issue explicitly asks for; the note in the issue about *where* something might always emit `decision_0` couldn't be located in this codebase (no automatic decision-ID assignment exists here), so this PR only adds the missing detection, as the issue itself suggests.

## Test plan
- [x] Added `TestValidate_DuplicateDecisionID` (TDD: confirmed it fails against the unfixed code first) and `TestValidate_UniqueDecisionIDs` (no false positive).
- [x] `go test ./...`, `go vet`, `staticcheck ./internal/model/...`, `gofmt -l` all clean.
- No new command/flag/pipeline added, so no new e2e scenario required per the PR merge policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)