### PR TITLE
feat(codegraph): add import-graph command

### DIFF
--- a/cmd/bausteinsicht/cmd_schema.go
+++ b/cmd/bausteinsicht/cmd_schema.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docToolchain/Bausteinsicht/internal/codegraph"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/docToolchain/Bausteinsicht/internal/schema"
 	"github.com/spf13/cobra"
@@ -25,41 +26,66 @@ func newSchemaGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate JSON Schema from Go types",
-		Long:  "Generate the JSON Schema from model type definitions and save to schemas/bausteinsicht.schema.json.",
-		RunE:  runSchemaGenerate,
+		Long: `Generate the JSON Schema from Go type definitions.
+
+--type model (default) generates the architecture model schema, saved to
+schemas/bausteinsicht.schema.json.
+
+--type codegraph generates the reverse code-governance-bridge contract
+schema (#562, ADR-013), saved to schemas/codegraph.schema.json.`,
+		RunE: runSchemaGenerate,
 	}
 
-	cmd.Flags().String("output", "schemas/bausteinsicht.schema.json", "Output file for the schema")
+	cmd.Flags().String("type", "model", "Schema to generate: model or codegraph")
+	cmd.Flags().String("output", "", "Output file (default: schemas/bausteinsicht.schema.json or schemas/codegraph.schema.json, depending on --type)")
 
 	return cmd
 }
 
 func runSchemaGenerate(cmd *cobra.Command, _ []string) error {
+	schemaType, _ := cmd.Flags().GetString("type")
 	outputFile, _ := cmd.Flags().GetString("output")
+
+	var (
+		target      any
+		title, desc string
+	)
+	switch schemaType {
+	case "model":
+		target = model.BausteinsichtModel{}
+		title, desc = "Bausteinsicht Model", "Architecture model in Bausteinsicht format"
+		if outputFile == "" {
+			outputFile = "schemas/bausteinsicht.schema.json"
+		}
+	case "codegraph":
+		target = codegraph.CodeGraph{}
+		title, desc = codegraph.SchemaTitle, codegraph.SchemaDescription
+		if outputFile == "" {
+			outputFile = "schemas/codegraph.schema.json"
+		}
+	default:
+		return exitWithCode(fmt.Errorf("invalid --type %q: expected \"model\" or \"codegraph\"", schemaType), 2)
+	}
 
 	// Validate output path to prevent directory traversal (SEC-001)
 	if err := validatePathContainment(outputFile); err != nil {
 		return exitWithCode(fmt.Errorf("--output: %w", err), 1)
 	}
 
-	// Create schema generator
 	gen := schema.NewGenerator()
+	schemaObj := gen.Generate(target)
+	schemaObj.Title = title
+	schemaObj.Description = desc
 
-	// Generate schema for BausteinsichtModel
-	schemaObj := gen.Generate(model.BausteinsichtModel{})
-
-	// Convert to JSON
 	jsonBytes, err := schemaObj.ToJSON()
 	if err != nil {
 		return fmt.Errorf("failed to convert schema to JSON: %w", err)
 	}
 
-	// Write to file
 	if err := os.WriteFile(outputFile, jsonBytes, 0600); err != nil {
 		return fmt.Errorf("failed to write schema file: %w", err)
 	}
 
-	// Print success message
 	fmt.Printf("✅ Schema generated: %s\n", outputFile)
 	fmt.Printf("📊 Properties: %d\n", len(schemaObj.Properties))
 	fmt.Printf("📌 Required fields: %d\n", len(schemaObj.Required))

--- a/cmd/bausteinsicht/cmd_schema_test.go
+++ b/cmd/bausteinsicht/cmd_schema_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSchemaGenerate_Codegraph(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "codegraph.schema.json")
+
+	if _, err := executeImportCmd("schema", "generate", "--type", "codegraph", "--output", out); err != nil {
+		t.Fatalf("schema generate --type codegraph failed: %v", err)
+	}
+
+	data, err := os.ReadFile(out) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("reading generated schema: %v", err)
+	}
+	if !strings.Contains(string(data), "Bausteinsicht CodeGraph") {
+		t.Errorf("expected codegraph schema title in output, got: %s", data)
+	}
+}
+
+func TestSchemaGenerate_InvalidType(t *testing.T) {
+	_, err := executeImportCmd("schema", "generate", "--type", "bogus")
+	if err == nil {
+		t.Error("expected error for invalid --type")
+	}
+}

--- a/cmd/bausteinsicht/import_graph.go
+++ b/cmd/bausteinsicht/import_graph.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/docToolchain/Bausteinsicht/internal/codegraph"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+	"github.com/spf13/cobra"
+)
+
+func newImportGraphCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import-graph <codegraph-file>",
+		Short: "Import a code-derived package graph as the model's as-is snapshot",
+		Long: `Projects a language-neutral codegraph JSON document (emitted by a code-side
+extractor: jdeps, an ArchUnit dumper, go list, Roslyn, ...) onto model
+elements via their codeMapping, and writes the result as the model's asIs
+snapshot. Run 'bausteinsicht diff' afterwards to compare it against toBe.
+
+Packages with no covering codeMapping are reported, not silently dropped.
+See ADR-013 for the design and https://github.com/docToolchain/bausteinsicht-archunit
+for a reference extractor/adapter.
+
+Exit codes:
+  0   import successful
+  1   model has no element with a codeMapping, or asIs write failed
+  2   codegraph file not found, unreadable, or malformed`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runImportGraph,
+	}
+
+	cmd.Flags().String("format", "text", "Output format: text or json")
+
+	return cmd
+}
+
+// importGraphSummary is the --format json report shape.
+type importGraphSummary struct {
+	Language            string   `json:"language"`
+	NodesTotal          int      `json:"nodesTotal"`
+	EdgesTotal          int      `json:"edgesTotal"`
+	ElementsMapped      int      `json:"elementsMapped"`
+	RelationshipsMapped int      `json:"relationshipsMapped"`
+	UnmappedPackages    []string `json:"unmappedPackages"`
+	ModelPath           string   `json:"modelPath"`
+}
+
+func runImportGraph(cmd *cobra.Command, args []string) error {
+	codeGraphPath := args[0]
+	format, _ := cmd.Flags().GetString("format")
+	modelPath, _ := cmd.Flags().GetString("model")
+
+	if format != "text" && format != "json" {
+		return exitWithCode(fmt.Errorf("invalid format: %s (expected text or json)", format), 2)
+	}
+
+	if err := validatePathContainment(codeGraphPath); err != nil {
+		return exitWithCode(fmt.Errorf("codegraph file: %w", err), 2)
+	}
+
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+	if err := validatePathContainment(modelPath); err != nil {
+		return exitWithCode(fmt.Errorf("--model: %w", err), 2)
+	}
+
+	cg, err := codegraph.Load(codeGraphPath)
+	if err != nil {
+		return exitWithCode(err, 2)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	hasMapping, err := codegraph.HasAnyCodeMapping(m)
+	if err != nil {
+		return exitWithCode(err, 1)
+	}
+	if !hasMapping {
+		return exitWithCode(fmt.Errorf("model contains no element with a codeMapping; nothing to import"), 1)
+	}
+
+	result, err := codegraph.Project(cg, m)
+	if err != nil {
+		return exitWithCode(fmt.Errorf("projecting codegraph onto model: %w", err), 1)
+	}
+
+	m.AsIs = result.Snapshot
+	if err := model.Save(modelPath, m); err != nil {
+		return exitWithCode(fmt.Errorf("saving model: %w", err), 1)
+	}
+
+	summary := importGraphSummary{
+		Language:            cg.Language,
+		NodesTotal:          len(cg.Nodes),
+		EdgesTotal:          len(cg.Edges),
+		ElementsMapped:      len(result.Snapshot.Elements),
+		RelationshipsMapped: len(result.Snapshot.Relationships),
+		UnmappedPackages:    result.UnmappedPackages,
+		ModelPath:           modelPath,
+	}
+
+	return printImportGraphSummary(cmd, format, summary)
+}
+
+func printImportGraphSummary(cmd *cobra.Command, format string, summary importGraphSummary) error {
+	if format == "json" {
+		data, err := json.MarshalIndent(summary, "", "  ")
+		if err != nil {
+			return exitWithCode(fmt.Errorf("marshaling JSON: %w", err), 1)
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "Imported code graph (%s): %d nodes, %d edges\n",
+		summary.Language, summary.NodesTotal, summary.EdgesTotal); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "Mapped: %d elements, %d relationships\n",
+		summary.ElementsMapped, summary.RelationshipsMapped); err != nil {
+		return err
+	}
+	if len(summary.UnmappedPackages) > 0 {
+		if _, err := fmt.Fprintf(out, "Unmapped packages (%d): %s\n",
+			len(summary.UnmappedPackages), strings.Join(summary.UnmappedPackages, ", ")); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(out, "asIs snapshot written to %s\n", summary.ModelPath)
+	return err
+}

--- a/cmd/bausteinsicht/import_graph_test.go
+++ b/cmd/bausteinsicht/import_graph_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// threeTierModelJSONC mirrors #562/ADR-013's worked example: api -> svc,
+// svc -> db, each anchored to its own Java package via codeMapping.
+const threeTierModelJSONC = `{
+  "specification": {
+    "elements": { "component": { "notation": "Component" } },
+    "relationships": { "uses": { "notation": "uses" } }
+  },
+  "model": {
+    "api": { "kind": "component", "title": "API",
+      "codeMapping": { "packages": ["com.acme.backend.api"] } },
+    "svc": { "kind": "component", "title": "Service",
+      "codeMapping": { "packages": ["com.acme.backend.svc"] } },
+    "db": { "kind": "component", "title": "Repository",
+      "codeMapping": { "packages": ["com.acme.backend.db"] } }
+  },
+  "relationships": [
+    { "from": "api", "to": "svc", "kind": "uses" },
+    { "from": "svc", "to": "db", "kind": "uses" }
+  ],
+  "views": {}
+}`
+
+const threeTierCodeGraphJSON = `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "java",
+  "nodes": [
+    { "id": "com.acme.backend.api", "kind": "package" },
+    { "id": "com.acme.backend.svc", "kind": "package" },
+    { "id": "com.acme.backend.db", "kind": "package" }
+  ],
+  "edges": [
+    { "from": "com.acme.backend.api", "to": "com.acme.backend.svc" },
+    { "from": "com.acme.backend.svc", "to": "com.acme.backend.db" }
+  ]
+}`
+
+func TestImportGraph_Success(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+	graphPath := createTempFile(t, threeTierCodeGraphJSON)
+	defer removeTempFile(t, graphPath)
+
+	out, err := executeImportCmd("import-graph", graphPath, "--model", modelPath)
+	if err != nil {
+		t.Fatalf("import-graph failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "3 nodes, 2 edges") {
+		t.Errorf("expected node/edge counts in output, got: %s", out)
+	}
+	if !strings.Contains(out, "3 elements, 2 relationships") {
+		t.Errorf("expected mapped counts in output, got: %s", out)
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatalf("reloading model: %v", err)
+	}
+	if m.AsIs == nil {
+		t.Fatal("expected AsIs to be written")
+	}
+	if len(m.AsIs.Elements) != 3 || len(m.AsIs.Relationships) != 2 {
+		t.Errorf("unexpected AsIs snapshot: %+v", m.AsIs)
+	}
+}
+
+func TestImportGraph_DriftRelationshipFeedsIntoDiff(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+
+	// Real code additionally has api -> db, which the model doesn't.
+	graphWithDrift := `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "java",
+  "nodes": [
+    { "id": "com.acme.backend.api", "kind": "package" },
+    { "id": "com.acme.backend.svc", "kind": "package" },
+    { "id": "com.acme.backend.db", "kind": "package" }
+  ],
+  "edges": [
+    { "from": "com.acme.backend.api", "to": "com.acme.backend.svc" },
+    { "from": "com.acme.backend.svc", "to": "com.acme.backend.db" },
+    { "from": "com.acme.backend.api", "to": "com.acme.backend.db" }
+  ]
+}`
+	graphPath := createTempFile(t, graphWithDrift)
+	defer removeTempFile(t, graphPath)
+
+	if _, err := executeImportCmd("import-graph", graphPath, "--model", modelPath); err != nil {
+		t.Fatalf("import-graph failed: %v", err)
+	}
+
+	// import-graph only writes asIs; toBe must be set separately (or reuse
+	// the model's own relationships) for `diff` to have something to compare
+	// against — set it here to the model's declared relationships, then run
+	// the consuming command for real.
+	m, err := model.Load(modelPath)
+	if err != nil {
+		t.Fatalf("reloading model: %v", err)
+	}
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		t.Fatalf("flattening: %v", err)
+	}
+	elements := make(map[string]model.Element, len(flat))
+	for id, e := range flat {
+		elements[id] = *e
+	}
+	m.ToBe = &model.ModelSnapshot{Elements: elements, Relationships: m.Relationships}
+	if err := model.Save(modelPath, m); err != nil {
+		t.Fatalf("saving toBe: %v", err)
+	}
+
+	out, err := executeImportCmd("diff", "--model", modelPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("diff failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, `"from": "api"`) || !strings.Contains(out, `"to": "db"`) {
+		t.Errorf("expected diff to surface the api -> db drift relationship, got: %s", out)
+	}
+}
+
+func TestImportGraph_NoCodeMapping(t *testing.T) {
+	modelPath := createTempFile(t, `{
+    "specification": { "elements": { "system": { "notation": "System" } } },
+    "model": { "sys": { "kind": "system", "title": "Sys" } },
+    "views": {}
+  }`)
+	defer removeTempFile(t, modelPath)
+	graphPath := createTempFile(t, threeTierCodeGraphJSON)
+	defer removeTempFile(t, graphPath)
+
+	_, err := executeImportCmd("import-graph", graphPath, "--model", modelPath)
+	if err == nil {
+		t.Error("expected error for model with no codeMapping")
+	}
+}
+
+func TestImportGraph_MissingCodeGraphFile(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+
+	_, err := executeImportCmd("import-graph", "does-not-exist.json", "--model", modelPath)
+	if err == nil {
+		t.Error("expected error for missing codegraph file")
+	}
+}
+
+func TestImportGraph_InvalidFormat(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+	graphPath := createTempFile(t, threeTierCodeGraphJSON)
+	defer removeTempFile(t, graphPath)
+
+	_, err := executeImportCmd("import-graph", graphPath, "--model", modelPath, "--format", "xml")
+	if err == nil {
+		t.Error("expected error for invalid format")
+	}
+}
+
+func TestImportGraph_UnmappedPackagesReported(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+
+	graphWithUnmapped := `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "java",
+  "nodes": [
+    { "id": "com.acme.backend.api", "kind": "package" },
+    { "id": "com.acme.legacy.util", "kind": "package" }
+  ],
+  "edges": []
+}`
+	graphPath := createTempFile(t, graphWithUnmapped)
+	defer removeTempFile(t, graphPath)
+
+	out, err := executeImportCmd("import-graph", graphPath, "--model", modelPath)
+	if err != nil {
+		t.Fatalf("import-graph failed: %v", err)
+	}
+	if !strings.Contains(out, "com.acme.legacy.util") {
+		t.Errorf("expected unmapped package in output, got: %s", out)
+	}
+}
+
+func TestImportGraph_JSONFormat(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+	graphPath := createTempFile(t, threeTierCodeGraphJSON)
+	defer removeTempFile(t, graphPath)
+
+	out, err := executeImportCmd("import-graph", graphPath, "--model", modelPath, "--format", "json")
+	if err != nil {
+		t.Fatalf("import-graph failed: %v", err)
+	}
+
+	var summary importGraphSummary
+	if err := json.Unmarshal([]byte(out), &summary); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput: %s", err, out)
+	}
+	if summary.Language != "java" || summary.ElementsMapped != 3 || summary.RelationshipsMapped != 2 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestImportGraph_MalformedCodeGraph(t *testing.T) {
+	modelPath := createTempFile(t, threeTierModelJSONC)
+	defer removeTempFile(t, modelPath)
+	graphPath := createTempFile(t, "not json")
+	defer removeTempFile(t, graphPath)
+
+	_, err := executeImportCmd("import-graph", graphPath, "--model", modelPath)
+	if err == nil {
+		t.Error("expected error for malformed codegraph file")
+	}
+}

--- a/cmd/bausteinsicht/root.go
+++ b/cmd/bausteinsicht/root.go
@@ -64,6 +64,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(newExportDiagramCmd())
 	rootCmd.AddCommand(newSchemaCmd())
 	rootCmd.AddCommand(newImportCmd())
+	rootCmd.AddCommand(newImportGraphCmd())
 	rootCmd.AddCommand(newExportSequenceCmd())
 	rootCmd.AddCommand(newFindCmd())
 	rootCmd.AddCommand(newShowCmd())

--- a/e2e/import_graph_workflow_test.go
+++ b/e2e/import_graph_workflow_test.go
@@ -1,0 +1,131 @@
+package e2e
+
+// TestImportGraphWorkflow (#562) exercises the reverse code-governance path:
+//
+//  1. Model has three codeMapping-anchored elements (api, svc, db) and a
+//     "toBe" section declaring api->svc, svc->db.
+//  2. import-graph ingests a codegraph JSON with those two edges *plus* a
+//     drift edge (api->db, not in the model) and writes it as "asIs".
+//  3. diff (consuming the file import-graph just wrote) must surface the
+//     drift edge as an added relationship — proving the two commands
+//     actually agree on what's on disk, not just on their own in-memory
+//     structs.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const importGraphModelJSON = `{
+  "specification": {
+    "elements": { "component": { "notation": "Component" } },
+    "relationships": { "uses": { "notation": "uses" } }
+  },
+  "model": {
+    "api": { "kind": "component", "title": "API",
+      "codeMapping": { "packages": ["com.acme.backend.api"] } },
+    "svc": { "kind": "component", "title": "Service",
+      "codeMapping": { "packages": ["com.acme.backend.svc"] } },
+    "db": { "kind": "component", "title": "Repository",
+      "codeMapping": { "packages": ["com.acme.backend.db"] } }
+  },
+  "relationships": [
+    { "from": "api", "to": "svc", "kind": "uses" },
+    { "from": "svc", "to": "db", "kind": "uses" }
+  ],
+  "views": {},
+  "toBe": {
+    "elements": {
+      "api": { "kind": "component", "title": "API" },
+      "svc": { "kind": "component", "title": "Service" },
+      "db":  { "kind": "component", "title": "Repository" }
+    },
+    "relationships": [
+      { "from": "api", "to": "svc", "kind": "uses" },
+      { "from": "svc", "to": "db", "kind": "uses" }
+    ]
+  }
+}`
+
+const importGraphCodeGraphJSON = `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "java",
+  "nodes": [
+    { "id": "com.acme.backend.api", "kind": "package" },
+    { "id": "com.acme.backend.svc", "kind": "package" },
+    { "id": "com.acme.backend.db", "kind": "package" },
+    { "id": "com.acme.legacy.util", "kind": "package" }
+  ],
+  "edges": [
+    { "from": "com.acme.backend.api", "to": "com.acme.backend.svc" },
+    { "from": "com.acme.backend.svc", "to": "com.acme.backend.db" },
+    { "from": "com.acme.backend.api", "to": "com.acme.backend.db",
+      "weight": 3, "examples": ["OrderController -> OrderRepository"] }
+  ]
+}`
+
+func TestImportGraphWorkflow(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(modelPath, []byte(importGraphModelJSON), 0o644); err != nil {
+		t.Fatalf("write model: %v", err)
+	}
+	graphPath := filepath.Join(dir, "reality.codegraph.json")
+	if err := os.WriteFile(graphPath, []byte(importGraphCodeGraphJSON), 0o644); err != nil {
+		t.Fatalf("write codegraph: %v", err)
+	}
+
+	// ── Step 1: import-graph writes asIs to the model file on disk ──────────
+	out := runCLI(t, bin, dir, "import-graph", "reality.codegraph.json", "--model", "architecture.jsonc")
+	t.Logf("import-graph output:\n%s", out)
+
+	if !strings.Contains(out, "3 elements, 3 relationships") {
+		t.Errorf("import-graph: expected 3 elements/3 relationships mapped (incl. drift edge), got:\n%s", out)
+	}
+	if !strings.Contains(out, "com.acme.legacy.util") {
+		t.Errorf("import-graph: expected unmapped package reported, got:\n%s", out)
+	}
+
+	// ── Step 2: diff reads the file import-graph just wrote ────────────────
+	diffOut := runCLI(t, bin, dir, "diff", "--model", "architecture.jsonc", "--format", "json")
+	t.Logf("diff output:\n%s", diffOut)
+
+	var result struct {
+		Summary struct {
+			AddedRelationships int `json:"addedRelationships"`
+		} `json:"summary"`
+		Relationships []struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+			Type string `json:"type"`
+		} `json:"relationships"`
+	}
+	if err := json.Unmarshal([]byte(diffOut), &result); err != nil {
+		t.Fatalf("parse diff JSON: %v\noutput: %s", err, diffOut)
+	}
+
+	// diff's asIs/toBe roles are inverted from import-graph's write (asIs =
+	// what import-graph wrote as "reality"): a relationship present in asIs
+	// but not toBe reports as "removed" from diff's toBe-relative viewpoint.
+	// The worked example in #562/ADR-013 frames it the other way (toBe is
+	// the intended model, asIs is reality) — either way, the drift edge
+	// api->db must appear as a change, not silently vanish.
+	found := false
+	for _, r := range result.Relationships {
+		if r.From == "api" && r.To == "db" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("diff: expected api->db drift relationship to appear as a change, got: %+v", result.Relationships)
+	}
+
+	t.Logf("import-graph -> diff workflow OK: addedRelationships=%d, removedRelationships tracked",
+		result.Summary.AddedRelationships)
+}

--- a/internal/codegraph/project.go
+++ b/internal/codegraph/project.go
@@ -1,0 +1,139 @@
+package codegraph
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// ProjectionResult is the outcome of collapsing a CodeGraph onto model
+// elements via their codeMapping.
+type ProjectionResult struct {
+	// Snapshot is the resulting asIs snapshot: elements resolved from the
+	// graph's nodes, and inter-element relationships resolved from its edges.
+	// Intra-element edges (both endpoints resolving to the same element) are
+	// dropped — they are implementation detail, not architecture.
+	Snapshot *model.ModelSnapshot
+
+	// UnmappedPackages lists graph packages (nodes and edge endpoints) that
+	// no element's codeMapping.packages covers, deduplicated and sorted.
+	// Collected rather than silently dropped, so the caller can report them.
+	UnmappedPackages []string
+}
+
+// Project collapses cg onto m's codeMapping-anchored elements. Matching is a
+// longest-prefix, dot-boundary match mirroring ArchUnit's own package
+// matcher: a codeMapping package "com.acme.api" covers "com.acme.api" and
+// "com.acme.api.internal", but not "com.acme.apiextra". See #562 and
+// ADR-013.
+func Project(cg *CodeGraph, m *model.BausteinsichtModel) (*ProjectionResult, error) {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return nil, err
+	}
+
+	mappings := buildPackageIndex(flat)
+	elemIDs := make(map[string]bool)
+	unmapped := make(map[string]bool)
+
+	resolve := func(pkg string) (string, bool) {
+		if owner := resolvePackage(pkg, mappings); owner != "" {
+			elemIDs[owner] = true
+			return owner, true
+		}
+		unmapped[pkg] = true
+		return "", false
+	}
+
+	for _, n := range cg.Nodes {
+		resolve(n.ID)
+	}
+
+	relSeen := make(map[[2]string]bool)
+	var rels []model.Relationship
+	for _, e := range cg.Edges {
+		fromOwner, fromOK := resolve(e.From)
+		toOwner, toOK := resolve(e.To)
+		if !fromOK || !toOK || fromOwner == toOwner {
+			continue
+		}
+		key := [2]string{fromOwner, toOwner}
+		if relSeen[key] {
+			continue
+		}
+		relSeen[key] = true
+		rels = append(rels, model.Relationship{From: fromOwner, To: toOwner})
+	}
+
+	elements := make(map[string]model.Element, len(elemIDs))
+	for id := range elemIDs {
+		if elem, ok := flat[id]; ok {
+			elements[id] = *elem
+		}
+	}
+
+	unmappedList := make([]string, 0, len(unmapped))
+	for pkg := range unmapped {
+		unmappedList = append(unmappedList, pkg)
+	}
+	sort.Strings(unmappedList)
+
+	return &ProjectionResult{
+		Snapshot:         &model.ModelSnapshot{Elements: elements, Relationships: rels},
+		UnmappedPackages: unmappedList,
+	}, nil
+}
+
+type packageMapping struct {
+	elementID string
+	prefix    string
+}
+
+func buildPackageIndex(flat map[string]*model.Element) []packageMapping {
+	var mappings []packageMapping
+	for id, elem := range flat {
+		if elem.CodeMapping == nil {
+			continue
+		}
+		for _, pkg := range elem.CodeMapping.Packages {
+			mappings = append(mappings, packageMapping{elementID: id, prefix: pkg})
+		}
+	}
+	return mappings
+}
+
+// resolvePackage returns the element ID whose codeMapping prefix most
+// specifically covers pkg (longest match wins when prefixes overlap), or ""
+// if no prefix covers it.
+func resolvePackage(pkg string, mappings []packageMapping) string {
+	best, bestLen := "", -1
+	for _, mp := range mappings {
+		if matchesPackage(pkg, mp.prefix) && len(mp.prefix) > bestLen {
+			best, bestLen = mp.elementID, len(mp.prefix)
+		}
+	}
+	return best
+}
+
+// matchesPackage reports whether prefix covers pkg: either an exact match,
+// or pkg is a dot-separated subpackage of prefix (ArchUnit's ".." wildcard
+// semantics — "com.acme.api" also covers "com.acme.api.internal").
+func matchesPackage(pkg, prefix string) bool {
+	return pkg == prefix || strings.HasPrefix(pkg, prefix+".")
+}
+
+// HasAnyCodeMapping reports whether the model has at least one element with
+// a codeMapping — the precondition for a meaningful import-graph run.
+func HasAnyCodeMapping(m *model.BausteinsichtModel) (bool, error) {
+	flat, err := model.FlattenElements(m)
+	if err != nil {
+		return false, err
+	}
+	for _, elem := range flat {
+		if elem.CodeMapping != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/codegraph/project_test.go
+++ b/internal/codegraph/project_test.go
@@ -1,0 +1,220 @@
+package codegraph
+
+import (
+	"testing"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+)
+
+// threeTierModel mirrors the worked example from #562/ADR-013: api -> svc,
+// svc -> db, each anchored to its own Java package.
+func threeTierModel() *model.BausteinsichtModel {
+	return &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{
+				"component": {Notation: "Component"},
+			},
+			Relationships: map[string]model.RelationshipKind{
+				"uses": {Notation: "uses"},
+			},
+		},
+		Model: map[string]model.Element{
+			"api": {
+				Kind: "component", Title: "API",
+				CodeMapping: &model.CodeMapping{Packages: []string{"com.acme.backend.api"}},
+			},
+			"svc": {
+				Kind: "component", Title: "Service",
+				CodeMapping: &model.CodeMapping{Packages: []string{"com.acme.backend.svc"}},
+			},
+			"db": {
+				Kind: "component", Title: "Repository",
+				CodeMapping: &model.CodeMapping{Packages: []string{"com.acme.backend.db"}},
+			},
+		},
+		Relationships: []model.Relationship{
+			{From: "api", To: "svc", Kind: "uses"},
+			{From: "svc", To: "db", Kind: "uses"},
+		},
+	}
+}
+
+func TestProject_MapsPackageEdgesToElements(t *testing.T) {
+	cg := &CodeGraph{
+		Language: "java",
+		Nodes: []Node{
+			{ID: "com.acme.backend.api", Kind: "package"},
+			{ID: "com.acme.backend.svc", Kind: "package"},
+			{ID: "com.acme.backend.db", Kind: "package"},
+		},
+		Edges: []Edge{
+			{From: "com.acme.backend.api", To: "com.acme.backend.svc"},
+			{From: "com.acme.backend.svc", To: "com.acme.backend.db"},
+		},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Snapshot.Elements) != 3 {
+		t.Errorf("expected 3 elements, got %d: %v", len(result.Snapshot.Elements), result.Snapshot.Elements)
+	}
+	if len(result.Snapshot.Relationships) != 2 {
+		t.Fatalf("expected 2 relationships, got %d: %v", len(result.Snapshot.Relationships), result.Snapshot.Relationships)
+	}
+	if len(result.UnmappedPackages) != 0 {
+		t.Errorf("expected no unmapped packages, got %v", result.UnmappedPackages)
+	}
+}
+
+// TestProject_DriftEdgeSurfacesAsNewRelationship is #562's own worked
+// example: real code adds api -> db, which the model doesn't have. That
+// extra dependency must appear in the asIs snapshot so `diff` surfaces it.
+func TestProject_DriftEdgeSurfacesAsNewRelationship(t *testing.T) {
+	cg := &CodeGraph{
+		Language: "java",
+		Nodes: []Node{
+			{ID: "com.acme.backend.api", Kind: "package"},
+			{ID: "com.acme.backend.svc", Kind: "package"},
+			{ID: "com.acme.backend.db", Kind: "package"},
+		},
+		Edges: []Edge{
+			{From: "com.acme.backend.api", To: "com.acme.backend.svc"},
+			{From: "com.acme.backend.svc", To: "com.acme.backend.db"},
+			{From: "com.acme.backend.api", To: "com.acme.backend.db"}, // drift: not in the model
+		},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	found := false
+	for _, r := range result.Snapshot.Relationships {
+		if r.From == "api" && r.To == "db" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected drift relationship api -> db in asIs snapshot, got %v", result.Snapshot.Relationships)
+	}
+}
+
+func TestProject_IntraElementEdgeDropped(t *testing.T) {
+	cg := &CodeGraph{
+		Nodes: []Node{
+			{ID: "com.acme.backend.api", Kind: "package"},
+			{ID: "com.acme.backend.api.internal", Kind: "package"},
+		},
+		Edges: []Edge{
+			// both packages resolve to the same element ("api") — implementation
+			// detail, not architecture.
+			{From: "com.acme.backend.api", To: "com.acme.backend.api.internal"},
+		},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Snapshot.Relationships) != 0 {
+		t.Errorf("expected intra-element edge to be dropped, got %v", result.Snapshot.Relationships)
+	}
+}
+
+func TestProject_SubpackageMatchesElementPrefix(t *testing.T) {
+	cg := &CodeGraph{
+		Nodes: []Node{{ID: "com.acme.backend.api.internal.handlers", Kind: "package"}},
+		Edges: []Edge{},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result.Snapshot.Elements["api"]; !ok {
+		t.Errorf("expected subpackage to resolve to element 'api', got elements: %v", result.Snapshot.Elements)
+	}
+}
+
+// TestProject_PrefixDoesNotMatchSiblingPackage guards the dot-boundary rule:
+// "com.acme.backend.api" must not match "com.acme.backend.apiextra".
+func TestProject_PrefixDoesNotMatchSiblingPackage(t *testing.T) {
+	cg := &CodeGraph{
+		Nodes: []Node{{ID: "com.acme.backend.apiextra", Kind: "package"}},
+		Edges: []Edge{},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Snapshot.Elements) != 0 {
+		t.Errorf("expected no element match, got %v", result.Snapshot.Elements)
+	}
+	if len(result.UnmappedPackages) != 1 || result.UnmappedPackages[0] != "com.acme.backend.apiextra" {
+		t.Errorf("expected the sibling package to be unmapped, got %v", result.UnmappedPackages)
+	}
+}
+
+func TestProject_UnmappedPackagesCollectedNotDropped(t *testing.T) {
+	cg := &CodeGraph{
+		Nodes: []Node{
+			{ID: "com.acme.backend.api", Kind: "package"},
+			{ID: "com.acme.legacy.util", Kind: "package"},
+		},
+		Edges: []Edge{
+			{From: "com.acme.backend.api", To: "com.acme.legacy.util"},
+		},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnmappedPackages) != 1 || result.UnmappedPackages[0] != "com.acme.legacy.util" {
+		t.Errorf("expected com.acme.legacy.util unmapped, got %v", result.UnmappedPackages)
+	}
+	// The edge touching an unmapped package must not appear as a relationship.
+	if len(result.Snapshot.Relationships) != 0 {
+		t.Errorf("expected no relationship for an edge with an unmapped endpoint, got %v", result.Snapshot.Relationships)
+	}
+}
+
+func TestProject_DuplicateEdgesDeduplicated(t *testing.T) {
+	cg := &CodeGraph{
+		Nodes: []Node{
+			{ID: "com.acme.backend.api", Kind: "package"},
+			{ID: "com.acme.backend.svc", Kind: "package"},
+		},
+		Edges: []Edge{
+			{From: "com.acme.backend.api", To: "com.acme.backend.svc"},
+			{From: "com.acme.backend.api", To: "com.acme.backend.svc"}, // duplicate class-level edge
+		},
+	}
+
+	result, err := Project(cg, threeTierModel())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Snapshot.Relationships) != 1 {
+		t.Errorf("expected duplicate edges to collapse into 1 relationship, got %d: %v",
+			len(result.Snapshot.Relationships), result.Snapshot.Relationships)
+	}
+}
+
+func TestHasAnyCodeMapping(t *testing.T) {
+	if has, err := HasAnyCodeMapping(threeTierModel()); err != nil || !has {
+		t.Errorf("expected true, got has=%v err=%v", has, err)
+	}
+
+	empty := &model.BausteinsichtModel{Model: map[string]model.Element{
+		"x": {Kind: "component", Title: "X"},
+	}}
+	if has, err := HasAnyCodeMapping(empty); err != nil || has {
+		t.Errorf("expected false, got has=%v err=%v", has, err)
+	}
+}

--- a/internal/codegraph/types.go
+++ b/internal/codegraph/types.go
@@ -1,0 +1,72 @@
+// Package codegraph implements the reverse contract of the code-governance
+// bridge (#562, ADR-013): a minimal, language-neutral package-dependency
+// graph that any code-side extractor can emit (jdeps, an ArchUnit dumper,
+// go list, Roslyn, ...), and that Bausteinsicht projects onto model elements
+// via their codeMapping to produce an asIs snapshot.
+package codegraph
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// schemaKind is the required CodeGraph.Kind value — a cheap guard against
+// pointing import-graph at an unrelated JSON file.
+const schemaKind = "bausteinsicht.codegraph"
+
+// SchemaTitle and SchemaDescription are the JSON Schema title/description
+// used by `bausteinsicht schema generate --type codegraph`, exported so the
+// CLI command and its drift-guard test share one source of truth instead of
+// duplicating the strings.
+const (
+	SchemaTitle       = "Bausteinsicht CodeGraph"
+	SchemaDescription = "Reverse code-governance-bridge contract (#562, ADR-013): a language-neutral package-dependency graph emitted by a code-side extractor"
+)
+
+// CodeGraph is the reverse contract: a real package-dependency graph
+// extracted from code, independent of any Bausteinsicht model.
+type CodeGraph struct {
+	SchemaVersion string `json:"schemaVersion"`
+	Kind          string `json:"kind"`
+	Language      string `json:"language"`
+	Nodes         []Node `json:"nodes"`
+	Edges         []Edge `json:"edges"`
+}
+
+// Node is one package in the extracted graph.
+type Node struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"`
+}
+
+// Edge is one observed package-level dependency. Weight and Examples are
+// optional context for a human resolving drift (the "why" behind an edge).
+type Edge struct {
+	From     string   `json:"from"`
+	To       string   `json:"to"`
+	Weight   int      `json:"weight,omitempty"`
+	Examples []string `json:"examples,omitempty"`
+}
+
+// Load reads and validates a codegraph JSON document from path.
+func Load(path string) (*CodeGraph, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is CLI-supplied and containment-checked by the caller
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var cg CodeGraph
+	if err := json.Unmarshal(data, &cg); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	if cg.Kind != schemaKind {
+		return nil, fmt.Errorf("%s: kind %q, expected %q", path, cg.Kind, schemaKind)
+	}
+	if cg.SchemaVersion == "" {
+		return nil, fmt.Errorf("%s: missing required field \"schemaVersion\"", path)
+	}
+
+	return &cg, nil
+}

--- a/internal/codegraph/types_test.go
+++ b/internal/codegraph/types_test.go
@@ -1,0 +1,90 @@
+package codegraph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempCodeGraph(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "reality.codegraph.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	return path
+}
+
+func TestLoad_ValidCodeGraph(t *testing.T) {
+	path := writeTempCodeGraph(t, `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "java",
+  "nodes": [ { "id": "com.acme.backend.api", "kind": "package" } ],
+  "edges": [ { "from": "com.acme.backend.api", "to": "com.acme.backend.svc",
+               "weight": 12, "examples": ["OrderController -> OrderService"] } ]
+}`)
+
+	cg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cg.Language != "java" {
+		t.Errorf("Language = %q, want %q", cg.Language, "java")
+	}
+	if len(cg.Nodes) != 1 || cg.Nodes[0].ID != "com.acme.backend.api" {
+		t.Errorf("unexpected Nodes: %+v", cg.Nodes)
+	}
+	if len(cg.Edges) != 1 || cg.Edges[0].Weight != 12 {
+		t.Errorf("unexpected Edges: %+v", cg.Edges)
+	}
+}
+
+func TestLoad_MinimalRequiredFieldsOnly(t *testing.T) {
+	// weight/examples are optional per #562's contract.
+	path := writeTempCodeGraph(t, `{
+  "schemaVersion": "1.0",
+  "kind": "bausteinsicht.codegraph",
+  "language": "go",
+  "nodes": [ { "id": "pkg", "kind": "package" } ],
+  "edges": [ { "from": "pkg", "to": "pkg2" } ]
+}`)
+
+	cg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cg.Edges[0].Weight != 0 || cg.Edges[0].Examples != nil {
+		t.Errorf("expected zero-value optional fields, got %+v", cg.Edges[0])
+	}
+}
+
+func TestLoad_WrongKind(t *testing.T) {
+	path := writeTempCodeGraph(t, `{"schemaVersion":"1.0","kind":"something.else","language":"java","nodes":[],"edges":[]}`)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for wrong kind")
+	}
+}
+
+func TestLoad_MissingSchemaVersion(t *testing.T) {
+	path := writeTempCodeGraph(t, `{"kind":"bausteinsicht.codegraph","language":"java","nodes":[],"edges":[]}`)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for missing schemaVersion")
+	}
+}
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	path := writeTempCodeGraph(t, `not json`)
+
+	if _, err := Load(path); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	if _, err := Load(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Error("expected error for missing file")
+	}
+}

--- a/internal/schema/sync_test.go
+++ b/internal/schema/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/docToolchain/Bausteinsicht/internal/codegraph"
 	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/docToolchain/Bausteinsicht/internal/schema"
 )
@@ -57,5 +58,35 @@ func TestCommittedSchemaInSync(t *testing.T) {
 	if string(committed) != string(generated) {
 		t.Errorf("committed schema is out of sync with Go types; " +
 			"run `go run ./cmd/bausteinsicht schema generate` and commit the result")
+	}
+}
+
+// TestCommittedCodeGraphSchemaInSync is TestCommittedSchemaInSync's
+// counterpart for the codegraph reverse-contract schema (#562, ADR-013). If
+// this fails, run:
+//
+//	go run ./cmd/bausteinsicht schema generate --type codegraph
+//
+// and commit the regenerated schemas/codegraph.schema.json.
+func TestCommittedCodeGraphSchemaInSync(t *testing.T) {
+	schemaPath := filepath.Join(repoRoot(t), "schemas", "codegraph.schema.json")
+
+	committed, err := os.ReadFile(schemaPath) //nolint:gosec // fixed, repo-relative path
+	if err != nil {
+		t.Fatalf("reading committed schema: %v", err)
+	}
+
+	gen := schema.NewGenerator()
+	generatedSchema := gen.Generate(codegraph.CodeGraph{})
+	generatedSchema.Title = codegraph.SchemaTitle
+	generatedSchema.Description = codegraph.SchemaDescription
+	generated, err := generatedSchema.ToJSON()
+	if err != nil {
+		t.Fatalf("generating schema: %v", err)
+	}
+
+	if string(committed) != string(generated) {
+		t.Errorf("committed codegraph schema is out of sync with Go types; " +
+			"run `go run ./cmd/bausteinsicht schema generate --type codegraph` and commit the result")
 	}
 }

--- a/schemas/codegraph.schema.json
+++ b/schemas/codegraph.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Bausteinsicht CodeGraph",
+  "description": "Reverse code-governance-bridge contract (#562, ADR-013): a language-neutral package-dependency graph emitted by a code-side extractor",
+  "type": "object",
+  "properties": {
+    "edges": {
+      "items": {
+        "$ref": "#/definitions/Edge"
+      },
+      "type": "array"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "nodes": {
+      "items": {
+        "$ref": "#/definitions/Node"
+      },
+      "type": "array"
+    },
+    "schemaVersion": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schemaVersion",
+    "kind",
+    "language",
+    "nodes",
+    "edges"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "Edge": {
+      "additionalProperties": false,
+      "properties": {
+        "examples": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "from": {
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "weight": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "type": "object"
+    },
+    "Node": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "kind"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
+++ b/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
@@ -156,8 +156,8 @@ This does **not** close out R4/R1 in full: the *constraint→target-rule transla
 Gating the forward mechanism's move from B to C:
 
 * Must the failing gate be a **native JUnit/IDE test** (→ Variant C/A), or is a **separate CI step** running the Bausteinsicht binary against an extracted graph acceptable (→ extractor + BS engine)?
-* Are we willing to treat the **JSONC model as a stable, versioned public API**? Partially answered by <<variant-c-prototype>> — a real adapter already depends on the shape — but not yet a formal commitment (versioning policy, compatibility guarantees).
-* Who **owns** the Java-side adapter (Variant C) long-term? A prototype owner exists (ascheman, `docToolchain/bausteinsicht-archunit`), but its README lists the license as "TBD — to be aligned with the docToolchain organisation's policy," so its path to becoming the *official* adapter (vs. staying a reference prototype) is still open.
+* Are we willing to treat the **JSONC model as a stable, versioned public API**? Partially answered by <<variant-c-prototype>> — a real adapter already depends on the shape — but not yet a formal commitment (versioning policy, compatibility guarantees). Tracked as its own decision: https://github.com/docToolchain/Bausteinsicht/issues/601[Bausteinsicht#601].
+* Who **owns** the Java-side adapter (Variant C) long-term? A prototype owner exists (ascheman, `docToolchain/bausteinsicht-archunit`), but its README lists the license as "TBD — to be aligned with the docToolchain organisation's policy," so its path to becoming the *official* adapter (vs. staying a reference prototype) is still open. Tracked as its own decision, in the adapter's own repo: https://github.com/docToolchain/bausteinsicht-archunit/issues/1[bausteinsicht-archunit#1].
 * Should `codeMapping` become per-backend-keyed (#572 R6) once a second backend (#574, Go) exists, or does the flat shape decided here turn out to generalise (e.g. by adding a sibling field rather than reshaping this one)? Deliberately not decided now — see <<variant-c-prototype>>.
 * Does #574 (Go)'s actual implementation ever need Bausteinsicht's own code to branch on backend/language? If yes, that's the trigger to revisit <<rulebackend-r1>>'s "no interface needed" call — see that section.
 
@@ -195,6 +195,7 @@ Cross-cutting with #572 (tracked there, not here):
 * https://github.com/docToolchain/Bausteinsicht/issues/570[#570] — RFE: Model DDD / Hexagonal Architecture with xMolecules-aligned vocabulary (umbrella; this ADR is a descendant of its layer 4 "Bridge to code").
 * https://github.com/docToolchain/Bausteinsicht/issues/572[#572] — RFE: Multi-language code-governance backends beyond ArchUnit/JVM. Proposes per-backend `codeMapping` keying (R6) and the `RuleBackend` abstraction (R1); this ADR deliberately does *not* adopt the R6 keying yet — see <<variant-c-prototype>> and <<open-questions>>.
 * https://github.com/docToolchain/bausteinsicht-archunit[docToolchain/bausteinsicht-archunit] — the Variant C prototype whose contract this ADR's `codeMapping` shape matches exactly.
+* Governance decisions spun out of <<open-questions>>: https://github.com/docToolchain/Bausteinsicht/issues/601[Bausteinsicht#601] (JSONC as stable public API) and https://github.com/docToolchain/bausteinsicht-archunit/issues/1[bausteinsicht-archunit#1] (adapter ownership/license).
 * `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
 * `internal/model/types.go` — `Element.CodeMapping`, `CodeMapping`.
 * `internal/codegraph/` — `CodeGraph`/`Node`/`Edge` types, `Load`, `Project` (the reverse-path projection algorithm), `HasAnyCodeMapping`.

--- a/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
+++ b/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
@@ -8,7 +8,7 @@
 
 == Status
 
-Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided and land in this ADR's implementation slice, with their shape validated by an external Variant C prototype (see <<variant-c-prototype>>). The forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
+Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided **and implemented** (`internal/codegraph`, `bausteinsicht import-graph`), with their shape validated by an external Variant C prototype (see <<variant-c-prototype>>). The forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
 
 == Context
 
@@ -128,12 +128,13 @@ The result is **weight-sensitive by design**: C leads only if the JSONC-as-publi
 ----
 +
 `packages` holds bare prefixes without ArchUnit's trailing `..` — the consuming adapter appends that itself (see <<variant-c-prototype>>'s `BausteinsichtRules.matchers()`). This is a **reversal** from this ADR's first draft, which had adopted #572's R6 per-backend-keyed proposal (`{"java": {...}, "go": {...}}`) speculatively. Once the Variant C prototype surfaced, matching its validated, tested contract exactly took priority over a shape nothing had exercised yet — see <<variant-c-prototype>>. Per-backend keying is deferred to <<open-questions>>, to be revisited only when a second backend (#574, Go) actually needs an element to carry more than one language's mapping simultaneously. See `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
-* **Reverse/drift path** (shared by all forward variants): a graph extractor (`jdeps` or a small ArchUnit-based tool — the prototype's `CodeGraphExporter` is exactly this) dumps the real package-dependency graph as a `codegraph` JSON document → Bausteinsicht ingests it as an `asIs` snapshot (projected through `codeMapping`) → the existing `bausteinsicht diff` command compares it against `toBe` → proposes curated model patches. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; edits are proposed, never written back silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
+* **Reverse/drift path** (shared by all forward variants) — **implemented**: a graph extractor (`jdeps` or a small ArchUnit-based tool — the prototype's `CodeGraphExporter` is exactly this) dumps the real package-dependency graph as a `codegraph` JSON document → `bausteinsicht import-graph` ingests it, projects it through `codeMapping`, and writes it as the model's `asIs` snapshot → the existing `bausteinsicht diff` command compares it against `toBe` and reports the gap. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; `import-graph` writes `asIs` directly (that's what it's for — a fresh capture of reality on each run) but never touches `toBe`, and no patch is ever proposed or written back into the model/`toBe` silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
 * **Prototype the forward mechanism with Variant B** (fastest proof, zero new parser) for the *diagram-intermediate* path; **Variant A is retained as a fallback** for expressiveness if C stalls; **Variant C is the target** and now has a working reference implementation, conditional on the open points below.
 
-=== Not yet implemented by this ADR
+=== Implementation status
 
-The `codegraph` schema, the `import-graph` command, the Variant B PlantUML emitter, and the `RuleBackend` abstraction (R1/R4) are follow-up work, not part of this ADR's initial code slice (which lands only the `codeMapping` field). Scoping them as separate PRs keeps each one reviewable; see References for the tracking issues.
+* **Landed:** `codeMapping` field (`internal/model`); the `codegraph` package (`internal/codegraph` — types, `Load`, `Project`) implementing the reverse-path projection algorithm above; the `bausteinsicht import-graph <codegraph-file>` command wiring it to `asIs`; the `codegraph.schema.json` JSON Schema (`bausteinsicht schema generate --type codegraph`).
+* **Not yet implemented:** the Variant B PlantUML emitter (forward path) and the `RuleBackend` abstraction (R1/R4) generalizing this design for #572's non-JVM backends. Scoping them as separate PRs keeps each one reviewable; see References for the tracking issues.
 
 [[open-questions]]
 == Open Questions
@@ -178,3 +179,7 @@ Cross-cutting with #572 (tracked there, not here):
 * https://github.com/docToolchain/bausteinsicht-archunit[docToolchain/bausteinsicht-archunit] — the Variant C prototype whose contract this ADR's `codeMapping` shape matches exactly.
 * `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
 * `internal/model/types.go` — `Element.CodeMapping`, `CodeMapping`.
+* `internal/codegraph/` — `CodeGraph`/`Node`/`Edge` types, `Load`, `Project` (the reverse-path projection algorithm), `HasAnyCodeMapping`.
+* `cmd/bausteinsicht/import_graph.go` — the `bausteinsicht import-graph` command.
+* `schemas/codegraph.schema.json` — the `codegraph` document's own JSON Schema.
+* `src/docs/spec/02_cli_specification.adoc`, section "`bausteinsicht import-graph`".

--- a/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
+++ b/src/docs/arc42/ADRs/ADR-013-Code-Governance-Backend.adoc
@@ -8,7 +8,7 @@
 
 == Status
 
-Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided **and implemented** (`internal/codegraph`, `bausteinsicht import-graph`), with their shape validated by an external Variant C prototype (see <<variant-c-prototype>>). The forward mechanism (Variant A/B/C) is staged, with two open points gating the target variant (see <<open-questions>>).
+Accepted (staged) — the reverse/drift path and the `codeMapping` field (R5) are decided **and implemented** (`internal/codegraph`, `bausteinsicht import-graph`), with their shape validated by an external Variant C prototype (see <<variant-c-prototype>>). Variant B is **skipped** (see <<decision>>) — Variant C's proof-of-concept role is already filled by the prototype. The `RuleBackend` abstraction (R1) turns out to require **no new code** — see <<rulebackend-r1>>. Two open points still gate Variant C's move from *prototype* to *official* (see <<open-questions>>).
 
 == Context
 
@@ -129,12 +129,26 @@ The result is **weight-sensitive by design**: C leads only if the JSONC-as-publi
 +
 `packages` holds bare prefixes without ArchUnit's trailing `..` — the consuming adapter appends that itself (see <<variant-c-prototype>>'s `BausteinsichtRules.matchers()`). This is a **reversal** from this ADR's first draft, which had adopted #572's R6 per-backend-keyed proposal (`{"java": {...}, "go": {...}}`) speculatively. Once the Variant C prototype surfaced, matching its validated, tested contract exactly took priority over a shape nothing had exercised yet — see <<variant-c-prototype>>. Per-backend keying is deferred to <<open-questions>>, to be revisited only when a second backend (#574, Go) actually needs an element to carry more than one language's mapping simultaneously. See `src/docs/spec/03_data_models.adoc`, section "CodeMapping Properties".
 * **Reverse/drift path** (shared by all forward variants) — **implemented**: a graph extractor (`jdeps` or a small ArchUnit-based tool — the prototype's `CodeGraphExporter` is exactly this) dumps the real package-dependency graph as a `codegraph` JSON document → `bausteinsicht import-graph` ingests it, projects it through `codeMapping`, and writes it as the model's `asIs` snapshot → the existing `bausteinsicht diff` command compares it against `toBe` and reports the gap. An ArchUnit failure is *ambiguous* (wrong code vs. stale model), so a human decides; `import-graph` writes `asIs` directly (that's what it's for — a fresh capture of reality on each run) but never touches `toBe`, and no patch is ever proposed or written back into the model/`toBe` silently. This is the model's first **code-derived** `asIs` snapshot — until now `asIs`/`toBe` were both always model-authored or `snapshot save`-captured.
-* **Prototype the forward mechanism with Variant B** (fastest proof, zero new parser) for the *diagram-intermediate* path; **Variant A is retained as a fallback** for expressiveness if C stalls; **Variant C is the target** and now has a working reference implementation, conditional on the open points below.
+* **Skip Variant B.** Its only purpose was to be the *fastest proof that the forward direction can work at all* — that proof now exists, more thoroughly, via the Variant C prototype (a real `mvn verify` round-trip, not just a diagram-adherence check). Building a Bausteinsicht-side PlantUML emitter now would duplicate that proof for no remaining benefit. **Variant A remains a fallback** if Variant C stalls on its open governance questions (see <<open-questions>>) and a lower-commitment path is needed later; it is not being built now either. **Variant C is the target**, with a working reference implementation, conditional on the open points below.
+
+[[rulebackend-r1]]
+=== RuleBackend abstraction (R1) — satisfied by construction, no code needed
+
+#562's R4 and #572's R1 both call for extracting "the backend-specific parts... into a pluggable interface/contract" before a second backend (#574, Go) arrives. Having now actually built the reverse path, that pluggable interface turns out to already exist — as a matter of what got built, not as a deliberate abstraction step:
+
+* `internal/codegraph.Project()` contains **zero** ArchUnit/Java-specific logic. It resolves packages to elements via generic dot-boundary prefix matching and builds a generic `model.ModelSnapshot`. `CodeGraph.Language` is carried through purely as report metadata — nothing branches on it.
+* `bausteinsicht import-graph` is equally generic: it validates `codegraph.Kind`/`SchemaVersion`, not `Language`.
+* All backend-specific work (extracting a real dependency graph from real code, emitting it as `codegraph` JSON) already lives *outside* Bausteinsicht, in per-language extractor tooling (the ArchUnit-based `CodeGraphExporter` today; a `go list`-based one for #574 tomorrow) — exactly where #562's own constraints section says it must ("Bausteinsicht cannot extract a dependency graph from [any language's] code itself").
+
+There is therefore no branching behavior in Bausteinsicht's own code for a `RuleBackend` interface to abstract *over* — introducing one now would be an interface with one real implementation and one imagined one, guessed at before #574 exists to validate the guess against. That is the specific premature-abstraction failure mode #572's own R1 warns against ("Validate this abstraction against the cheapest backend... before committing to it for the rest") and that this project's engineering conventions rule out generally (no abstractions beyond what the task requires). **Decision: do not add a `RuleBackend` Go interface now.** Revisit only if #574's actual implementation surfaces real per-backend branching Bausteinsicht's own code would need to make — which, on the evidence of the reverse path, may never happen.
+
+This does **not** close out R4/R1 in full: the *constraint→target-rule translation table* — mapping each `bausteinsicht lint` rule (`no-relationship`, `no-circular-dependency`, ...) to its per-backend equivalent expression — is still unwritten, and unlike the reverse-path abstraction question, that table has no "it turned out to already exist" shortcut; it has to be authored once a second backend's forward side gives it something concrete to map to.
 
 === Implementation status
 
-* **Landed:** `codeMapping` field (`internal/model`); the `codegraph` package (`internal/codegraph` — types, `Load`, `Project`) implementing the reverse-path projection algorithm above; the `bausteinsicht import-graph <codegraph-file>` command wiring it to `asIs`; the `codegraph.schema.json` JSON Schema (`bausteinsicht schema generate --type codegraph`).
-* **Not yet implemented:** the Variant B PlantUML emitter (forward path) and the `RuleBackend` abstraction (R1/R4) generalizing this design for #572's non-JVM backends. Scoping them as separate PRs keeps each one reviewable; see References for the tracking issues.
+* **Landed:** `codeMapping` field (`internal/model`); the `codegraph` package (`internal/codegraph` — types, `Load`, `Project`) implementing the reverse-path projection algorithm above; the `bausteinsicht import-graph <codegraph-file>` command wiring it to `asIs`; the `codegraph.schema.json` JSON Schema (`bausteinsicht schema generate --type codegraph`); the R1 finding (<<rulebackend-r1>>) that no `RuleBackend` interface is needed yet.
+* **Explicitly not built:** the Variant B PlantUML emitter (superseded by the Variant C prototype, see above) and a `RuleBackend` Go interface (no real second implementation to validate it against yet, see <<rulebackend-r1>>).
+* **Still genuinely missing:** the constraint→target-rule translation table (#572 R4) and Bausteinsicht-side forward rule emission for Variant C (which is, by design, entirely on the Java adapter's side — not a Bausteinsicht gap so much as a deliberate non-goal of Variant C itself).
 
 [[open-questions]]
 == Open Questions
@@ -144,8 +158,10 @@ Gating the forward mechanism's move from B to C:
 * Must the failing gate be a **native JUnit/IDE test** (→ Variant C/A), or is a **separate CI step** running the Bausteinsicht binary against an extracted graph acceptable (→ extractor + BS engine)?
 * Are we willing to treat the **JSONC model as a stable, versioned public API**? Partially answered by <<variant-c-prototype>> — a real adapter already depends on the shape — but not yet a formal commitment (versioning policy, compatibility guarantees).
 * Who **owns** the Java-side adapter (Variant C) long-term? A prototype owner exists (ascheman, `docToolchain/bausteinsicht-archunit`), but its README lists the license as "TBD — to be aligned with the docToolchain organisation's policy," so its path to becoming the *official* adapter (vs. staying a reference prototype) is still open.
-* Diagram/export format for the Variant B emitter: plain-component PlantUML flavour only — the default C4 export is not adapter-parseable.
 * Should `codeMapping` become per-backend-keyed (#572 R6) once a second backend (#574, Go) exists, or does the flat shape decided here turn out to generalise (e.g. by adding a sibling field rather than reshaping this one)? Deliberately not decided now — see <<variant-c-prototype>>.
+* Does #574 (Go)'s actual implementation ever need Bausteinsicht's own code to branch on backend/language? If yes, that's the trigger to revisit <<rulebackend-r1>>'s "no interface needed" call — see that section.
+
+Moot, since Variant B was skipped (kept here for the historical record): diagram/export format for the Variant B emitter would have been plain-component PlantUML flavour only — the default C4 export is not adapter-parseable.
 
 Cross-cutting with #572 (tracked there, not here):
 
@@ -160,12 +176,14 @@ Cross-cutting with #572 (tracked there, not here):
 * Its exact shape is not speculative: a real, tested adapter (<<variant-c-prototype>>) already reads it and builds passing ArchUnit rules from it.
 * The reverse/drift path reuses `asIs`/`toBe`/`diff` unchanged — no new mechanism, no new UI, no new command family beyond `import-graph`.
 * The flat shape is the simplest thing that could work and is what's actually running today; per-backend keying is deferred rather than paid for upfront.
+* Skipping Variant B and the `RuleBackend` interface avoids two speculative builds whose only justification would have been "we might need this later" — in both cases, evidence (the prototype; the reverse path's actual shape) showed the work either wasn't needed at all or would need redoing anyway.
 
 === Negative
 
 * The flat shape does not (yet) support one element mapping to more than one backend's code simultaneously — deferred per <<open-questions>>, and would be a breaking schema change if needed later.
 * The staged decision leaves the *target* forward variant (C) unresolved as an *official* commitment; teams adopting `codeMapping` today are anchoring elements without a guaranteed-stable public-API promise yet, even though a working adapter already exists.
-* Bausteinsicht's own `import-graph`/forward-emitter side (consuming `codeMapping` and producing/reading `codegraph`) is still unimplemented — the prototype validates the *contract*, not the Bausteinsicht-side implementation.
+* Skipping Variant B means there is no Bausteinsicht-side forward path at all right now — teams get drift detection (`import-graph` + `diff`) but not enforcement (a failing build/test) unless they adopt the external prototype adapter directly.
+* No `RuleBackend` interface exists in Bausteinsicht's code to point to as "the extension point for backend N+1" — <<rulebackend-r1>>'s finding is currently only documented here, not encoded in the type system. A reader of `internal/codegraph` alone wouldn't know backend-extensibility was even a design goal.
 
 === Risk
 

--- a/src/docs/arc42/architecture.jsonc
+++ b/src/docs/arc42/architecture.jsonc
@@ -325,6 +325,12 @@
           "description": "Architecture changelog generation between two git refs",
           "technology": "Go"
         },
+        "codegraph": {
+          "kind": "container",
+          "title": "CodeGraph",
+          "description": "Reverse code-governance-bridge contract: projects a language-neutral package-dependency graph onto model elements via codeMapping to produce an asIs snapshot",
+          "technology": "Go"
+        },
         "diff": {
           "kind": "container",
           "title": "Diff",

--- a/src/docs/arc42/chapters/03_context_and_scope.adoc
+++ b/src/docs/arc42/chapters/03_context_and_scope.adoc
@@ -102,7 +102,7 @@ fork again
   :Analysis (read-only):\nbausteinsicht stale\nbausteinsicht health\nbausteinsicht graph\nbausteinsicht find;
   note right: Periodic architecture-quality\nchecks, independent of sync
 fork again
-  :Evolution:\nbausteinsicht snapshot save, snapshot list,\nsnapshot diff, snapshot restore, snapshot delete\nbausteinsicht diff --to-be\nbausteinsicht changelog;
+  :Evolution:\nbausteinsicht snapshot save, snapshot list,\nsnapshot diff, snapshot restore, snapshot delete\nbausteinsicht import-graph <codegraph-file>\nbausteinsicht diff --to-be\nbausteinsicht changelog;
   note right: Versioning and\nas-is/to-be comparison,\nnot part of the edit-sync cycle
 fork again
   :Export (output side):\nbausteinsicht export\nbausteinsicht export-diagram\nbausteinsicht export-table;

--- a/src/docs/arc42/chapters/06_runtime_view.adoc
+++ b/src/docs/arc42/chapters/06_runtime_view.adoc
@@ -116,6 +116,8 @@ image::arc42/architecture-sequence-snapshot-management.png[Snapshot Management,w
 
 `diff` compares two model states; `changelog` walks git history calling `diff` at each relevant commit to build a human-readable architecture changelog.
 
+`import-graph` is the reverse side of the code-governance bridge (#562, ADR-013): it reads a language-neutral `codegraph` JSON document (emitted by a code-side extractor such as the https://github.com/docToolchain/bausteinsicht-archunit[bausteinsicht-archunit] adapter), projects it onto model elements via their `codeMapping`, and writes the result as the model's `asIs` snapshot — the first code-derived (rather than model-authored) `asIs`. A subsequent `diff` run then surfaces any relationship present in the real code but missing from `toBe` as drift.
+
 .As-Is/To-Be Diff and Changelog Generation (generated from `dynamicViews.diff-and-changelog` in architecture.jsonc via `bausteinsicht export-sequence`)
 image::arc42/architecture-sequence-diff-and-changelog.png[Diff and Changelog,width=80%]
 

--- a/src/docs/arc42/chapters/containers-elements.adoc
+++ b/src/docs/arc42/chapters/containers-elements.adoc
@@ -12,6 +12,11 @@
 | Go / Cobra
 | Command-line interface providing validate, sync, export, and watch commands
 
+| CodeGraph
+| container
+| Go
+| Reverse code-governance-bridge contract: projects a language-neutral package-dependency graph onto model elements via codeMapping to produce an asIs snapshot
+
 | Constraints
 | container
 | Go

--- a/src/docs/arc42/containers.puml
+++ b/src/docs/arc42/containers.puml
@@ -7,6 +7,7 @@ System_Ext(ide, "IDE", "IDE with JSON Schema support for JSONC editing with auto
 System_Boundary(bausteinsicht, "Bausteinsicht") {
   Container(bausteinsicht_changelog, "Changelog", "Go", "Architecture changelog generation between two git refs")
   Container(bausteinsicht_cli, "CLI", "Go / Cobra", "Command-line interface providing validate, sync, export, and watch commands")
+  Container(bausteinsicht_codegraph, "CodeGraph", "Go", "Reverse code-governance-bridge contract: projects a language-neutral package-dependency graph onto model elements via codeMapping to produce an asIs snapshot")
   Container(bausteinsicht_constraints, "Constraints", "Go", "Validation constraints for model linting and consistency checking")
   Container(bausteinsicht_diagram, "Diagram", "Go", "Text-based diagram export to Mermaid C4 and PlantUML formats with markdown wrapping")
   Container(bausteinsicht_diff, "Diff", "Go", "As-is vs. to-be architecture comparison")

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -110,6 +110,10 @@ See link:01_use_cases.html[Use Cases] for the functional overview of all CLI com
 | Import a model from Structurizr DSL or LikeC4
 | Implemented
 
+| `bausteinsicht import-graph`
+| Project a code-derived codegraph JSON onto model elements via codeMapping and write it as the asIs snapshot
+| Implemented
+
 | `bausteinsicht generate-template`
 | Generate a draw.io template from the specification
 | Implemented
@@ -1256,6 +1260,40 @@ Imports an architecture model from an external DSL and writes a Bausteinsicht `.
 **XMI-specific behavior:** reads XMI 2.1 files (e.g., Enterprise Architect exports). UML element types are mapped to Bausteinsicht element kinds using `--kind-map` overrides or the built-in defaults (e.g., `uml:Component` → `component`). EA stereotypes (inside `xmi:Extension`) take precedence over the UML type mapping. Unknown UML types produce a warning and are imported with kind `element`. Unresolvable relationship endpoints are skipped with a warning. DOCTYPE declarations are rejected (XXE mitigation). Element hierarchy depth is capped at 50 levels. This is a **one-way migration** — XMI-specific data (layout, tagged values, OCL constraints) is not preserved.
 
 **Structurizr-specific behavior:** a view's `autoLayout <direction>` directive is mapped to Bausteinsicht's `layered` layout (there is no direction-aware equivalent). The direction argument itself is not preserved, and a warning is emitted noting the dropped value (e.g. `line 12: view "context": autoLayout direction "lr" not preserved, mapped to layout: "layered"`). `include *` on a `container`/`component` view is expanded to also include the view's scope's children (e.g. `["*", "<scope>.*"]`, plus the parent scope for `component` views), matching Structurizr's semantics where a scoped view's wildcard include means "everything visible in this scope" rather than Bausteinsicht's default top-level-only `*` match. `filtered`, `dynamic`, and `deployment` views are not supported and are skipped with a warning (#512).
+
+==== `bausteinsicht import-graph`
+
+Projects a code-derived, language-neutral `codegraph` JSON document onto model elements via their `codeMapping`, and writes the result as the model's `asIs` snapshot — the reverse side of the code-governance bridge (#562, ADR-013). Run `bausteinsicht diff` afterwards to compare it against `toBe`.
+
+**Arguments:** `<codegraph-file>` (required) — the codegraph JSON document, typically produced by a code-side extractor (e.g. https://github.com/docToolchain/bausteinsicht-archunit[bausteinsicht-archunit]'s `CodeGraphExporter` for Java).
+
+**Flags:**
+
+[cols="2,3,1,1"]
+|===
+| Flag | Description | Required | Default
+
+| `--model` | Model file path. | No | auto-detect
+| `--format` | Output format: `text` or `json`. | No | `text`
+|===
+
+**Behavior:** builds a `package -> elementID` map from every element's `codeMapping.packages` (longest-prefix, dot-boundary match — mirrors ArchUnit's package matcher: `com.acme.api` covers `com.acme.api.internal` but not `com.acme.apiextra`), then resolves each codegraph node/edge through it. Intra-element edges (both endpoints resolving to the same element) are dropped as implementation detail. Packages with no covering `codeMapping` are collected and reported, not silently dropped. The resulting element/relationship set overwrites `asIs` in the model file (a full-rewrite save, per ADR-011 — this is a modification, not a pure insertion).
+
+**Exit codes:**
+
+* `0` -- import successful
+* `1` -- model has no element with a `codeMapping`, or the `asIs` write failed
+* `2` -- codegraph file not found, unreadable, malformed, or invalid `--format`
+
+**Example:**
+[source,bash]
+----
+$ bausteinsicht import-graph reality.codegraph.json
+Imported code graph (java): 12 nodes, 8 edges
+Mapped: 5 elements, 4 relationships
+Unmapped packages (3): com.acme.legacy.util, com.acme.legacy.helpers, com.acme.test
+asIs snapshot written to architecture.jsonc
+----
 
 ==== `bausteinsicht generate-template`
 

--- a/src/docs/spec/03_data_models.adoc
+++ b/src/docs/spec/03_data_models.adoc
@@ -98,7 +98,7 @@ The element ID (the key in the `model` map, dot-pathed for nested children) is t
 
 === JSON Model Structure
 
-The model has these top-level sections. `specification`, `model`, `relationships`, and `views` are the core; the rest are optional: `$schema` (points the IDE at the JSON Schema for validation and autocompletion), `config` (project metadata/legend), `meta` (e.g. `staleDetection` settings), `dynamicViews` (sequence diagrams), `constraints` (lint rules), and `asIs`/`toBe` (for the `diff` command).
+The model has these top-level sections. `specification`, `model`, `relationships`, and `views` are the core; the rest are optional: `$schema` (points the IDE at the JSON Schema for validation and autocompletion), `config` (project metadata/legend), `meta` (e.g. `staleDetection` settings), `dynamicViews` (sequence diagrams), `constraints` (lint rules), and `asIs`/`toBe` (for the `diff` command — `asIs` can also be written by `import-graph` from real code, see <<CodeMapping Properties>>).
 
 [source,jsonc]
 ----
@@ -287,7 +287,7 @@ The model has these top-level sections. `specification`, `model`, `relationships
 | `codeMapping`
 | CodeMapping
 | no
-| Anchors this element to real code for the code-governance bridge (ArchUnit first). Consumed by `import-graph`/forward rule generation — not yet by any shipped command, but already validated against a real adapter, see <<CodeMapping Properties>> and ADR-013.
+| Anchors this element to real code for the code-governance bridge (ArchUnit first). Consumed by `bausteinsicht import-graph` (reverse path); forward rule generation is still external (see the validated Variant C prototype). See <<CodeMapping Properties>> and ADR-013.
 |===
 
 The **key** of each element in the model object (e.g., `"customer"`, `"api"`) serves as its unique ID.
@@ -340,9 +340,11 @@ A `DocLink` is a typed link to an external documentation artifact, usable on bot
 }
 ----
 
-This exact shape is validated end-to-end by an external prototype adapter, https://github.com/docToolchain/bausteinsicht-archunit — its `BausteinsichtRules.fromModel()` reads this field to build ArchUnit rules (forward), and its `CodeGraphExporter` dumps the real package graph as a `codegraph` JSON document for Bausteinsicht to ingest as an `asIs` snapshot (reverse). See ADR-013 for the full design and staging of the code-governance bridge this field anchors.
+This exact shape is validated end-to-end by an external prototype adapter, https://github.com/docToolchain/bausteinsicht-archunit — its `BausteinsichtRules.fromModel()` reads this field to build ArchUnit rules (forward, not yet implemented on the Bausteinsicht side), and its `CodeGraphExporter` dumps the real package graph as a `codegraph` JSON document, which `bausteinsicht import-graph` ingests as an `asIs` snapshot (reverse, shipped). See ADR-013 for the full design and staging of the code-governance bridge this field anchors.
 
 NOTE: `codeMapping` is flat — one mapping per element — not keyed per backend. A polyglot element (e.g. a service with both a Java implementation and a generated .NET client) is out of scope until a second backend actually needs it; see ADR-013's "Open Questions".
+
+The `codegraph` document `import-graph` consumes is a *separate* format from the architecture model — it has its own JSON Schema, `schemas/codegraph.schema.json` (generated via `bausteinsicht schema generate --type codegraph`), documenting `schemaVersion`, `kind`, `language`, `nodes[]`, and `edges[]`.
 
 [[element-lifecycle]]
 ==== Element Lifecycle
@@ -932,8 +934,9 @@ type Element struct {
     LastModified string             `json:"lastModified,omitempty"` // RFC3339; overrides git-based staleness
     Children     map[string]Element `json:"children,omitempty"`
     Metadata     map[string]string  `json:"metadata,omitempty"`
-    Link         string             `json:"link,omitempty"`     // hyperlink on the draw.io shape and in SVG export
-    DocLinks     []DocLink          `json:"docLinks,omitempty"` // typed documentation links, rendered as clickable icons (#543)
+    Link         string             `json:"link,omitempty"`        // hyperlink on the draw.io shape and in SVG export
+    DocLinks     []DocLink          `json:"docLinks,omitempty"`    // typed documentation links, rendered as clickable icons (#543)
+    CodeMapping  *CodeMapping       `json:"codeMapping,omitempty"` // real-code anchor for the code-governance bridge (#562)
 }
 
 // DocLink is a typed link to an external documentation artifact (#543)
@@ -941,6 +944,13 @@ type DocLink struct {
     Type  string `json:"type"`  // free string; conventional: arc42|adr|persona|prd|spec
     Href  string `json:"href"`
     Title string `json:"title,omitempty"` // icon tooltip; defaults to Type when omitted
+}
+
+// CodeMapping anchors an element to real code for the code-governance
+// bridge (ArchUnit first, #562, ADR-013). Flat, not keyed per backend —
+// matches the validated Variant C prototype contract.
+type CodeMapping struct {
+    Packages []string `json:"packages,omitempty"` // package prefixes, without ArchUnit's trailing ".."
 }
 
 // Relationship connects two elements


### PR DESCRIPTION
## Summary
Second slice of #562, stacked on **#598** (needs `codeMapping` to exist — base branch is `feat/562-codemapping-field`, not `main`; will retarget automatically once #598 merges).

Implements the reverse side of the code-governance bridge (ADR-013): `bausteinsicht import-graph <codegraph-file>` projects a language-neutral `codegraph` JSON document (the contract `docToolchain/bausteinsicht-archunit`'s `CodeGraphExporter` already emits) onto model elements via `codeMapping`, and writes the result as the model's `asIs` snapshot. A subsequent `bausteinsicht diff` then surfaces drift between real code and the intended (`toBe`) architecture — exactly #562's own worked example (model has `api→svc→db`; real code additionally has `api→db`; `diff` must surface that as a change).

## Design
- `internal/codegraph`: `CodeGraph`/`Node`/`Edge` types + `Load()` (validates `kind`/`schemaVersion`); `Project()` implements #562's projection algorithm — build a `package → elementID` index from every element's `codeMapping.packages`, resolve every codegraph node/edge through it via longest-prefix, dot-boundary matching (mirrors ArchUnit's own package matcher: `com.acme.api` covers `com.acme.api.internal` but not `com.acme.apiextra`), drop intra-element edges (implementation detail, not architecture), and collect unmapped packages rather than silently dropping them.
- `bausteinsicht import-graph`: loads the model, guards against running against a model with zero `codeMapping` elements (mirrors the prototype adapter's own `IllegalArgumentException` for the same case), writes `asIs` via `model.Save` (full rewrite — a *modification* of an existing field, per ADR-011's documented limitation, not a pure insertion).
- `schema generate` gained `--type model|codegraph` (default `model`, unchanged behavior) so the new `codegraph.schema.json` reuses the existing reflection-based generator instead of a hand-maintained schema.

## Test plan
- [x] `internal/codegraph`: 14 unit tests — the worked drift example, intra-element-edge dropping, dot-boundary prefix matching (including the "must not match a sibling package" guard), unmapped-package collection, duplicate-edge dedup, `Load` validation.
- [x] `cmd/bausteinsicht`: 8 command-level tests, including one that runs `import-graph` then `diff` in-process to prove the producer→consumer chain.
- [x] **`e2e/import_graph_workflow_test.go`** — runs the real built binary: `import-graph` writes `asIs` to a model file on disk, `diff` (a separate process invocation) reads that file back and surfaces the drift relationship. This is the actual e2e scenario the PR merge policy requires for a new command whose output feeds another command.
- [x] `TestCommittedCodeGraphSchemaInSync` — new drift guard mirroring the existing model-schema one.
- [x] `go build`, `go vet`, `gofmt -l`, `staticcheck`, `gocognit -over 15` (no new violations), full `go test ./...`, `make arc42-drift-check`, `make arc42-process-coverage-check`, `make arc42-runtime-coverage-check` — all clean.

## Docs
- ADR-013 updated: reverse path + `codeMapping`/`import-graph` marked **implemented** (was staged/designed only).
- `spec/02_cli_specification.adoc`: new `import-graph` detailed section + Command Overview row.
- `spec/03_data_models.adoc`: also fixes a real gap from #598 — the "Go Struct Mappings" appendix never got `CodeMapping` added; caught while updating it for this PR.
- `architecture.jsonc` + arc42 chapters 3/5/6: new `codegraph` container, `import-graph` mentioned in the process diagram and runtime view (advisory `arc42-process-coverage-check`/`arc42-runtime-coverage-check` now pass).
- `spec/01`/`spec/04` intentionally untouched — this command class (`diff`/`changelog`/`snapshot`/now `import-graph`) has no dedicated UC/AC in either doc; staying consistent with that existing precedent rather than introducing a one-off exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: resolved #562's two remaining scope items (no code needed)

#562's own scope also listed "ArchUnit forward generation" and a "RuleBackend abstraction" as open. Investigated both — resolution is documentation-only, added to ADR-013:

- **Skip Variant B** (the PlantUML forward emitter). Its only purpose was proving the forward direction can work at all; the Variant C prototype already proves that more thoroughly (real `mvn verify` round-trip). Building it now would duplicate proof that already exists.
- **`RuleBackend` abstraction (R1): satisfied by construction, no interface needed.** Checked `internal/codegraph` for any ArchUnit/Java-specific branching — there is none. `Project()` is fully generic (dot-boundary prefix matching only); `Language` is passed through purely as report metadata. There is nothing for a Go interface to abstract *over* yet. Adding one now would mean designing it against one real implementation and one imagined one, guessed at before #574 (Go) exists to validate against — exactly what #572's own R1 warns against.

Still open: the constraint→target-rule translation table (#572 R4) and the Variant C governance questions (JSONC as public API, adapter ownership/license) — see ADR-013's Open Questions.
