### PR TITLE
feat(model): add codeMapping field to Element

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -259,30 +259,29 @@ func (s *Specification) IsDashed(kind string) bool {
 }
 
 type Element struct {
-	Kind         string                 `json:"kind"`
-	Title        string                 `json:"title"`
-	Description  string                 `json:"description,omitempty"`
-	Technology   string                 `json:"technology,omitempty"`
-	Tags         []string               `json:"tags,omitempty"`
-	Status       string                 `json:"status,omitempty"`       // e.g., "deployed", "deprecated", "archived"
-	Decisions    []string               `json:"decisions,omitempty"`    // ADR IDs linked to this element
-	LastModified string                 `json:"lastModified,omitempty"` // RFC3339 timestamp (optional override for git-based staleness detection)
-	Children     map[string]Element     `json:"children,omitempty"`
-	Metadata     map[string]string      `json:"metadata,omitempty"`
-	Link         string                 `json:"link,omitempty"`        // hyperlink on the draw.io shape and in SVG export
-	DocLinks     []DocLink              `json:"docLinks,omitempty"`    // typed documentation links, rendered as clickable icons (#543)
-	CodeMapping  map[string]CodeMapping `json:"codeMapping,omitempty"` // element → real code locations, keyed per code-governance backend (#562)
+	Kind         string             `json:"kind"`
+	Title        string             `json:"title"`
+	Description  string             `json:"description,omitempty"`
+	Technology   string             `json:"technology,omitempty"`
+	Tags         []string           `json:"tags,omitempty"`
+	Status       string             `json:"status,omitempty"`       // e.g., "deployed", "deprecated", "archived"
+	Decisions    []string           `json:"decisions,omitempty"`    // ADR IDs linked to this element
+	LastModified string             `json:"lastModified,omitempty"` // RFC3339 timestamp (optional override for git-based staleness detection)
+	Children     map[string]Element `json:"children,omitempty"`
+	Metadata     map[string]string  `json:"metadata,omitempty"`
+	Link         string             `json:"link,omitempty"`        // hyperlink on the draw.io shape and in SVG export
+	DocLinks     []DocLink          `json:"docLinks,omitempty"`    // typed documentation links, rendered as clickable icons (#543)
+	CodeMapping  *CodeMapping       `json:"codeMapping,omitempty"` // element → real code locations for the code-governance bridge (#562)
 }
 
-// CodeMapping anchors a model element to real code for one code-governance
-// backend (e.g. "java" for ArchUnit). Keyed per backend on Element.CodeMapping
-// rather than as a flat list so a polyglot model doesn't collide across
-// languages — a Go element and its .NET bindings each get their own entry
-// (see #562 R5, #572 R6).
+// CodeMapping anchors a model element to real code for the code-governance
+// bridge (ArchUnit first, #562). Flat (not keyed per backend) matching the
+// validated Variant C prototype contract — see
+// https://github.com/docToolchain/bausteinsicht-archunit and ADR-013.
 type CodeMapping struct {
 	// Packages are backend-native package/namespace/module prefixes that
 	// belong to this element, prefix-matched the way ArchUnit's package
-	// matcher works (e.g. "com.acme.backend.api..").
+	// matcher works (e.g. "com.acme.backend.api").
 	Packages []string `json:"packages,omitempty"`
 }
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -259,18 +259,31 @@ func (s *Specification) IsDashed(kind string) bool {
 }
 
 type Element struct {
-	Kind         string             `json:"kind"`
-	Title        string             `json:"title"`
-	Description  string             `json:"description,omitempty"`
-	Technology   string             `json:"technology,omitempty"`
-	Tags         []string           `json:"tags,omitempty"`
-	Status       string             `json:"status,omitempty"`       // e.g., "deployed", "deprecated", "archived"
-	Decisions    []string           `json:"decisions,omitempty"`    // ADR IDs linked to this element
-	LastModified string             `json:"lastModified,omitempty"` // RFC3339 timestamp (optional override for git-based staleness detection)
-	Children     map[string]Element `json:"children,omitempty"`
-	Metadata     map[string]string  `json:"metadata,omitempty"`
-	Link         string             `json:"link,omitempty"`     // hyperlink on the draw.io shape and in SVG export
-	DocLinks     []DocLink          `json:"docLinks,omitempty"` // typed documentation links, rendered as clickable icons (#543)
+	Kind         string                 `json:"kind"`
+	Title        string                 `json:"title"`
+	Description  string                 `json:"description,omitempty"`
+	Technology   string                 `json:"technology,omitempty"`
+	Tags         []string               `json:"tags,omitempty"`
+	Status       string                 `json:"status,omitempty"`       // e.g., "deployed", "deprecated", "archived"
+	Decisions    []string               `json:"decisions,omitempty"`    // ADR IDs linked to this element
+	LastModified string                 `json:"lastModified,omitempty"` // RFC3339 timestamp (optional override for git-based staleness detection)
+	Children     map[string]Element     `json:"children,omitempty"`
+	Metadata     map[string]string      `json:"metadata,omitempty"`
+	Link         string                 `json:"link,omitempty"`        // hyperlink on the draw.io shape and in SVG export
+	DocLinks     []DocLink              `json:"docLinks,omitempty"`    // typed documentation links, rendered as clickable icons (#543)
+	CodeMapping  map[string]CodeMapping `json:"codeMapping,omitempty"` // element → real code locations, keyed per code-governance backend (#562)
+}
+
+// CodeMapping anchors a model element to real code for one code-governance
+// backend (e.g. "java" for ArchUnit). Keyed per backend on Element.CodeMapping
+// rather than as a flat list so a polyglot model doesn't collide across
+// languages — a Go element and its .NET bindings each get their own entry
+// (see #562 R5, #572 R6).
+type CodeMapping struct {
+	// Packages are backend-native package/namespace/module prefixes that
+	// belong to this element, prefix-matched the way ArchUnit's package
+	// matcher works (e.g. "com.acme.backend.api..").
+	Packages []string `json:"packages,omitempty"`
 }
 
 // DocLink is a typed link from a diagram element or view to an external

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -67,18 +67,15 @@ func TestJSONRoundTrip(t *testing.T) {
 	}
 }
 
-// TestElement_CodeMapping_JSONRoundTrip verifies the per-backend keyed shape
-// (element → {backend → packages}) round-trips through JSON, so a polyglot
-// model can carry a Java and a Go code anchor on the same element without
-// collision. See #562 R5, #572 R6.
+// TestElement_CodeMapping_JSONRoundTrip verifies codeMapping round-trips
+// through JSON. Shape is flat (Element -> one CodeMapping), matching the
+// validated Variant C prototype contract, not a per-backend map — see #562,
+// ADR-013, and https://github.com/docToolchain/bausteinsicht-archunit.
 func TestElement_CodeMapping_JSONRoundTrip(t *testing.T) {
 	original := Element{
-		Kind:  "container",
-		Title: "Order API",
-		CodeMapping: map[string]CodeMapping{
-			"java": {Packages: []string{"com.acme.backend.orders.."}},
-			"go":   {Packages: []string{"github.com/acme/orders/..."}},
-		},
+		Kind:        "container",
+		Title:       "Order API",
+		CodeMapping: &CodeMapping{Packages: []string{"com.acme.backend.orders"}},
 	}
 
 	data, err := json.Marshal(original)
@@ -93,6 +90,27 @@ func TestElement_CodeMapping_JSONRoundTrip(t *testing.T) {
 
 	if !reflect.DeepEqual(original, restored) {
 		t.Errorf("round-trip mismatch:\noriginal: %+v\nrestored: %+v", original, restored)
+	}
+}
+
+// TestElement_CodeMapping_MatchesArchUnitPrototypeContract pins the exact
+// JSON shape read by the running bausteinsicht-archunit Variant C prototype
+// (adapter/src/test/resources/architecture.jsonc there), so a future change
+// here doesn't silently break that external, already-validated adapter.
+func TestElement_CodeMapping_MatchesArchUnitPrototypeContract(t *testing.T) {
+	raw := `{"kind":"component","title":"API","codeMapping":{"packages":["com.acme.backend.api"]}}`
+
+	var elem Element
+	if err := json.Unmarshal([]byte(raw), &elem); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if elem.CodeMapping == nil {
+		t.Fatal("expected CodeMapping to be set")
+	}
+	want := []string{"com.acme.backend.api"}
+	if !reflect.DeepEqual(elem.CodeMapping.Packages, want) {
+		t.Errorf("Packages = %v, want %v", elem.CodeMapping.Packages, want)
 	}
 }
 

--- a/internal/model/types_test.go
+++ b/internal/model/types_test.go
@@ -67,6 +67,48 @@ func TestJSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestElement_CodeMapping_JSONRoundTrip verifies the per-backend keyed shape
+// (element → {backend → packages}) round-trips through JSON, so a polyglot
+// model can carry a Java and a Go code anchor on the same element without
+// collision. See #562 R5, #572 R6.
+func TestElement_CodeMapping_JSONRoundTrip(t *testing.T) {
+	original := Element{
+		Kind:  "container",
+		Title: "Order API",
+		CodeMapping: map[string]CodeMapping{
+			"java": {Packages: []string{"com.acme.backend.orders.."}},
+			"go":   {Packages: []string{"github.com/acme/orders/..."}},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var restored Element
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, restored) {
+		t.Errorf("round-trip mismatch:\noriginal: %+v\nrestored: %+v", original, restored)
+	}
+}
+
+// TestElement_CodeMapping_OmittedWhenAbsent ensures elements without a
+// codeMapping don't grow a stray "codeMapping": null/{} in the serialized
+// JSONC, keeping existing models byte-for-byte unaffected by this addition.
+func TestElement_CodeMapping_OmittedWhenAbsent(t *testing.T) {
+	data, err := json.Marshal(Element{Kind: "actor", Title: "Customer"})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(data), "codeMapping") {
+		t.Errorf("expected no codeMapping key when unset, got: %s", data)
+	}
+}
+
 func TestDeserializeSampleModel(t *testing.T) {
 	raw, err := os.ReadFile("../../templates/sample-model.jsonc")
 	if err != nil {

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -61,6 +61,18 @@
   ],
   "additionalProperties": false,
   "definitions": {
+    "CodeMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "packages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "Config": {
       "additionalProperties": false,
       "properties": {
@@ -224,6 +236,12 @@
         "children": {
           "additionalProperties": {
             "$ref": "#/definitions/Element"
+          },
+          "type": "object"
+        },
+        "codeMapping": {
+          "additionalProperties": {
+            "$ref": "#/definitions/CodeMapping"
           },
           "type": "object"
         },

--- a/schemas/bausteinsicht.schema.json
+++ b/schemas/bausteinsicht.schema.json
@@ -240,10 +240,7 @@
           "type": "object"
         },
         "codeMapping": {
-          "additionalProperties": {
-            "$ref": "#/definitions/CodeMapping"
-          },
-          "type": "object"
+          "$ref": "#/definitions/CodeMapping"
         },
         "decisions": {
           "items": {

--- a/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
+++ b/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
@@ -1,0 +1,162 @@
+:jbake-title: ADR-013: Code-Governance Backend (ArchUnit/JVM First)
+:jbake-type: page_toc
+:jbake-status: published
+:jbake-menu: ADR
+:jbake-order: 13
+
+= ADR-013: Code-Governance Backend (ArchUnit/JVM First)
+
+== Status
+
+Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided and land in this ADR's implementation slice; the forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
+
+== Context
+
+Bausteinsicht models a target architecture and already enforces rules on that *abstract* model (`bausteinsicht lint`: `no-relationship`, `allowed-relationship`, `no-circular-dependency`, ...). These are, one abstraction level lower, exactly what https://www.archunit.org[ArchUnit] enforces on real Java code.
+
+Bausteinsicht is — like Enterprise Architect and other modelling tools — an *external* source of truth relative to a codebase, but lightweight, text/JSONC-based and LLM-friendly. Its weakness is integration reach into the Java build/IDE world. We want the modelled architecture to actually **govern the code** — turning the model into an enforceable contract rather than documentation — and to **detect drift** back from the code into the model.
+
+Java teams prefer to stay in their own toolchain, which is why they reach for ArchUnit (a plain test dependency) over https://jqassistant.org[jQAssistant] (Neo4j-based). The adoption strategy is therefore: meet the Java world at ArchUnit. jQAssistant is an anticipated *later* backend and is out of scope here.
+
+=== Constraints
+
+* **Bausteinsicht is a Go CLI.** It cannot *run* ArchUnit (a JVM test library) and cannot *extract* a dependency graph from Java bytecode itself. Any code-side execution or extraction happens on the JVM side.
+* **The model has no code anchor today.** An `Element` carries no `package`/`namespace`/`sourcePath`; a code-level rule needs an element → code mapping.
+* **Drift already has a home.** The model supports `asIs`/`toBe` snapshots and a `diff` command; the reverse path reuses these instead of introducing a second mechanism.
+* **This is the first of several backends.** https://github.com/docToolchain/Bausteinsicht/issues/572[#572] extends code-governance beyond the JVM (Go, .NET, Python, Rust, C/C++) — the abstractions decided here (`codeMapping` shape, `RuleBackend` extensibility) must not paint the JVM backend into a corner that a second backend has to break.
+
+=== Forces
+
+* Full rule expressiveness (cycles, naming, technology checks) vs. lowest implementation cost / fastest prototype
+* Keeping Bausteinsicht free of foreign-language coupling (no Java in this repo) vs. single source of truth (no stale intermediate artifact)
+* Fits Java developers staying inside ArchUnit/their IDE vs. avoiding a new public-API commitment (the JSONC model becoming a stable, versioned contract)
+
+== Evaluated Options (forward mechanism)
+
+All variants keep the model as the single source of truth; they differ in the **integration surface** (what the Java side consumes) and **where the rules are built**. The reverse/drift path (below) is shared by all of them and is not itself a Pugh-matrix option — it is decided independently of which forward variant wins.
+
+=== Variant A: Generated ArchUnit Test Class (fallback)
+
+Bausteinsicht emits a Java test class. Full expressiveness, no diagram, but a Go tool now templates Java and tracks ArchUnit's DSL — foreign-language coupling in the Bausteinsicht repo. Runtime flow mirrors Variant B.
+
+=== Variant B: PlantUML as Intermediate (prototype baseline)
+
+Bausteinsicht generates an ArchUnit-flavoured component diagram; the Java side uses ArchUnit's *built-in* adapter `classes().should(adhereToPlantUmlDiagram(...))` — no extra dependency, no parser to build. Cheapest path; limited to package-dependency adherence; the `.puml` is an intermediate that can go stale.
+
+=== Variant C: Native Adapter Reads the JSONC Directly (target)
+
+A thin adapter *in the Java world* reads the model and builds `ArchRule`s programmatically — no intermediate, full expressiveness. Price: the JSONC model becomes a stable, versioned **public contract**, and an adapter owner is needed. No Java code enters the Bausteinsicht repo either way.
+
+== Weighted Pugh Matrix
+
+Rating scale: `-1` = worse than reference, `0` = same, `+1` = better. Reference option: **B** (the natural zero-cost prototype baseline).
+
+[cols="4,1,1,1,1"]
+|===
+| Criterion | Weight | A: native test class | B: PlantUML (ref) | C: JSONC adapter
+
+| Lowest implementation cost / time-to-prototype
+| 4
+| -1
+| 0
+| -1
+
+| Rule expressiveness (cycles/naming/technology)
+| 3
+| +1
+| 0
+| +1
+
+| Single source of truth (no stale intermediate)
+| 3
+| +1
+| 0
+| +1
+
+| Fits Java devs staying in ArchUnit/IDE
+| 4
+| +1
+| 0
+| +1
+
+| Keeps Bausteinsicht free of foreign-language coupling
+| 3
+| -1
+| 0
+| +1
+
+| Avoids new public-API commitment (stable JSONC contract)
+| 2
+| 0
+| 0
+| -1
+
+| *Weighted total*
+| —
+| *+3*
+| *0*
+| *+7*
+|===
+
+The result is **weight-sensitive by design**: C leads only if the JSONC-as-public-contract commitment and an adapter owner are accepted (its sole penalty). The matrix *informs* but does not *settle* the forward mechanism — see <<open-questions>>.
+
+== Decision
+
+=== Decided now
+
+* **Integration at ArchUnit** (not jQAssistant) — meets Java teams inside their existing toolchain.
+* **`codeMapping` field on `Element`** (R5), keyed per code-governance backend rather than a flat list:
++
+[source,jsonc]
+----
+"codeMapping": {
+  "java": { "packages": ["com.acme.backend.orders.."] }
+}
+----
++
+The per-backend keying is adopted now from #572's R6 (rather than shipping a flat `packages` list and migrating later) because #572 already establishes that a polyglot model needs this shape to avoid a Go element and its .NET bindings colliding on one flat string list. Getting the shape right in this first slice avoids a schema-breaking migration when the second backend (#574, Go) lands. See `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
+* **Reverse/drift path** (shared by all forward variants): a graph extractor (`jdeps` or a small ArchUnit-based tool) dumps the real package-dependency graph as a `codegraph` JSON document → Bausteinsicht ingests it as an `asIs` snapshot (projected through `codeMapping`) → the existing `bausteinsicht diff` command compares it against `toBe` → proposes curated model patches. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; edits are proposed, never written back silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
+* **Prototype the forward mechanism with Variant B** (fastest proof, zero new parser); **Variant A is retained as a fallback** for expressiveness if C stalls; **Variant C is the target**, conditional on the open points below.
+
+=== Not yet implemented by this ADR
+
+The `codegraph` schema, the `import-graph` command, the Variant B PlantUML emitter, and the `RuleBackend` abstraction (R1/R4) are follow-up work, not part of this ADR's initial code slice (which lands only the `codeMapping` field). Scoping them as separate PRs keeps each one reviewable; see References for the tracking issues.
+
+[[open-questions]]
+== Open Questions
+
+Gating the forward mechanism's move from B to C:
+
+* Must the failing gate be a **native JUnit/IDE test** (→ Variant C/A), or is a **separate CI step** running the Bausteinsicht binary against an extracted graph acceptable (→ extractor + BS engine)?
+* Are we willing to treat the **JSONC model as a stable, versioned public API**, and who **owns** the Java-side adapter (Variant C)?
+* Diagram/export format for the Variant B emitter: plain-component PlantUML flavour only — the default C4 export is not adapter-parseable.
+
+Cross-cutting with #572 (tracked there, not here):
+
+* Does the `codegraph` schema's `nodes`/`edges`/`language` shape already generalise past the JVM, or does a non-JVM backend need a change?
+* Should the Rust (#577) / C/C++ (#578) research spikes report a go/no-go before further sub-issue work is scheduled against them?
+
+== Consequences
+
+=== Positive
+
+* `codeMapping` gives elements a real anchor into code without committing to any specific forward mechanism yet — the field is useful (and stable) regardless of how the A/B/C question resolves.
+* The reverse/drift path reuses `asIs`/`toBe`/`diff` unchanged — no new mechanism, no new UI, no new command family beyond `import-graph`.
+* Per-backend keying means the second backend (#574, Go) does not need a schema migration.
+
+=== Negative
+
+* Shipping the field now, ahead of any command that consumes it, means it is unvalidated against real usage until `import-graph` and a forward emitter land — it could still need adjustment (e.g. additional match kinds per R6's `paths` proposal for C/C++, deliberately deferred).
+* The staged decision leaves the *target* forward variant (C) unresolved; teams adopting `codeMapping` today are anchoring elements without yet getting rule enforcement.
+
+=== Risk
+
+* R-CODEGOV-1: `codeMapping.packages` prefix-matching semantics are convention-based (mirroring ArchUnit's package matcher), not currently validated by any Bausteinsicht code path — a malformed prefix is a silent no-match until `import-graph` exists to exercise it.
+
+== References
+
+* Epic: https://github.com/docToolchain/Bausteinsicht/issues/562[#562] — RFE: Generate & synchronize code-level architecture rules (ArchUnit) from the model. Source of this ADR's content (motivation, variants, Pugh matrix, reverse-path design).
+* https://github.com/docToolchain/Bausteinsicht/issues/570[#570] — RFE: Model DDD / Hexagonal Architecture with xMolecules-aligned vocabulary (umbrella; this ADR is a descendant of its layer 4 "Bridge to code").
+* https://github.com/docToolchain/Bausteinsicht/issues/572[#572] — RFE: Multi-language code-governance backends beyond ArchUnit/JVM. Source of the per-backend `codeMapping` keying adopted here (R6), and of the `RuleBackend` abstraction (R1) this ADR's implementation must stay compatible with.
+* `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
+* `internal/model/types.go` — `Element.CodeMapping`, `CodeMapping`.

--- a/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
+++ b/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
@@ -8,7 +8,7 @@
 
 == Status
 
-Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided and land in this ADR's implementation slice; the forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
+Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided and land in this ADR's implementation slice, with their shape validated by an external Variant C prototype (see <<variant-c-prototype>>). The forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
 
 == Context
 
@@ -46,6 +46,20 @@ Bausteinsicht generates an ArchUnit-flavoured component diagram; the Java side u
 === Variant C: Native Adapter Reads the JSONC Directly (target)
 
 A thin adapter *in the Java world* reads the model and builds `ArchRule`s programmatically — no intermediate, full expressiveness. Price: the JSONC model becomes a stable, versioned **public contract**, and an adapter owner is needed. No Java code enters the Bausteinsicht repo either way.
+
+[[variant-c-prototype]]
+=== Variant C prototype (validation evidence)
+
+A runnable Java adapter implementing *both* directions of this ADR already exists: https://github.com/docToolchain/bausteinsicht-archunit.
+
+* **Forward:** `BausteinsichtRules.fromModel()` reads a Bausteinsicht JSONC model (with `codeMapping`) and builds `ArchRule`s that check real code — no intermediate diagram. For every element with a `codeMapping`, its classes may depend only on its own packages, the packages of elements it has an outgoing relationship to, and the JDK.
+* **Reverse:** `CodeGraphExporter` dumps the real package-dependency graph as the minimal `codegraph` JSON described below, for Bausteinsicht to ingest as an `asIs` snapshot.
+* A happy-path integration test over a tiny three-package example app (`api → svc → db`) passes both directions via `mvn verify`, with CI included.
+* Scope is explicitly happy-path only — "enough to pin down the two contracts and prove the round-trip," per its README. `codeMapping` there is called out as *proposed*; the real Bausteinsicht-side changes (this ADR) land separately.
+
+This directly answers part of <<open-questions>>: an adapter owner exists (ascheman) and a concrete implementation is running. It does **not** settle the remaining open points (native-test-vs-CI-step gate, formal public-API commitment, license) — see <<open-questions>>.
+
+**Impact on this ADR's `codeMapping` design:** the prototype's `Element` type carries a single `CodeMapping` (`{"packages": [...]}`), not a map keyed per backend. This ADR adopts that flat shape exactly (see <<decision>>) rather than the per-backend-keyed shape #572's R6 proposes for later multi-language use — preferring a shape validated end-to-end by a real, tested adapter over a speculative one nothing has exercised yet. See <<open-questions>> for when per-backend keying would actually be revisited.
 
 == Weighted Pugh Matrix
 
@@ -100,23 +114,22 @@ Rating scale: `-1` = worse than reference, `0` = same, `+1` = better. Reference 
 
 The result is **weight-sensitive by design**: C leads only if the JSONC-as-public-contract commitment and an adapter owner are accepted (its sole penalty). The matrix *informs* but does not *settle* the forward mechanism — see <<open-questions>>.
 
+[[decision]]
 == Decision
 
 === Decided now
 
 * **Integration at ArchUnit** (not jQAssistant) — meets Java teams inside their existing toolchain.
-* **`codeMapping` field on `Element`** (R5), keyed per code-governance backend rather than a flat list:
+* **`codeMapping` field on `Element`** (R5), **flat** — one mapping per element, not keyed per backend:
 +
 [source,jsonc]
 ----
-"codeMapping": {
-  "java": { "packages": ["com.acme.backend.orders.."] }
-}
+"codeMapping": { "packages": ["com.acme.backend.orders"] }
 ----
 +
-The per-backend keying is adopted now from #572's R6 (rather than shipping a flat `packages` list and migrating later) because #572 already establishes that a polyglot model needs this shape to avoid a Go element and its .NET bindings colliding on one flat string list. Getting the shape right in this first slice avoids a schema-breaking migration when the second backend (#574, Go) lands. See `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
-* **Reverse/drift path** (shared by all forward variants): a graph extractor (`jdeps` or a small ArchUnit-based tool) dumps the real package-dependency graph as a `codegraph` JSON document → Bausteinsicht ingests it as an `asIs` snapshot (projected through `codeMapping`) → the existing `bausteinsicht diff` command compares it against `toBe` → proposes curated model patches. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; edits are proposed, never written back silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
-* **Prototype the forward mechanism with Variant B** (fastest proof, zero new parser); **Variant A is retained as a fallback** for expressiveness if C stalls; **Variant C is the target**, conditional on the open points below.
+`packages` holds bare prefixes without ArchUnit's trailing `..` — the consuming adapter appends that itself (see <<variant-c-prototype>>'s `BausteinsichtRules.matchers()`). This is a **reversal** from this ADR's first draft, which had adopted #572's R6 per-backend-keyed proposal (`{"java": {...}, "go": {...}}`) speculatively. Once the Variant C prototype surfaced, matching its validated, tested contract exactly took priority over a shape nothing had exercised yet — see <<variant-c-prototype>>. Per-backend keying is deferred to <<open-questions>>, to be revisited only when a second backend (#574, Go) actually needs an element to carry more than one language's mapping simultaneously. See `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
+* **Reverse/drift path** (shared by all forward variants): a graph extractor (`jdeps` or a small ArchUnit-based tool — the prototype's `CodeGraphExporter` is exactly this) dumps the real package-dependency graph as a `codegraph` JSON document → Bausteinsicht ingests it as an `asIs` snapshot (projected through `codeMapping`) → the existing `bausteinsicht diff` command compares it against `toBe` → proposes curated model patches. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; edits are proposed, never written back silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
+* **Prototype the forward mechanism with Variant B** (fastest proof, zero new parser) for the *diagram-intermediate* path; **Variant A is retained as a fallback** for expressiveness if C stalls; **Variant C is the target** and now has a working reference implementation, conditional on the open points below.
 
 === Not yet implemented by this ADR
 
@@ -128,8 +141,10 @@ The `codegraph` schema, the `import-graph` command, the Variant B PlantUML emitt
 Gating the forward mechanism's move from B to C:
 
 * Must the failing gate be a **native JUnit/IDE test** (→ Variant C/A), or is a **separate CI step** running the Bausteinsicht binary against an extracted graph acceptable (→ extractor + BS engine)?
-* Are we willing to treat the **JSONC model as a stable, versioned public API**, and who **owns** the Java-side adapter (Variant C)?
+* Are we willing to treat the **JSONC model as a stable, versioned public API**? Partially answered by <<variant-c-prototype>> — a real adapter already depends on the shape — but not yet a formal commitment (versioning policy, compatibility guarantees).
+* Who **owns** the Java-side adapter (Variant C) long-term? A prototype owner exists (ascheman, `docToolchain/bausteinsicht-archunit`), but its README lists the license as "TBD — to be aligned with the docToolchain organisation's policy," so its path to becoming the *official* adapter (vs. staying a reference prototype) is still open.
 * Diagram/export format for the Variant B emitter: plain-component PlantUML flavour only — the default C4 export is not adapter-parseable.
+* Should `codeMapping` become per-backend-keyed (#572 R6) once a second backend (#574, Go) exists, or does the flat shape decided here turn out to generalise (e.g. by adding a sibling field rather than reshaping this one)? Deliberately not decided now — see <<variant-c-prototype>>.
 
 Cross-cutting with #572 (tracked there, not here):
 
@@ -141,22 +156,25 @@ Cross-cutting with #572 (tracked there, not here):
 === Positive
 
 * `codeMapping` gives elements a real anchor into code without committing to any specific forward mechanism yet — the field is useful (and stable) regardless of how the A/B/C question resolves.
+* Its exact shape is not speculative: a real, tested adapter (<<variant-c-prototype>>) already reads it and builds passing ArchUnit rules from it.
 * The reverse/drift path reuses `asIs`/`toBe`/`diff` unchanged — no new mechanism, no new UI, no new command family beyond `import-graph`.
-* Per-backend keying means the second backend (#574, Go) does not need a schema migration.
+* The flat shape is the simplest thing that could work and is what's actually running today; per-backend keying is deferred rather than paid for upfront.
 
 === Negative
 
-* Shipping the field now, ahead of any command that consumes it, means it is unvalidated against real usage until `import-graph` and a forward emitter land — it could still need adjustment (e.g. additional match kinds per R6's `paths` proposal for C/C++, deliberately deferred).
-* The staged decision leaves the *target* forward variant (C) unresolved; teams adopting `codeMapping` today are anchoring elements without yet getting rule enforcement.
+* The flat shape does not (yet) support one element mapping to more than one backend's code simultaneously — deferred per <<open-questions>>, and would be a breaking schema change if needed later.
+* The staged decision leaves the *target* forward variant (C) unresolved as an *official* commitment; teams adopting `codeMapping` today are anchoring elements without a guaranteed-stable public-API promise yet, even though a working adapter already exists.
+* Bausteinsicht's own `import-graph`/forward-emitter side (consuming `codeMapping` and producing/reading `codegraph`) is still unimplemented — the prototype validates the *contract*, not the Bausteinsicht-side implementation.
 
 === Risk
 
-* R-CODEGOV-1: `codeMapping.packages` prefix-matching semantics are convention-based (mirroring ArchUnit's package matcher), not currently validated by any Bausteinsicht code path — a malformed prefix is a silent no-match until `import-graph` exists to exercise it.
+* R-CODEGOV-1: `codeMapping.packages` prefix-matching semantics are convention-based (mirroring ArchUnit's package matcher), not currently validated by any Bausteinsicht code path — a malformed prefix is a silent no-match until `import-graph` exists to exercise it. Partially mitigated: the shape itself is validated by <<variant-c-prototype>>, just not Bausteinsicht's own production of/consumption of it yet.
 
 == References
 
 * Epic: https://github.com/docToolchain/Bausteinsicht/issues/562[#562] — RFE: Generate & synchronize code-level architecture rules (ArchUnit) from the model. Source of this ADR's content (motivation, variants, Pugh matrix, reverse-path design).
 * https://github.com/docToolchain/Bausteinsicht/issues/570[#570] — RFE: Model DDD / Hexagonal Architecture with xMolecules-aligned vocabulary (umbrella; this ADR is a descendant of its layer 4 "Bridge to code").
-* https://github.com/docToolchain/Bausteinsicht/issues/572[#572] — RFE: Multi-language code-governance backends beyond ArchUnit/JVM. Source of the per-backend `codeMapping` keying adopted here (R6), and of the `RuleBackend` abstraction (R1) this ADR's implementation must stay compatible with.
+* https://github.com/docToolchain/Bausteinsicht/issues/572[#572] — RFE: Multi-language code-governance backends beyond ArchUnit/JVM. Proposes per-backend `codeMapping` keying (R6) and the `RuleBackend` abstraction (R1); this ADR deliberately does *not* adopt the R6 keying yet — see <<variant-c-prototype>> and <<open-questions>>.
+* https://github.com/docToolchain/bausteinsicht-archunit[docToolchain/bausteinsicht-archunit] — the Variant C prototype whose contract this ADR's `codeMapping` shape matches exactly.
 * `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
 * `internal/model/types.go` — `Element.CodeMapping`, `CodeMapping`.

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -76,7 +76,7 @@ Element *-- "0..*" Element : children
 Element ..> ElementKind : kind
 Element ..> DecisionRecord : decisions
 Element *-- "0..*" DocLink : docLinks
-Element *-- "0..*" CodeMapping : codeMapping
+Element *-- "0..1" CodeMapping : codeMapping
 
 Relationship ..> Element : from / to
 Relationship ..> RelationshipKind : kind
@@ -285,9 +285,9 @@ The model has these top-level sections. `specification`, `model`, `relationships
 | Typed documentation links (arc42 chapter, ADR, PRD/persona, spec, ...), rendered as clickable icons next to the element in HTML/SVG export — independent of `link`/`decisions`, which also get their own icons. See <<DocLink Properties>> and ADR-009's "Extension: Doc/ADR Drilldown Icons (#543)".
 
 | `codeMapping`
-| object (backend → CodeMapping)
+| CodeMapping
 | no
-| Anchors this element to real code, keyed per code-governance backend (e.g. `"java"`) so a polyglot element doesn't collide across languages. Consumed by the code-governance bridge (`import-graph`, forward rule generation) — not yet by any shipped command. See <<CodeMapping Properties>> and ADR-013.
+| Anchors this element to real code for the code-governance bridge (ArchUnit first). Consumed by `import-graph`/forward rule generation — not yet by any shipped command, but already validated against a real adapter, see <<CodeMapping Properties>> and ADR-013.
 |===
 
 The **key** of each element in the model object (e.g., `"customer"`, `"api"`) serves as its unique ID.
@@ -321,8 +321,6 @@ A `DocLink` is a typed link to an external documentation artifact, usable on bot
 [[CodeMapping Properties]]
 ==== CodeMapping Properties
 
-`Element.codeMapping` is an object keyed by backend name (e.g. `"java"`, `"go"`), each value a `CodeMapping`:
-
 [cols="1,1,1,3"]
 |===
 | Property | Type | Required | Description
@@ -330,7 +328,7 @@ A `DocLink` is a typed link to an external documentation artifact, usable on bot
 | `packages`
 | string[]
 | no
-| Backend-native package/namespace/module prefixes belonging to this element, prefix-matched the way ArchUnit's package matcher works (e.g. `"com.acme.backend.orders.."`).
+| Package prefixes belonging to this element, without the trailing ArchUnit `..` wildcard — the consuming adapter appends it itself (e.g. `"com.acme.backend.orders"`, not `"com.acme.backend.orders.."`).
 |===
 
 [source,jsonc]
@@ -338,13 +336,13 @@ A `DocLink` is a typed link to an external documentation artifact, usable on bot
 "orders": {
   "kind": "container",
   "title": "Order API",
-  "codeMapping": {
-    "java": { "packages": ["com.acme.backend.orders.."] }
-  }
+  "codeMapping": { "packages": ["com.acme.backend.orders"] }
 }
 ----
 
-Keying per backend (rather than a flat `packages` list) lets one element carry mappings for more than one language without collision — e.g. a service with both a Java implementation and a generated .NET client. See ADR-013 for the design and staging of the code-governance bridge this field anchors.
+This exact shape is validated end-to-end by an external prototype adapter, https://github.com/docToolchain/bausteinsicht-archunit — its `BausteinsichtRules.fromModel()` reads this field to build ArchUnit rules (forward), and its `CodeGraphExporter` dumps the real package graph as a `codegraph` JSON document for Bausteinsicht to ingest as an `asIs` snapshot (reverse). See ADR-013 for the full design and staging of the code-governance bridge this field anchors.
+
+NOTE: `codeMapping` is flat — one mapping per element — not keyed per backend. A polyglot element (e.g. a service with both a Java implementation and a generated .NET client) is out of scope until a second backend actually needs it; see ADR-013's "Open Questions".
 
 [[element-lifecycle]]
 ==== Element Lifecycle

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -50,6 +50,7 @@ class TagDefinition
 class PatternDefinition
 class DecisionRecord
 class DocLink
+class CodeMapping
 class Element
 class Relationship
 class View
@@ -75,6 +76,7 @@ Element *-- "0..*" Element : children
 Element ..> ElementKind : kind
 Element ..> DecisionRecord : decisions
 Element *-- "0..*" DocLink : docLinks
+Element *-- "0..*" CodeMapping : codeMapping
 
 Relationship ..> Element : from / to
 Relationship ..> RelationshipKind : kind
@@ -281,6 +283,11 @@ The model has these top-level sections. `specification`, `model`, `relationships
 | DocLink[]
 | no
 | Typed documentation links (arc42 chapter, ADR, PRD/persona, spec, ...), rendered as clickable icons next to the element in HTML/SVG export — independent of `link`/`decisions`, which also get their own icons. See <<DocLink Properties>> and ADR-009's "Extension: Doc/ADR Drilldown Icons (#543)".
+
+| `codeMapping`
+| object (backend → CodeMapping)
+| no
+| Anchors this element to real code, keyed per code-governance backend (e.g. `"java"`) so a polyglot element doesn't collide across languages. Consumed by the code-governance bridge (`import-graph`, forward rule generation) — not yet by any shipped command. See <<CodeMapping Properties>> and ADR-013.
 |===
 
 The **key** of each element in the model object (e.g., `"customer"`, `"api"`) serves as its unique ID.
@@ -310,6 +317,34 @@ A `DocLink` is a typed link to an external documentation artifact, usable on bot
 | no
 | Icon tooltip text. Defaults to `type` when omitted.
 |===
+
+[[CodeMapping Properties]]
+==== CodeMapping Properties
+
+`Element.codeMapping` is an object keyed by backend name (e.g. `"java"`, `"go"`), each value a `CodeMapping`:
+
+[cols="1,1,1,3"]
+|===
+| Property | Type | Required | Description
+
+| `packages`
+| string[]
+| no
+| Backend-native package/namespace/module prefixes belonging to this element, prefix-matched the way ArchUnit's package matcher works (e.g. `"com.acme.backend.orders.."`).
+|===
+
+[source,jsonc]
+----
+"orders": {
+  "kind": "container",
+  "title": "Order API",
+  "codeMapping": {
+    "java": { "packages": ["com.acme.backend.orders.."] }
+  }
+}
+----
+
+Keying per backend (rather than a flat `packages` list) lets one element carry mappings for more than one language without collision — e.g. a service with both a Java implementation and a generated .NET client. See ADR-013 for the design and staging of the code-governance bridge this field anchors.
 
 [[element-lifecycle]]
 ==== Element Lifecycle


### PR DESCRIPTION
## Summary
Part of #562 (RFE: generate & synchronize code-level architecture rules — ArchUnit first), which is itself the prerequisite for the multi-language code-governance epic (#572).

This PR ships **only R5** — the `codeMapping` field #562 calls out as its own prerequisite ("no code anchor exists today"). It's deliberately scoped small; #562's other pieces (`codegraph` schema, `import-graph` command, Variant B PlantUML emitter, `RuleBackend` abstraction) are follow-up PRs, called out explicitly in the new ADR so the sequencing is visible from the design doc itself.

## Design decision (updated after review)
Added **ADR-013**, reusing #562's own motivation/variants/Pugh-matrix analysis. The first push of this PR shipped `codeMapping` keyed per backend (`{"java": {...}, "go": {...}}`), speculatively adopted from #572's R6 proposal for future multi-language support.

**That was wrong** — [ascheman's comment on #562](https://github.com/docToolchain/Bausteinsicht/issues/562#issuecomment-4992739242) points at a runnable Variant C prototype, https://github.com/docToolchain/bausteinsicht-archunit, with a green `mvn verify` integration test implementing *both* directions of this RFE. Its `Element` type reads a **flat** `codeMapping: { packages: [...] }` — no backend key. I hadn't seen that comment before the first push. Matching a real, tested, already-running contract beats a speculative one nothing has exercised yet, so this PR now ships the flat shape instead, with a test (`TestElement_CodeMapping_MatchesArchUnitPrototypeContract`) pinning the exact external fixture shape so a future change here can't silently break that adapter. Per-backend keying is deferred in ADR-013's Open Questions until a second backend genuinely needs it.

- **Decided:** ArchUnit as the first backend, flat `codeMapping` field (validated against a real adapter), and the reverse/drift path (extractor → `codegraph` → `asIs` snapshot → existing `diff` → curated model-patch proposals, model always wins).
- **Staged/open:** the forward mechanism's *official* status (native-test-vs-CI-step gate, formal public-API commitment, prototype's license is TBD).

## Changes
- `internal/model/types.go` — `CodeMapping` type (`Packages []string`) + `Element.CodeMapping *CodeMapping` (pointer, one per element — matches the `AsIs`/`ToBe` optional-struct precedent)
- `schemas/bausteinsicht.schema.json` — regenerated via `bausteinsicht schema generate`
- `src/docs/spec/03_data_models.adoc` — `codeMapping` property row, "CodeMapping Properties" subsection with example + link to the validating prototype, entity diagram (`0..1` cardinality)
- `src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc` — new ADR, including a "Variant C prototype" section documenting the validation evidence

## Test plan
- [x] `TestElement_CodeMapping_JSONRoundTrip` — round-trips through JSON
- [x] `TestElement_CodeMapping_MatchesArchUnitPrototypeContract` — pins the exact JSON shape the external adapter's test fixture uses
- [x] `TestElement_CodeMapping_OmittedWhenAbsent` — no stray `codeMapping` key on existing models without it (backward compatible)
- [x] `TestCommittedSchemaInSync` (existing drift guard) passes against the regenerated schema
- [x] `go build`, `go vet`, `gofmt -l`, `staticcheck`, `make arc42-drift-check` all clean
- [x] Full `go test ./...` green
- No new command/flag, so no new e2e scenario required per the PR merge policy — this field has no Bausteinsicht-side consumer yet (that's the follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
