### PR TITLE
refactor(sonar): quick-win findings from #623 (S1192, S8209, duplication)

### DIFF
--- a/cmd/bausteinsicht/add_specification.go
+++ b/cmd/bausteinsicht/add_specification.go
@@ -42,30 +42,11 @@ func runAddSpecificationElement(cmd *cobra.Command, args []string) error {
 	notation, _ := cmd.Flags().GetString("notation")
 	description, _ := cmd.Flags().GetString("description")
 	container, _ := cmd.Flags().GetBool("container")
-
-	modelPath, _ := cmd.Flags().GetString("model")
 	format, _ := cmd.Flags().GetString("format")
 
-	// Validate key format
-	if !isValidKey(key) {
-		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", key),
-			1,
-		)
-	}
-
-	// Load model
-	if modelPath == "" {
-		detected, err := model.AutoDetect(".")
-		if err != nil {
-			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
-		}
-		modelPath = detected
-	}
-
-	m, err := model.Load(modelPath)
+	m, modelPath, err := loadModelForSpecificationCmd(cmd, key)
 	if err != nil {
-		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+		return err
 	}
 
 	// Add element kind
@@ -134,30 +115,11 @@ func runAddSpecificationRelationship(cmd *cobra.Command, args []string) error {
 	notation, _ := cmd.Flags().GetString("notation")
 	description, _ := cmd.Flags().GetString("description")
 	dashed, _ := cmd.Flags().GetBool("dashed")
-
-	modelPath, _ := cmd.Flags().GetString("model")
 	format, _ := cmd.Flags().GetString("format")
 
-	// Validate key format
-	if !isValidKey(key) {
-		return exitWithCode(
-			fmt.Errorf("invalid specification key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", key),
-			1,
-		)
-	}
-
-	// Load model
-	if modelPath == "" {
-		detected, err := model.AutoDetect(".")
-		if err != nil {
-			return exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
-		}
-		modelPath = detected
-	}
-
-	m, err := model.Load(modelPath)
+	m, modelPath, err := loadModelForSpecificationCmd(cmd, key)
 	if err != nil {
-		return exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+		return err
 	}
 
 	// Add relationship kind
@@ -201,4 +163,33 @@ func runAddSpecificationRelationship(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// loadModelForSpecificationCmd validates key, then auto-detects (if
+// --model was omitted) and loads the model shared by "add specification
+// element" and "add specification relationship" — both need the exact same
+// key-validation-then-load sequence before diverging on what they add.
+func loadModelForSpecificationCmd(cmd *cobra.Command, key string) (*model.BausteinsichtModel, string, error) {
+	if !isValidKey(key) {
+		return nil, "", exitWithCode(
+			fmt.Errorf("invalid specification key %q: must start with a letter and contain only letters, digits, hyphens, or underscores", key),
+			1,
+		)
+	}
+
+	modelPath, _ := cmd.Flags().GetString("model")
+	if modelPath == "" {
+		detected, err := model.AutoDetect(".")
+		if err != nil {
+			return nil, "", exitWithCode(fmt.Errorf("auto-detecting model: %w", err), 2)
+		}
+		modelPath = detected
+	}
+
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return nil, "", exitWithCode(fmt.Errorf("loading model: %w", err), 2)
+	}
+
+	return m, modelPath, nil
 }

--- a/cmd/bausteinsicht/add_specification_test.go
+++ b/cmd/bausteinsicht/add_specification_test.go
@@ -157,6 +157,62 @@ func TestAddSpecificationCmd_CamelCaseKeys(t *testing.T) {
 	}
 }
 
+// TestAddSpecificationElementCmd_AutoDetectFails covers
+// loadModelForSpecificationCmd's auto-detect error branch: no --model flag,
+// and no .jsonc file in the working directory for AutoDetect to find.
+func TestAddSpecificationElementCmd_AutoDetectFails(t *testing.T) {
+	dir := t.TempDir()
+	restore := chdir(t, dir)
+	defer restore()
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "specification", "element", "custom_type", "--notation", "Box"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no .jsonc file exists for auto-detection")
+	}
+}
+
+// TestAddSpecificationRelationshipCmd_LoadModelFails covers
+// loadModelForSpecificationCmd's model.Load error branch: --model points at
+// a file that isn't valid JSONC.
+func TestAddSpecificationRelationshipCmd_LoadModelFails(t *testing.T) {
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "architecture.jsonc")
+	if err := os.WriteFile(modelPath, []byte("not valid jsonc {{{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := NewRootCmd()
+	cmd.SetArgs([]string{"add", "specification", "relationship", "custom_rel",
+		"--model", modelPath,
+		"--notation", "->",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error loading a malformed model file")
+	}
+}
+
+// chdir changes the working directory for the duration of a test and
+// returns a func to restore it — used to exercise AutoDetect's cwd-scanning
+// behavior without depending on the ambient test-runner working directory.
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func writeSpecTestModel(t *testing.T, dir string) string {
 	t.Helper()
 	p := filepath.Join(dir, "architecture.jsonc")

--- a/internal/e2eplan/registry.go
+++ b/internal/e2eplan/registry.go
@@ -17,6 +17,13 @@
 // several plan lines, or a subtest name that predates this convention.
 package e2eplan
 
+// Subtest names for e2e/jsonc_comment_preservation_test.go, named here
+// (rather than repeated inline) since each covers several plan lines below.
+const (
+	testJSONCCommentPreservationReverseSync = "TestJSONCCommentPreservation/ReverseSync"
+	testJSONCCommentPreservationAddElement  = "TestJSONCCommentPreservation/AddElement"
+)
+
 // Registry maps a plan ID to the qualified go-test name(s) — in
 // "TestFunc" or "TestFunc/Subtest" form, matching the "Test" field of `go
 // test -json` events — that automate it. A plan ID mapped to more than one
@@ -24,12 +31,12 @@ package e2eplan
 var Registry = map[string][]string{
 	// e2e/jsonc_comment_preservation_test.go — subtest names predate the
 	// "<planID>_" convention and one subtest covers multiple plan lines.
-	"4.16": {"TestJSONCCommentPreservation/ReverseSync"},
-	"4.17": {"TestJSONCCommentPreservation/ReverseSync"},
-	"4.18": {"TestJSONCCommentPreservation/ReverseSync"},
-	"6.25": {"TestJSONCCommentPreservation/AddElement"},
-	"6.26": {"TestJSONCCommentPreservation/AddElement"},
-	"6.27": {"TestJSONCCommentPreservation/AddElement"},
+	"4.16": {testJSONCCommentPreservationReverseSync},
+	"4.17": {testJSONCCommentPreservationReverseSync},
+	"4.18": {testJSONCCommentPreservationReverseSync},
+	"6.25": {testJSONCCommentPreservationAddElement},
+	"6.26": {testJSONCCommentPreservationAddElement},
+	"6.27": {testJSONCCommentPreservationAddElement},
 	"6.28": {"TestJSONCCommentPreservation/AddElementMixedComments"},
 	"6.29": {"TestJSONCCommentPreservation/TwoSequentialAdds"},
 	"6.30": {"TestJSONCCommentPreservation/AddRelationship"},

--- a/internal/stale/detector.go
+++ b/internal/stale/detector.go
@@ -154,7 +154,7 @@ func isExcluded(kind string, excludeKinds []string) bool {
 }
 
 // isTagExcluded returns true if any of the element's tags appear in excludeTags.
-func isTagExcluded(elemTags []string, excludeTags []string) bool {
+func isTagExcluded(elemTags, excludeTags []string) bool {
 	if len(excludeTags) == 0 {
 		return false
 	}


### PR DESCRIPTION
## Description

First of several PRs working through #623 (26 open SonarCloud findings + new-code duplication). This one covers the three lowest-risk, mechanical fixes.

## Changes

- `internal/e2eplan/registry.go` (go:S1192): the two 3×-repeated test-name literals extracted as constants.
- `internal/stale/detector.go` (godre:S8209): `isTagExcluded(elemTags []string, excludeTags []string)` → `isTagExcluded(elemTags, excludeTags []string)`.
- `cmd/bausteinsicht/add_specification.go` (100% new-code duplication density): extracted `loadModelForSpecificationCmd` — the exact key-validation-then-load sequence `add specification element` and `add specification relationship` both duplicated verbatim.

Scoped intentionally narrow: the same load-model pattern repeats in ~10 other `cmd/bausteinsicht/*.go` files, but SonarCloud only flagged the duplication *within* `add_specification.go` — extracting a repo-wide shared helper across unrelated commands would be a much bigger, out-of-scope change for what's actually a two-function duplication.

## Type of Change

- [x] Improvement/refactoring — behavior-preserving only, no new logic, no CLI-visible change.

## Testing

- `go build ./...`, `go vet`, `gofmt -l`, `staticcheck` all clean.
- `go test ./internal/e2eplan/... ./cmd/bausteinsicht/... ./internal/stale/...` — all pass, no test changes needed since behavior is unchanged.

## Documentation

N/A — internal refactor, no user-visible or cross-command effect.

Refs #623