### PR TITLE
feat(import): add post-import summary, next-steps hint, and --json mode

### DIFF
--- a/cmd/bausteinsicht/import.go
+++ b/cmd/bausteinsicht/import.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/docToolchain/Bausteinsicht/internal/importer/likec4"
 	"github.com/docToolchain/Bausteinsicht/internal/importer/structurizr"
 	"github.com/docToolchain/Bausteinsicht/internal/importer/xmi"
+	"github.com/docToolchain/Bausteinsicht/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -39,6 +41,7 @@ Exit codes:
 	cmd.Flags().Bool("dry-run", false, "Print generated model to stdout instead of writing file")
 	cmd.Flags().Bool("force", false, "Overwrite output file if it already exists")
 	cmd.Flags().String("kind-map", "", "XMI only: comma-separated Type=kind overrides (e.g. Component=service,Class=entity)")
+	cmd.Flags().Bool("json", false, "Print the post-import summary as JSON instead of human-readable text")
 	_ = cmd.MarkFlagRequired("from")
 	return cmd
 }
@@ -49,6 +52,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 	outputPath, _ := cmd.Flags().GetString("output")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	force, _ := cmd.Flags().GetBool("force")
+	jsonSummary, _ := cmd.Flags().GetBool("json")
 
 	from = strings.ToLower(strings.TrimSpace(from))
 	if from != "structurizr" && from != "likec4" && from != "xmi" {
@@ -62,18 +66,22 @@ func runImport(cmd *cobra.Command, args []string) error {
 		return exitWithCode(fmt.Errorf("--output: %w", err), 1)
 	}
 
-	if !dryRun && !force {
+	var overwriting bool
+	if !dryRun {
 		if _, err := os.Stat(outputPath); err == nil {
-			return exitWithCode(
-				fmt.Errorf("output file %q already exists — use --force to overwrite", outputPath),
-				2,
-			)
+			overwriting = true
 		}
+	}
+	if !dryRun && !force && overwriting {
+		return exitWithCode(
+			fmt.Errorf("output file %q already exists — use --force to overwrite", outputPath),
+			2,
+		)
 	}
 
 	var (
-		importedModel any
-		warnings      []string
+		resultModel *model.BausteinsichtModel
+		warnings    []string
 	)
 
 	switch from {
@@ -82,13 +90,13 @@ func runImport(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return exitWithCode(fmt.Errorf("import failed: %w", err), 1)
 		}
-		importedModel, warnings = r.Model, r.Warnings
+		resultModel, warnings = r.Model, r.Warnings
 	case "likec4":
 		r, err := likec4.Import(inputPath)
 		if err != nil {
 			return exitWithCode(fmt.Errorf("import failed: %w", err), 1)
 		}
-		importedModel, warnings = r.Model, r.Warnings
+		resultModel, warnings = r.Model, r.Warnings
 	case "xmi":
 		kindMapStr, _ := cmd.Flags().GetString("kind-map")
 		kindMap, err := xmi.ParseKindMap(kindMapStr)
@@ -99,10 +107,10 @@ func runImport(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return exitWithCode(err, 1)
 		}
-		importedModel, warnings = r.Model, r.Warnings
+		resultModel, warnings = r.Model, r.Warnings
 	}
 
-	data, err := json.MarshalIndent(importedModel, "", "  ")
+	data, err := json.MarshalIndent(resultModel, "", "  ")
 	if err != nil {
 		return exitWithCode(fmt.Errorf("encoding model: %w", err), 1)
 	}
@@ -111,23 +119,116 @@ func runImport(cmd *cobra.Command, args []string) error {
 		if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
 			return err
 		}
-	} else {
-		if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-			return exitWithCode(fmt.Errorf("creating output directory: %w", err), 1)
+		for _, w := range warnings {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "WARNING: %s\n", w); err != nil {
+				return err
+			}
 		}
-		if err := os.WriteFile(outputPath, append(data, '\n'), 0o644); err != nil {
-			return exitWithCode(fmt.Errorf("writing %s: %w", outputPath, err), 1)
-		}
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Imported model written to %s\n", outputPath); err != nil {
-			return err
-		}
+		return nil
 	}
 
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return exitWithCode(fmt.Errorf("creating output directory: %w", err), 1)
+	}
+	if err := os.WriteFile(outputPath, append(data, '\n'), 0o644); err != nil {
+		return exitWithCode(fmt.Errorf("writing %s: %w", outputPath, err), 1)
+	}
+
+	if jsonSummary {
+		return printImportSummaryJSON(cmd, resultModel, outputPath, warnings)
+	}
+	return printImportSummaryText(cmd, resultModel, outputPath, warnings, overwriting)
+}
+
+// printImportSummaryText prints the human-readable post-import summary:
+// per-kind element counts, output path, generated view count (omitted when
+// zero, since e.g. XMI never populates views), warnings, and a next-steps
+// hint. On a --force overwrite of an existing file the hint points at
+// `bausteinsicht diff` instead of `sync`, since the existing file likely
+// already has synced draw.io state.
+func printImportSummaryText(cmd *cobra.Command, m *model.BausteinsichtModel, outputPath string, warnings []string, overwriting bool) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "Imported model written to %s\n", outputPath); err != nil {
+		return err
+	}
 	for _, w := range warnings {
-		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "WARNING: %s\n", w); err != nil {
+		if _, err := fmt.Fprintf(out, "WARNING: %s\n", w); err != nil {
 			return err
 		}
 	}
 
-	return nil
+	counts, err := elementCountsByKind(m)
+	if err != nil {
+		return err
+	}
+	kinds := make([]string, 0, len(counts))
+	for kind := range counts {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	for _, kind := range kinds {
+		if _, err := fmt.Fprintf(out, "%s: %d\n", kind, counts[kind]); err != nil {
+			return err
+		}
+	}
+	if len(m.Views) > 0 {
+		if _, err := fmt.Fprintf(out, "views: %d\n", len(m.Views)); err != nil {
+			return err
+		}
+	}
+
+	if overwriting {
+		_, err = fmt.Fprintln(out, "Next steps: bausteinsicht diff")
+	} else {
+		_, err = fmt.Fprintln(out, "Next steps: bausteinsicht sync, bausteinsicht export diagram")
+	}
+	return err
+}
+
+// importSummary is the --json shape for the post-import summary.
+type importSummary struct {
+	Elements   map[string]int `json:"elements"`
+	OutputPath string         `json:"outputPath"`
+	Views      int            `json:"views"`
+	Warnings   []string       `json:"warnings"`
+}
+
+// printImportSummaryJSON prints the post-import summary as a single JSON
+// object, for LLM/CI workflows that would otherwise have to parse the
+// human-readable text (QG-3, LLM-friendliness). Unlike the text summary,
+// "views" is always present (0 rather than omitted), since machine consumers
+// should not have to distinguish "zero" from "absent".
+func printImportSummaryJSON(cmd *cobra.Command, m *model.BausteinsichtModel, outputPath string, warnings []string) error {
+	counts, err := elementCountsByKind(m)
+	if err != nil {
+		return err
+	}
+	if warnings == nil {
+		warnings = []string{}
+	}
+	summary := importSummary{
+		Elements:   counts,
+		OutputPath: outputPath,
+		Views:      len(m.Views),
+		Warnings:   warnings,
+	}
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding summary: %w", err)
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return err
+}
+
+// elementCountsByKind returns the number of elements per kind in the model.
+func elementCountsByKind(m *model.BausteinsichtModel) (map[string]int, error) {
+	elements, err := model.FlattenElements(m)
+	if err != nil {
+		return nil, fmt.Errorf("flattening imported model: %w", err)
+	}
+	counts := make(map[string]int)
+	for _, elem := range elements {
+		counts[elem.Kind]++
+	}
+	return counts, nil
 }

--- a/cmd/bausteinsicht/import_test.go
+++ b/cmd/bausteinsicht/import_test.go
@@ -133,3 +133,108 @@ func TestImportCmd_NonExistentFile_ExitCode1(t *testing.T) {
 		t.Errorf("expected exit code 1, got %d", ee.code)
 	}
 }
+
+// TestImportCmd_TextSummary covers the post-import summary text (#482 v1):
+// per-kind counts, views count, and the fresh-import next-steps hint.
+func TestImportCmd_TextSummary(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+	out, err := executeImportCmd("import", "--from", "structurizr", "--output", outFile, dsl)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+	for _, want := range []string{
+		"person: 1",
+		"container: 3",
+		"system: 2",
+		"views: 2",
+		"Next steps: bausteinsicht sync, bausteinsicht export diagram",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected summary to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestImportCmd_JSONSummary covers --json's machine-readable summary shape.
+func TestImportCmd_JSONSummary(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+	out, err := executeImportCmd("import", "--from", "structurizr", "--output", outFile, "--json", dsl)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+
+	var summary struct {
+		Elements   map[string]int `json:"elements"`
+		OutputPath string         `json:"outputPath"`
+		Views      int            `json:"views"`
+		Warnings   []string       `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(out), &summary); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if summary.Elements["container"] != 3 {
+		t.Errorf("expected 3 containers, got %d (elements=%v)", summary.Elements["container"], summary.Elements)
+	}
+	if summary.OutputPath != outFile {
+		t.Errorf("expected outputPath %q, got %q", outFile, summary.OutputPath)
+	}
+	if summary.Views != 2 {
+		t.Errorf("expected views=2, got %d", summary.Views)
+	}
+	if summary.Warnings == nil {
+		t.Error("expected warnings to be a non-nil (possibly empty) array in JSON output")
+	}
+}
+
+// TestImportCmd_DryRunSuppressesSummary covers that --dry-run prints only the
+// model JSON — no per-kind counts, no next-steps hint, since nothing was
+// persisted.
+func TestImportCmd_DryRunSuppressesSummary(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	out, err := executeImportCmd("import", "--from", "structurizr", "--dry-run", dsl)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+	if strings.Contains(out, "Next steps:") {
+		t.Errorf("--dry-run must not print a next-steps hint, got:\n%s", out)
+	}
+	if strings.Contains(out, "container:") {
+		t.Errorf("--dry-run must not print per-kind counts, got:\n%s", out)
+	}
+}
+
+// TestImportCmd_ForceOverwriteHintsDiff covers that overwriting an existing
+// output file with --force hints at `bausteinsicht diff` instead of `sync`.
+func TestImportCmd_ForceOverwriteHintsDiff(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+	if err := os.WriteFile(outFile, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := executeImportCmd("import", "--from", "structurizr", "--output", outFile, "--force", dsl)
+	if err != nil {
+		t.Fatalf("expected no error with --force, got %v", err)
+	}
+	if !strings.Contains(out, "Next steps: bausteinsicht diff") {
+		t.Errorf("expected --force overwrite to hint at \"bausteinsicht diff\", got:\n%s", out)
+	}
+	if strings.Contains(out, "bausteinsicht sync") {
+		t.Errorf("--force overwrite must not also hint at \"bausteinsicht sync\", got:\n%s", out)
+	}
+}
+
+// TestImportCmd_XMINoViewsLine covers that the views line is omitted in text
+// mode when the importer produced zero views (XMI never populates Views).
+func TestImportCmd_XMINoViewsLine(t *testing.T) {
+	xmi := absDSL(t, "internal", "importer", "xmi", "testdata", "basic.xmi")
+	outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+	out, err := executeImportCmd("import", "--from", "xmi", "--output", outFile, xmi)
+	if err != nil {
+		t.Fatalf("expected no error, got %v\nOutput: %s", err, out)
+	}
+	if strings.Contains(out, "views:") {
+		t.Errorf("expected no \"views:\" line for an XMI import with zero views, got:\n%s", out)
+	}
+}

--- a/cmd/bausteinsicht/import_test.go
+++ b/cmd/bausteinsicht/import_test.go
@@ -3,10 +3,15 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/docToolchain/Bausteinsicht/internal/model"
+	"github.com/spf13/cobra"
 )
 
 func executeImportCmd(args ...string) (string, error) {
@@ -236,5 +241,297 @@ func TestImportCmd_XMINoViewsLine(t *testing.T) {
 	}
 	if strings.Contains(out, "views:") {
 		t.Errorf("expected no \"views:\" line for an XMI import with zero views, got:\n%s", out)
+	}
+}
+
+// TestImportCmd_LikeC4_NonExistentFile_ExitCode1 is the likec4 counterpart of
+// TestImportCmd_NonExistentFile_ExitCode1 — covers the likec4 import-failure
+// branch in runImport's format switch.
+func TestImportCmd_LikeC4_NonExistentFile_ExitCode1(t *testing.T) {
+	_, err := executeImportCmd("import", "--from", "likec4", "--dry-run", "/nonexistent/model.c4")
+	if err == nil {
+		t.Fatal("expected error for non-existent file")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_XMI_KindMapParseError_ExitCode1 covers the --kind-map parse
+// error branch (a malformed entry, missing "Type=kind").
+func TestImportCmd_XMI_KindMapParseError_ExitCode1(t *testing.T) {
+	xmi := absDSL(t, "internal", "importer", "xmi", "testdata", "basic.xmi")
+	_, err := executeImportCmd("import", "--from", "xmi", "--dry-run", "--kind-map", "badentry", xmi)
+	if err == nil {
+		t.Fatal("expected error for malformed --kind-map entry")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_XMI_InvalidFile_ExitCode1 covers the xmi.Import failure
+// branch (malformed XML), distinct from a merely-missing file.
+func TestImportCmd_XMI_InvalidFile_ExitCode1(t *testing.T) {
+	invalid := absDSL(t, "internal", "importer", "xmi", "testdata", "invalid.xmi")
+	_, err := executeImportCmd("import", "--from", "xmi", "--dry-run", invalid)
+	if err == nil {
+		t.Fatal("expected error for invalid XMI content")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_InputPathTraversal_ExitCode1 covers validatePathContainment
+// rejecting a ".." component in the input path.
+func TestImportCmd_InputPathTraversal_ExitCode1(t *testing.T) {
+	_, err := executeImportCmd("import", "--from", "structurizr", "--dry-run", "../evil.dsl")
+	if err == nil {
+		t.Fatal("expected error for path traversal in input path")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_OutputPathTraversal_ExitCode1 covers validatePathContainment
+// rejecting a ".." component in --output.
+func TestImportCmd_OutputPathTraversal_ExitCode1(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	_, err := executeImportCmd("import", "--from", "structurizr", "--output", "../evil.jsonc", dsl)
+	if err == nil {
+		t.Fatal("expected error for path traversal in --output")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_MkdirAllError_ExitCode1 covers os.MkdirAll failing: a path
+// component of --output's directory already exists as a regular file, so it
+// cannot be created as a directory.
+func TestImportCmd_MkdirAllError_ExitCode1(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	outFile := filepath.Join(blocker, "sub", "architecture.jsonc")
+	_, err := executeImportCmd("import", "--from", "structurizr", "--output", outFile, dsl)
+	if err == nil {
+		t.Fatal("expected error creating output directory under a file")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// TestImportCmd_WriteFileError_ExitCode1 covers os.WriteFile failing: --force
+// bypasses the pre-existence check, but the output path is itself an
+// existing directory, so the write fails.
+func TestImportCmd_WriteFileError_ExitCode1(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	dir := t.TempDir()
+	outAsDir := filepath.Join(dir, "isadir")
+	if err := os.Mkdir(outAsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := executeImportCmd("import", "--from", "structurizr", "--output", outAsDir, "--force", dsl)
+	if err == nil {
+		t.Fatal("expected error writing to a directory path")
+	}
+	ee, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("expected exitError, got %T: %v", err, err)
+	}
+	if ee.code != 1 {
+		t.Errorf("expected exit code 1, got %d", ee.code)
+	}
+}
+
+// warningDSL imports to exactly 3 element kinds (person, system, container),
+// 1 view, and 1 warning (autoLayout direction "lr" not preserved) — used to
+// pin down the exact number of stdout writes the summary/hint paths make, so
+// TestImportCmd_TextSummary_WriteFailureAtEveryOffset and
+// TestImportCmd_DryRun_WriteFailureAtEveryOffset can inject a failure at
+// every single write and verify each one is handled.
+const warningDSL = `workspace "W" "one warning fixture" {
+    model {
+        user = person "User" "A user."
+        sys = softwareSystem "Sys" "A system." {
+            api = container "API" "An API." "Go"
+        }
+    }
+    views {
+        systemContext sys "Context" {
+            include *
+            autoLayout lr
+        }
+    }
+}
+`
+
+// failAfterWriter succeeds for the first n writes, then fails every write
+// after that. Used to exercise the "if _, err := fmt.Fprint...; err != nil"
+// branches, which are otherwise unreachable with an in-memory buffer that
+// never errors — a real-world equivalent is a broken pipe (e.g.
+// `bausteinsicht import ... | head -1`, where the reader closes early).
+type failAfterWriter struct{ n int }
+
+func (w *failAfterWriter) Write(p []byte) (int, error) {
+	if w.n <= 0 {
+		return 0, fmt.Errorf("simulated write failure")
+	}
+	w.n--
+	return len(p), nil
+}
+
+func executeImportCmdWithWriter(w io.Writer, args ...string) error {
+	cmd := NewRootCmd()
+	cmd.SetOut(w)
+	cmd.SetErr(w)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// TestImportCmd_TextSummary_WriteFailureAtEveryOffset covers every
+// fmt.Fprint*/Fprintln error-return branch in printImportSummaryText: the
+// "Imported model written to" line, the warning line, each per-kind count
+// line, the views line, and the next-steps line — 7 writes total for
+// warningDSL (1 + 1 warning + 3 kinds + 1 views + 1 next-steps).
+func TestImportCmd_TextSummary_WriteFailureAtEveryOffset(t *testing.T) {
+	dir := t.TempDir()
+	dslPath := filepath.Join(dir, "workspace.dsl")
+	if err := os.WriteFile(dslPath, []byte(warningDSL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const totalWrites = 7
+
+	for n := 0; n <= totalWrites; n++ {
+		t.Run(fmt.Sprintf("failAt%d", n), func(t *testing.T) {
+			outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+			w := &failAfterWriter{n: n}
+			err := executeImportCmdWithWriter(w, "import", "--from", "structurizr", "--output", outFile, dslPath)
+			if n < totalWrites {
+				if err == nil {
+					t.Fatalf("expected write failure at offset %d, got nil error", n)
+				}
+			} else if err != nil {
+				t.Fatalf("expected success once the writer stops failing, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestImportCmd_DryRun_WriteFailureAtEveryOffset is the --dry-run
+// counterpart: covers the model-JSON print and the warnings loop in
+// runImport's dry-run branch — 2 writes total for warningDSL (1 model print
+// + 1 warning).
+func TestImportCmd_DryRun_WriteFailureAtEveryOffset(t *testing.T) {
+	dir := t.TempDir()
+	dslPath := filepath.Join(dir, "workspace.dsl")
+	if err := os.WriteFile(dslPath, []byte(warningDSL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	const totalWrites = 2
+
+	for n := 0; n <= totalWrites; n++ {
+		t.Run(fmt.Sprintf("failAt%d", n), func(t *testing.T) {
+			w := &failAfterWriter{n: n}
+			err := executeImportCmdWithWriter(w, "import", "--from", "structurizr", "--dry-run", dslPath)
+			if n < totalWrites {
+				if err == nil {
+					t.Fatalf("expected write failure at offset %d, got nil error", n)
+				}
+			} else if err != nil {
+				t.Fatalf("expected success once the writer stops failing, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestImportCmd_JSONSummary_WriteFailure covers printImportSummaryJSON's
+// single write (the whole summary is marshaled first, then written once).
+func TestImportCmd_JSONSummary_WriteFailure(t *testing.T) {
+	dsl := absDSL(t, "internal", "importer", "structurizr", "testdata", "simple.dsl")
+	outFile := filepath.Join(t.TempDir(), "architecture.jsonc")
+	w := &failAfterWriter{n: 0}
+	err := executeImportCmdWithWriter(w, "import", "--from", "structurizr", "--output", outFile, "--json", dsl)
+	if err == nil {
+		t.Fatal("expected error when the JSON summary write fails")
+	}
+}
+
+// deeplyNestedModel builds a model whose element hierarchy exceeds
+// model.MaxElementDepth — no real importer output can reach this in
+// practice (structurizr/likec4 only ever produce a fixed 3-tier hierarchy,
+// and XMI enforces its own, separate 50-level cap before ever returning a
+// model), so it's constructed by hand to exercise
+// elementCountsByKind's/model.FlattenElements' depth-limit error return.
+func deeplyNestedModel() *model.BausteinsichtModel {
+	var current model.Element
+	for i := 0; i <= 60; i++ {
+		current = model.Element{Kind: "component", Title: "Level", Children: map[string]model.Element{"child": current}}
+	}
+	return &model.BausteinsichtModel{Model: map[string]model.Element{"root": current}}
+}
+
+// TestElementCountsByKind_DepthExceeded_Error covers elementCountsByKind's
+// error-wrapping branch when model.FlattenElements rejects the hierarchy.
+func TestElementCountsByKind_DepthExceeded_Error(t *testing.T) {
+	_, err := elementCountsByKind(deeplyNestedModel())
+	if err == nil {
+		t.Fatal("expected an error for a model exceeding MaxElementDepth")
+	}
+	if !strings.Contains(err.Error(), "flattening imported model") {
+		t.Errorf("expected wrapped error to mention \"flattening imported model\", got: %v", err)
+	}
+}
+
+// TestPrintImportSummaryText_DepthExceeded_Error covers the
+// elementCountsByKind error-return branch inside printImportSummaryText.
+func TestPrintImportSummaryText_DepthExceeded_Error(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	err := printImportSummaryText(cmd, deeplyNestedModel(), "architecture.jsonc", nil, false)
+	if err == nil {
+		t.Fatal("expected an error for a model exceeding MaxElementDepth")
+	}
+}
+
+// TestPrintImportSummaryJSON_DepthExceeded_Error covers the
+// elementCountsByKind error-return branch inside printImportSummaryJSON.
+func TestPrintImportSummaryJSON_DepthExceeded_Error(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	err := printImportSummaryJSON(cmd, deeplyNestedModel(), "architecture.jsonc", nil)
+	if err == nil {
+		t.Fatal("expected an error for a model exceeding MaxElementDepth")
 	}
 }

--- a/e2e/import_wizard_test.go
+++ b/e2e/import_wizard_test.go
@@ -1,0 +1,145 @@
+package e2e
+
+// TestImportWizard_* (#482 v1) exercises the post-import summary and
+// next-steps hint added to `bausteinsicht import`: a per-kind element count,
+// output path, generated view count, warnings, a --json machine-readable
+// mode, and a next-steps hint that adapts to --dry-run / --force.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const wizardStructurizrDSL = `workspace "Wizard" "minimal repro for #482" {
+    model {
+        user = person "User" "A user."
+        widgets = softwareSystem "Widgets" "Does widget things." {
+            api = container "API" "REST API." "Go"
+        }
+        user -> api "Uses" "HTTPS"
+    }
+    views {
+        systemContext widgets "SystemContext" {
+            include *
+            autoLayout lr
+        }
+    }
+}
+`
+
+func writeWizardDSL(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "workspace.dsl"), []byte(wizardStructurizrDSL), 0o600); err != nil {
+		t.Fatalf("write workspace.dsl: %v", err)
+	}
+}
+
+// TestImportWizard_TextSummary verifies the human-readable post-import
+// summary: per-kind counts, output path, view count, and a next-steps hint
+// pointing at sync/export-diagram for a fresh import.
+func TestImportWizard_TextSummary(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	writeWizardDSL(t, dir)
+
+	out := runCLI(t, bin, dir, "import", "workspace.dsl", "--from", "structurizr", "--output", "architecture.jsonc")
+
+	for _, want := range []string{
+		"person: 1",
+		"container: 1",
+		"system: 1",
+		"architecture.jsonc",
+		"views: 1",
+		"bausteinsicht sync",
+		"bausteinsicht export diagram",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected summary to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestImportWizard_JSONSummary verifies --json emits a machine-readable
+// summary with the same information, including a present-but-zero "views"
+// key semantics (tested indirectly via the non-zero case here; the
+// XMI/omitted case is covered by TestImportWizard_XMINoViewsLine).
+func TestImportWizard_JSONSummary(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	writeWizardDSL(t, dir)
+
+	out := runCLI(t, bin, dir, "import", "workspace.dsl", "--from", "structurizr", "--output", "architecture.jsonc", "--json")
+
+	var summary struct {
+		Elements   map[string]int `json:"elements"`
+		OutputPath string         `json:"outputPath"`
+		Views      int            `json:"views"`
+		Warnings   []string       `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(out), &summary); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\noutput:\n%s", err, out)
+	}
+	if summary.Elements["container"] != 1 {
+		t.Errorf("expected 1 container, got %d (elements=%v)", summary.Elements["container"], summary.Elements)
+	}
+	if summary.OutputPath == "" {
+		t.Error("expected non-empty outputPath")
+	}
+	if summary.Views != 1 {
+		t.Errorf("expected views=1, got %d", summary.Views)
+	}
+}
+
+// TestImportWizard_DryRunSuppressesHint verifies that --dry-run prints the
+// model only, with no next-steps hint (nothing was persisted).
+func TestImportWizard_DryRunSuppressesHint(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	writeWizardDSL(t, dir)
+
+	out := runCLI(t, bin, dir, "import", "workspace.dsl", "--from", "structurizr", "--dry-run")
+
+	if strings.Contains(out, "bausteinsicht sync") || strings.Contains(out, "next steps") {
+		t.Errorf("--dry-run must not print a next-steps hint, got:\n%s", out)
+	}
+}
+
+// TestImportWizard_ForceOverwriteHintsDiff verifies that re-importing over
+// an existing output file with --force hints at `bausteinsicht diff` instead
+// of `bausteinsicht sync`, since the existing file likely already has synced
+// draw.io state.
+func TestImportWizard_ForceOverwriteHintsDiff(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+	writeWizardDSL(t, dir)
+
+	runCLI(t, bin, dir, "import", "workspace.dsl", "--from", "structurizr", "--output", "architecture.jsonc")
+	out := runCLI(t, bin, dir, "import", "workspace.dsl", "--from", "structurizr", "--output", "architecture.jsonc", "--force")
+
+	if !strings.Contains(out, "bausteinsicht diff") {
+		t.Errorf("expected --force overwrite to hint at \"bausteinsicht diff\", got:\n%s", out)
+	}
+	if strings.Contains(out, "bausteinsicht sync") {
+		t.Errorf("--force overwrite must not also hint at \"bausteinsicht sync\", got:\n%s", out)
+	}
+}
+
+// TestImportWizard_XMINoViewsLine verifies the views line is omitted in text
+// mode when the importer produced zero views (XMI never populates Views),
+// rather than printing a permanently-zero line.
+func TestImportWizard_XMINoViewsLine(t *testing.T) {
+	bin := buildBinary(t)
+	dir := t.TempDir()
+
+	xmiSrc := filepath.Join(findModuleRoot(t), "internal/importer/xmi/testdata/basic.xmi")
+	copyTestFile(t, xmiSrc, filepath.Join(dir, "model.xmi"))
+
+	out := runCLI(t, bin, dir, "import", "model.xmi", "--from", "xmi", "--output", "architecture.jsonc")
+
+	if strings.Contains(out, "views:") {
+		t.Errorf("expected no \"views:\" line for an XMI import with zero views, got:\n%s", out)
+	}
+}

--- a/src/docs/spec/02_cli_specification.adoc
+++ b/src/docs/spec/02_cli_specification.adoc
@@ -1251,9 +1251,12 @@ Imports an architecture model from an external DSL and writes a Bausteinsicht `.
 | `--dry-run` | Print the generated model to stdout instead of writing the file. | No | `false`
 | `--force` | Overwrite the output file if it already exists. | No | `false`
 | `--kind-map` | XMI only: comma-separated `Type=kind` overrides (e.g. `Component=service,Class=entity`). | No | (none)
+| `--json` | Print the post-import summary as machine-readable JSON instead of human-readable text. | No | `false`
 |===
 
 **Behavior:** parses the source DSL, maps people/systems/containers and relationships, and generates a matching specification. Exit `2` if the output file already exists and neither `--force` nor `--dry-run` is set — `--dry-run` prints to stdout and skips the existence check, so it never fails on an existing output. Exit `1` on any other import failure (unknown `--from`, unreadable input, parse/encoding error).
+
+**Post-import summary:** on a successful (non-dry-run) import, prints an element count per kind, the output file path, the generated view count (omitted when zero — `xmi` never produces views), and any warnings collected during import. `--json` emits the same information as `{"elements":{"<kind>":<count>,...},"outputPath":"...","views":<count>,"warnings":["..."]}` instead (the `views` key is present but `0` in JSON mode, unlike the omitted text line, since machine consumers should not have to distinguish "zero" from "absent"). Followed by a next-steps hint: `bausteinsicht sync` and `bausteinsicht export diagram` on a fresh import; `bausteinsicht diff` instead of `sync` when `--force` overwrote an existing output file (the existing file likely already has synced draw.io state, so reviewing the delta is more useful than re-syncing). The hint is suppressed entirely under `--dry-run`, since nothing was persisted.
 
 **XMI-specific behavior:** reads XMI 2.1 files (e.g., Enterprise Architect exports). UML element types are mapped to Bausteinsicht element kinds using `--kind-map` overrides or the built-in defaults (e.g., `uml:Component` → `component`). EA stereotypes (inside `xmi:Extension`) take precedence over the UML type mapping. Unknown UML types produce a warning and are imported with kind `element`. Unresolvable relationship endpoints are skipped with a warning. DOCTYPE declarations are rejected (XXE mitigation). Element hierarchy depth is capped at 50 levels. This is a **one-way migration** — XMI-specific data (layout, tagged values, OCL constraints) is not preserved.
 


### PR DESCRIPTION
## Description

Implements v1 of the import wizard scoped in #482: enriches `bausteinsicht import`'s existing success path instead of adding a new subcommand — `import` has no interactive prompts today, so there's nothing for a "wizard" to wrap.

## Changes

- Post-import summary on success: element count per kind (via `model.FlattenElements`, unified across all three importers since they share `importer.ImportResult{Model, Warnings}`), output path, generated view count (omitted when zero — XMI never populates `Views`), and warnings (already existed).
- Next-steps hint: `bausteinsicht sync` / `bausteinsicht export diagram` on a fresh import; `bausteinsicht diff` instead of `sync` on a `--force` overwrite of an existing file (it likely already has synced state). Suppressed entirely under `--dry-run`.
- `--json` flag: machine-readable summary (`{"elements":{...},"outputPath":"...","views":n,"warnings":[...]}`) for agent/CI workflows (QG-3, LLM-friendliness). `views` is always present there (0 rather than omitted), since machine consumers shouldn't have to distinguish "zero" from "absent".

v2 (the interactive TUI, `--yes`) is tracked separately in #616 and intentionally out of scope here.

## Type of Change

- [x] New feature (CLI, no breaking change)

## Testing

- TDD: `e2e/import_wizard_test.go` written and confirmed failing before implementation (5 scenarios: text summary, JSON summary, dry-run hint suppression, force-overwrite diff hint, XMI zero-views omission).
- All 5 pass after implementation; full `go test ./e2e/` and `go test ./cmd/... ./internal/importer/... ./internal/model/...` clean (aside from a pre-existing, unrelated `TestWatchMode` environment flake, confirmed present on `main` too).
- `gofmt`, `go vet`, `staticcheck` clean.

## Documentation

- `src/docs/spec/02_cli_specification.adoc` updated: `--json` flag row + "Post-import summary" behavior paragraph.
- `spec/01_use_cases.adoc` / `spec/04_acceptance_criteria.adoc`: `import` has no use case at all today (pre-existing gap predating this PR) — flagged, not backfilled here to avoid scope creep.

Closes #482