### PR TITLE
fix(build): bump go directive to 1.25.13 to resolve GO-2026-6088

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docToolchain/Bausteinsicht
 
-go 1.25.8
+go 1.25.13
 
 require (
 	github.com/beevik/etree v1.6.0


### PR DESCRIPTION
## Summary
CI's `govulncheck` (blocking, see CLAUDE.md's Risk Radar mitigations) started failing on every open PR today, unrelated to any of their actual content — including PR #602, which is how this was found: https://github.com/docToolchain/Bausteinsicht/actions/runs/31774636248/job/94687434045?pr=602

## Root cause
[GO-2026-6088](https://pkg.go.dev/vuln/GO-2026-6088) — a newly published `encoding/xml` stdlib vulnerability (missing recursion depth guard during decode) — affects `go1.25.8` (this repo's pinned version) and is fixed in `go1.25.13`. Reachable via:
- `internal/drawio.LoadTemplateFromBytes` → `etree.Document.ReadFromBytes` → `xml.Decoder`
- `internal/importer/xmi.handleElemStartElement` → `xml.Decoder.Skip`

Since this is a stdlib vulnerability with real call-site reachability (not just a transitive dependency nobody calls), it fails `govulncheck ./...` for any branch, regardless of what that branch actually changes.

## Fix
Bump `go.mod`'s `go` directive from `1.25.8` to `1.25.13`. CI resolves its Go toolchain from `go.mod` (`go-version-file: go.mod`, used by all 16 `actions/setup-go` steps in `go.yml`), so this one-line change is sufficient — no separate CI workflow edit needed. `go.sum` is unaffected (no dependency version changes).

## Test plan
- [x] Verified locally: `GOTOOLCHAIN=auto` downloads `go1.25.13` automatically on `go build`
- [x] `govulncheck ./...` now reports **0 vulnerabilities** in first-party code (down from 1)
- [x] `go build`, `go vet`, `gofmt -l`, full `go test ./...` all unaffected/clean

Unblocks #595, #596, #597, #598, #599, #602 (and #571) — none of them touch anything related to this; their `govulncheck` failures should clear once this merges and they rebase/re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)