### PR TITLE
test(cli): cover identifier rejection at command level

### DIFF
--- a/cmd/bausteinsicht/add_specification_test.go
+++ b/cmd/bausteinsicht/add_specification_test.go
@@ -71,6 +71,92 @@ func TestAddSpecificationRelationshipCmd_WithNotation(t *testing.T) {
 	}
 }
 
+// invalidKeys are rejected by isValidKey for every command that names an
+// identifier. Kept in one place so element, specification, and view keys are
+// asserted against the same set -- they drifted apart once already (#582).
+var invalidKeys = []string{
+	"foo.bar",    // dot (hierarchy separator)
+	"foo bar",    // space
+	"foo@bar",    // special char
+	"foo/bar",    // slash
+	"",           // empty
+	"123invalid", // starts with digit
+	"_leading",   // starts with underscore
+}
+
+// TestAddSpecificationElementCmd_InvalidKeys covers the key rejection branch of
+// "add specification element" at the command level, not just the validator.
+func TestAddSpecificationElementCmd_InvalidKeys(t *testing.T) {
+	for _, key := range invalidKeys {
+		t.Run(key, func(t *testing.T) {
+			dir := t.TempDir()
+			modelPath := writeSpecTestModel(t, dir)
+
+			cmd := NewRootCmd()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"add", "specification", "element", key,
+				"--model", modelPath,
+				"--notation", "Box",
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for invalid specification key %q", key)
+			}
+			if e, ok := err.(*exitError); ok && e.code != 1 {
+				t.Errorf("expected exit code 1, got %d", e.code)
+			}
+		})
+	}
+}
+
+// TestAddSpecificationRelationshipCmd_InvalidKeys is the relationship
+// counterpart of TestAddSpecificationElementCmd_InvalidKeys.
+func TestAddSpecificationRelationshipCmd_InvalidKeys(t *testing.T) {
+	for _, key := range invalidKeys {
+		t.Run(key, func(t *testing.T) {
+			dir := t.TempDir()
+			modelPath := writeSpecTestModel(t, dir)
+
+			cmd := NewRootCmd()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"add", "specification", "relationship", key,
+				"--model", modelPath,
+				"--notation", "->",
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for invalid specification key %q", key)
+			}
+			if e, ok := err.(*exitError); ok && e.code != 1 {
+				t.Errorf("expected exit code 1, got %d", e.code)
+			}
+		})
+	}
+}
+
+// TestAddSpecificationCmd_CamelCaseKeys is the regression test for #582: the
+// specification commands used a lowercase-only validator while the model,
+// schema, validate, and "add element" all accepted camelCase.
+func TestAddSpecificationCmd_CamelCaseKeys(t *testing.T) {
+	for _, key := range []string{"boundaryObject", "applicationService"} {
+		t.Run(key, func(t *testing.T) {
+			dir := t.TempDir()
+			modelPath := writeSpecTestModel(t, dir)
+
+			cmd := NewRootCmd()
+			cmd.SetArgs([]string{"add", "specification", "element", key,
+				"--model", modelPath,
+				"--notation", "Box",
+			})
+			if err := cmd.Execute(); err != nil {
+				t.Errorf("unexpected error for camelCase key %q: %v", key, err)
+			}
+		})
+	}
+}
+
 func writeSpecTestModel(t *testing.T, dir string) string {
 	t.Helper()
 	p := filepath.Join(dir, "architecture.jsonc")

--- a/cmd/bausteinsicht/add_view_test.go
+++ b/cmd/bausteinsicht/add_view_test.go
@@ -87,6 +87,49 @@ func TestAddViewCmd_MergeViewFields(t *testing.T) {
 	}
 }
 
+// TestAddViewCmd_InvalidKeys covers the key rejection branch of "add view" at
+// the command level. Shares invalidKeys with the specification tests so all
+// three identifier commands are held to the same contract (#582).
+func TestAddViewCmd_InvalidKeys(t *testing.T) {
+	for _, key := range invalidKeys {
+		t.Run(key, func(t *testing.T) {
+			dir := t.TempDir()
+			modelPath := writeViewTestModel(t, dir)
+
+			cmd := NewRootCmd()
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.SetArgs([]string{"add", "view", key,
+				"--model", modelPath,
+				"--title", "Test",
+			})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error for invalid view key %q", key)
+			}
+			if e, ok := err.(*exitError); ok && e.code != 1 {
+				t.Errorf("expected exit code 1, got %d", e.code)
+			}
+		})
+	}
+}
+
+// TestAddViewCmd_CamelCaseKey is the "add view" half of the #582 regression:
+// the view validator was lowercase-only.
+func TestAddViewCmd_CamelCaseKey(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := writeViewTestModel(t, dir)
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "view", "systemLandscape",
+		"--model", modelPath,
+		"--title", "System Landscape",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("unexpected error for camelCase view key: %v", err)
+	}
+}
+
 func writeViewTestModel(t *testing.T, dir string) string {
 	t.Helper()
 	p := filepath.Join(dir, "architecture.jsonc")


### PR DESCRIPTION
## Description

Adds command-level tests for the identifier validation in `add specification element|relationship` and `add view`.

Codecov flagged these three `isValidKey` guards as uncovered on #583. Consolidating the validators there removed the old per-command validator unit tests, leaving only `isValidKey` tested in isolation — which is the wrong level: **#582 was a wiring bug, not a regex bug**. An isolated validator test cannot catch a command being wired to the wrong validator, which is exactly how #582 happened.

## Related Issue

Refs #612 (coverage measurement consolidation — this PR closes the concrete gap, the issue covers the setup)
Follow-up to #583 / #582

## Type of Change

- [x] Improvement/refactoring (test coverage only — no production code touched)

## Testing

- Rejection tests for all three commands over a shared `invalidKeys` list (7 cases each, incl. exit code 1), so element, specification, and view keys are held to the same contract.
- camelCase acceptance tests as the actual #582 regression guard.
- **Coverage verified:** the three blocks flagged by Codecov (`add_specification.go:50`, `:142`, `add_view.go:38`) go from `0` to `1` in the coverage profile.
- **Mutation-checked:** reverting `validKeyPattern` to the old lowercase-only `^[a-z][a-z0-9_-]*$` makes all camelCase tests fail. The tests do not pass by accident.
- `gofmt`, `go vet`, `go test ./...` clean locally.

## Pre-Merge Checklist (Developer)

- [x] **Branch is up-to-date with main** — branched from `c99550d`
- [x] **No duplicate work** — checked open PRs
- [x] **Tests passing** — unit ✅, full suite ✅
- [x] **Code quality** — `gofmt`/`vet` clean, no new warnings
- [x] **Documentation** — N/A: test-only change, no CLI surface, data model, sync behavior, or package structure touched. No spec/arc42 file applies.

## Notes for Reviewers

No production code is modified — the diff is two test files. The `invalidKeys` list is deliberately shared between `add_specification_test.go` and `add_view_test.go` so the three identifier commands cannot drift apart again unnoticed.
