### PR TITLE
ci(stale-branches): dedupe against the existing open tracking issue

### DIFF
--- a/.github/workflows/check-stale-branches.yml
+++ b/.github/workflows/check-stale-branches.yml
@@ -65,11 +65,33 @@ jobs:
 
             # shellcheck disable=SC2016  # backticks are literal markdown code-fence text in the issue body, not command substitution
             BODY=$(printf 'Found stale branches (not merged to main, >7 days old):\n\n%s\n\n**Recommendation:**\nReview if these branches should be:\n1. Merged (if still relevant work)\n2. Deleted (if work is abandoned or superseded)\n\nDelete with:\n```bash\ngit fetch origin\ngit branch -D <branch>\ngit push origin --delete <branch>\n```' "$STALE_BRANCHES")
-            gh issue create \
-              --title "🧹 Cleanup: Stale branches found" \
-              --body "$BODY" \
-              --label infrastructure \
-              2>/dev/null || echo "Issue already exists or other error"
+
+            # Update the existing open tracking issue instead of creating a new
+            # one every run — a plain `gh issue create` has no duplicate-title
+            # detection, so it always succeeds and silently piled up multiple
+            # open "Cleanup: Stale branches found" issues in parallel (#619).
+            EXISTING_ISSUE=$(gh issue list \
+              --search '"🧹 Cleanup: Stale branches found" in:title' \
+              --state open --json number --jq '.[0].number')
+            if [ -n "$EXISTING_ISSUE" ]; then
+              gh issue comment "$EXISTING_ISSUE" --body "$BODY"
+            else
+              gh issue create \
+                --title "🧹 Cleanup: Stale branches found" \
+                --body "$BODY" \
+                --label infrastructure
+            fi
           else
             echo "✅ No stale branches found" >> "$GITHUB_STEP_SUMMARY"
+
+            # Close the tracking issue left over from a previous run — no
+            # point leaving it open with a now-stale branch list once the
+            # branches are gone (#619).
+            EXISTING_ISSUE=$(gh issue list \
+              --search '"🧹 Cleanup: Stale branches found" in:title' \
+              --state open --json number --jq '.[0].number')
+            if [ -n "$EXISTING_ISSUE" ]; then
+              gh issue close "$EXISTING_ISSUE" \
+                --comment "No stale branches found in this run — closing."
+            fi
           fi


### PR DESCRIPTION
## Description

Fixes #619: the weekly stale-branch check created a brand-new "🧹 Cleanup: Stale branches found" issue on every run instead of updating an existing open one. `gh issue create` has no duplicate-title detection — it always succeeds — so the `|| echo "Issue already exists or other error"` fallback was dead code that never actually triggered.

**Evidence:** three of these issues were open simultaneously (#584 from 2026-08-10, #617 from 2026-08-17, #618 from 2026-08-24), with heavy overlap in their branch lists (`brownfield`, `brownfield-2-phases`, `brownfield-socratic`, `claude/project-code-stats-9b66nz` appeared in all three, unaddressed for 2+ weeks across issues instead of one continuously updated tracker).

## Changes

- Before creating an issue: search for an existing **open** issue titled "🧹 Cleanup: Stale branches found" via `gh issue list --search ... --state open`. If found, `gh issue comment` on it with the current branch list instead of creating a duplicate.
- When a run finds zero stale branches: close the existing tracking issue (if any) instead of leaving it open with a now-stale list.

## Type of Change

- [x] Improvement/refactoring (CI workflow only — no production code)

## Testing

- YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `actionlint` runs on this file in CI (existing job).
- Not runnable end-to-end locally (depends on live `gh issue` state and the weekly cron), so this is a logic read-through + YAML validation rather than an executed test. Will observe the next scheduled/`workflow_dispatch` run for confirmation.

## Documentation

N/A — CI workflow only, no CLI/model/sync/package-structure change.

## Follow-up (done outside this PR)

Closing #584 and #617 as superseded by #618, which stays open as the single canonical tracker going forward.