### PR TITLE
fix(layout): bausteinsicht layout silently does nothing on real diagrams

### DIFF
--- a/internal/layout/apply.go
+++ b/internal/layout/apply.go
@@ -62,16 +62,16 @@ func updateElementPosition(doc *drawio.Document, elemID string, pos ElementPosit
 					return
 				}
 				if id, ok := getAttr(elem, "bausteinsicht_id"); ok && id == elemID {
-					// Find mxGeometry child and update coordinates
-					for _, child := range elem.ChildElements() {
-						if child.Tag == "mxGeometry" {
-							child.CreateAttr("x", fmt.Sprintf("%.0f", pos.X))
-							child.CreateAttr("y", fmt.Sprintf("%.0f", pos.Y))
-							child.CreateAttr("width", fmt.Sprintf("%.0f", pos.Width))
-							child.CreateAttr("height", fmt.Sprintf("%.0f", pos.Height))
-							found = true
-							break
-						}
+					// mxGeometry is nested inside an mxCell child, not a direct
+					// child of the <object> element itself (drawio.CreateElement
+					// always emits object > mxCell > mxGeometry) — search the
+					// whole subtree rather than only direct children.
+					if geom := findMxGeometry(elem); geom != nil {
+						geom.CreateAttr("x", fmt.Sprintf("%.0f", pos.X))
+						geom.CreateAttr("y", fmt.Sprintf("%.0f", pos.Y))
+						geom.CreateAttr("width", fmt.Sprintf("%.0f", pos.Width))
+						geom.CreateAttr("height", fmt.Sprintf("%.0f", pos.Height))
+						found = true
 					}
 				}
 			})
@@ -82,6 +82,21 @@ func updateElementPosition(doc *drawio.Document, elemID string, pos ElementPosit
 	}
 
 	return fmt.Errorf("element %s not found in diagram", elemID)
+}
+
+// findMxGeometry searches elem's subtree (not just direct children) for an
+// mxGeometry element, matching drawio.CreateElement's object > mxCell >
+// mxGeometry nesting.
+func findMxGeometry(elem *etree.Element) *etree.Element {
+	if elem.Tag == "mxGeometry" {
+		return elem
+	}
+	for _, child := range elem.ChildElements() {
+		if geom := findMxGeometry(child); geom != nil {
+			return geom
+		}
+	}
+	return nil
 }
 
 // walkElements recursively walks through all elements in the tree.

--- a/internal/layout/apply_test.go
+++ b/internal/layout/apply_test.go
@@ -1,0 +1,91 @@
+package layout
+
+import (
+	"testing"
+
+	"github.com/beevik/etree"
+	"github.com/docToolchain/Bausteinsicht/internal/drawio"
+)
+
+// TestApply_UpdatesRealElementStructure reproduces the bug where Apply silently
+// updates nothing on a real Bausteinsicht diagram. drawio.Page.CreateElement (used
+// by sync for every element it creates) nests <mxGeometry> two levels deep —
+// <object bausteinsicht_id="..."><mxCell><mxGeometry/></mxCell></object> — but
+// updateElementPosition only checked the object's *direct* children for an
+// mxGeometry tag, so it never found one and silently left every element
+// untouched (Apply()'s caller swallows the "not found" error). Regression test
+// for #604.
+func TestApply_UpdatesRealElementStructure(t *testing.T) {
+	doc := drawio.NewDocument()
+	page := doc.AddPage("page1", "Page 1")
+	if err := page.CreateElement(drawio.ElementData{
+		ID:     "svc",
+		Kind:   "container",
+		Title:  "Service",
+		X:      10,
+		Y:      20,
+		Width:  180,
+		Height: 60,
+	}, "rounded=1"); err != nil {
+		t.Fatalf("CreateElement failed: %v", err)
+	}
+
+	result := LayoutResult{
+		Positions: map[string]ElementPosition{
+			"svc": {ID: "svc", X: 999, Y: 888, Width: 200, Height: 100},
+		},
+		Algorithm: Hierarchical,
+	}
+
+	if err := Apply(doc, result, false); err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+
+	geom := findGeometry(t, page, "svc")
+	if x := geom.SelectAttrValue("x", ""); x != "999" {
+		t.Errorf("x = %q, want \"999\" — Apply did not update the real object>mxCell>mxGeometry structure", x)
+	}
+	if y := geom.SelectAttrValue("y", ""); y != "888" {
+		t.Errorf("y = %q, want \"888\"", y)
+	}
+}
+
+func findGeometry(t *testing.T, page *drawio.Page, bausteinsichtID string) *etree.Element {
+	t.Helper()
+	root := page.Root()
+	if root == nil {
+		t.Fatal("page has no root")
+	}
+	var found *etree.Element
+	walkElements(root, func(elem *etree.Element) {
+		if found != nil {
+			return
+		}
+		for _, attr := range elem.Attr {
+			if attr.Key == "bausteinsicht_id" && attr.Value == bausteinsichtID {
+				for _, child := range elem.ChildElements() {
+					if g := findGeometryRecursive(child); g != nil {
+						found = g
+						return
+					}
+				}
+			}
+		}
+	})
+	if found == nil {
+		t.Fatalf("no mxGeometry found for %s", bausteinsichtID)
+	}
+	return found
+}
+
+func findGeometryRecursive(elem *etree.Element) *etree.Element {
+	if elem.Tag == "mxGeometry" {
+		return elem
+	}
+	for _, child := range elem.ChildElements() {
+		if g := findGeometryRecursive(child); g != nil {
+			return g
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
`bausteinsicht layout` has been a complete no-op against every diagram `sync` actually produces, since (at latest) whenever `drawio.CreateElement`'s current `object > mxCell > mxGeometry` nesting was introduced. The command reports success and writes the file, but nothing changes.

Found while investigating #604 (arc42 diagram layout quality) — this is exactly why "just try `bausteinsicht layout`" wasn't a viable first step there. Filing as its own PR because a silently-inert command is a defect on its own merits, independent of whatever #604 concludes about layout *quality*.

## Root cause
`internal/layout/apply.go`'s `updateElementPosition` only scanned an element's **direct** children for an `mxGeometry` tag:
```go
for _, child := range elem.ChildElements() {
    if child.Tag == "mxGeometry" { ... }
}
```
But `drawio.CreateElement`'s own doc comment says exactly what it builds: `<object>` wrapping `<mxCell vertex="1">` with `<mxGeometry>` — geometry is a **grandchild** of the object, not a direct child. The direct-children scan never found it, `found` stayed `false`, `updateElementPosition` returned a "not found" error for every single element — and `Apply()`'s caller silently discards that error (`continue`), so the whole operation "succeeded" while doing nothing.

**Confirmed empirically** against the self-hosted `src/docs/arc42/architecture.drawio`: running `layout --algorithm hierarchical --rank-dir LR` against a copy produced a **byte-for-byte identical file** before this fix. After the fix, a real 224-line diff.

## Fix
`findMxGeometry` now searches the matched element's whole subtree instead of only direct children. Verified this can't accidentally grab the wrong element's geometry: `drawio.CreateElement`'s sub-cells (title/tech/description) are created as **siblings** under the page root, not as children of `<object>` — so recursing into the matched object's own subtree only ever finds its own geometry.

## Test plan
- [x] `internal/layout/apply_test.go` — new TDD test, builds a real `object>mxCell>mxGeometry` fixture via `drawio.Page.CreateElement` (the same helper `sync` itself uses, not hand-rolled XML), confirmed it failed against the unfixed code first
- [x] Full existing `internal/layout` test suite still passes
- [x] `go build`, `go vet`, `gofmt -l`, `staticcheck`, full `go test ./...` all clean
- No new command/flag; this restores existing, documented behavior of an existing command, so no new e2e scenario required per the PR merge policy — though `internal/layout` had zero test coverage of `Apply()` before this PR (only `Compute()` was tested), which is itself part of how this went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)