### PR TITLE
docs: correct SonarCloud new-code coverage threshold from 65% to 80%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Before merging any PR:
 4. **Code review** on the changes
 
 #### Quality Gate Override Policy
-SonarCloud's **New Code Coverage** gate (threshold: **65%**) may trip on PRs that touch previously-untested legacy code without adding new logic. A verified **behavior-preserving refactor** may be admin-merged despite the gate if ALL of these hold:
+SonarCloud's **New Code Coverage** gate (threshold: **80%**, as configured in the SonarCloud UI — see #612) may trip on PRs that touch previously-untested legacy code without adding new logic. A verified **behavior-preserving refactor** may be admin-merged despite the gate if ALL of these hold:
 - All functional CI checks are green (build, unit tests, lint, golangci-lint)
 - An independent code review confirms no new logic was added
 - The merge reason is noted in the PR description (e.g. "admin merge: refactor only, gate tripped by legacy untested lines")
@@ -236,7 +236,7 @@ _Updated by `/risk-mitigate` on 2026-03-04_
 | SAST | ✅ Present | `staticcheck` blocking (via `lint` job); `gosec`/`nilaway` run in CI non-blocking for now, tracked in #551 |
 | AI Code Review | ✅ Present | Claude Code with code-review plugin; PR merge policy requires review |
 | Property-Based Tests | ✅ Set up | `pgregory.net/rapid` — label roundtrip + escapeHTML + trimBrackets property tests |
-| SonarQube Quality Gate | ✅ Present | SonarCloud on all PRs; new-code coverage gate ≥ 65% (see override policy in PR Merge Policy section); `sonar.qualitygate.wait=true` in `sonar-project.properties`. SonarCloud is the single source of coverage truth — Codecov was retired in #612 |
+| SonarQube Quality Gate | ✅ Present | SonarCloud on all PRs; new-code coverage gate ≥ 80% (see override policy in PR Merge Policy section); `sonar.qualitygate.wait=true` in `sonar-project.properties`. SonarCloud is the single source of coverage truth — Codecov was retired in #612 |
 | Sampling Review (~20%) | ✅ Present | PR merge policy: security review + code review required |
 
 **Overall Status:** 10/10 measures active

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,7 +32,9 @@ sonar.coverage.exclusions=**/*_test.go,**/testdata/**,**/*_windows.go,**/*_darwi
 sonar.cpd.exclusions=**/*_test.go
 
 # Quality Gate
-# New-code-coverage threshold is set to 65% in the SonarCloud UI quality gate.
+# New-code-coverage threshold is set to 80% in the SonarCloud UI quality gate
+# (verified live via PR #621: "58.7% Coverage on New Code (required >= 80%)" —
+# corrected from a previously-documented but inaccurate 65%, see #612).
 # "Verified behavior-preserving refactors" may be admin-merged if the gate
 # trips on legacy untested lines — see override policy in CLAUDE.md.
 sonar.qualitygate.wait=true


### PR DESCRIPTION
## Description

#614 unified CLAUDE.md and `sonar-project.properties` on a "65%" new-code coverage threshold, but never checked that value against the actual SonarCloud UI quality gate setting — it's **80%**.

Discovered live: PR #621 failed its quality gate with `58.7% Coverage on New Code (required >= 80%)`.

## Changes

- `CLAUDE.md`: both mentions of the threshold (Quality Gate Override Policy, Risk Mitigation table) corrected to 80%.
- `sonar-project.properties`: comment corrected, with the PR #621 evidence noted inline.

No functional/CI change — documentation only, matching the docs to the SonarCloud project's actual configured gate rather than changing the gate itself (a SonarCloud-side setting, out of scope for a repo PR).

## Type of Change

- [x] Improvement/refactoring (documentation only)

## Related

Refs #612 (this closes one of two remaining open items — required status checks on `main` is a separate, repo-settings change tracked there)