### PR TITLE
refactor(sonar): reduce parameter counts in internal/sync/ (go:S107)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ e2e/                   # Automated end-to-end pipeline tests (Go); testdata/ hol
 - **draw.io elements carry `bausteinsicht_id` attribute** — this is the synchronization anchor between the two file formats.
 - **Views filter what is rendered** — each view has `include`/`exclude` lists; `model.ResolveView` expands them to a flat element ID set.
 - **Templates are `.drawio` files** — visual styles come from template pages, not hardcoded; `internal/drawio.TemplateSet` loads and clones them.
+- **Functions take at most 7 parameters** — SonarCloud's `go:S107` gate. When more inherently belong together (e.g. a `*ChangeSet`, page/document, templates, flattened model, and result accumulator threaded unchanged through a whole call chain, as in `internal/sync/forward.go`), bundle them into a small local struct (`fooRenderInputs`) rather than repeating the same 5-6 params function after function — that's usually a sign the bundle already exists implicitly and just needs a name, not a sign of over-abstraction.
 - **Run a single package's tests:** `go test ./internal/sync/` (or any other package path)
 - **Run a single test:** `go test -run TestName ./internal/sync/`
 - **Run automated E2E tests:** `go test ./e2e/ -v` — exercises full import→sync→adoc pipeline; SVG export step auto-skips if draw.io CLI is absent

--- a/internal/sync/diff.go
+++ b/internal/sync/diff.go
@@ -58,6 +58,32 @@ type drawioElemSnapshot struct {
 	kind        string
 }
 
+// presence pairs a value with whether it was actually found on the side
+// being compared — the three-way (model / draw.io / last-sync) comparison
+// functions below always receive a state value together with its presence
+// flag, never independently, so bundling them cuts one parameter per side.
+type presence[T any] struct {
+	value T
+	found bool
+}
+
+// elemScanContext bundles the change-set and the last-sync-state
+// environment threaded unchanged through the per-element comparison calls.
+type elemScanContext struct {
+	cs           *ChangeSet
+	lastState    *SyncState
+	visibleElems map[string]bool
+	newPageOnly  map[string]bool
+}
+
+// relScanContext is elemScanContext's relationship-side counterpart.
+type relScanContext struct {
+	cs          *ChangeSet
+	modelRels   map[string]RelationshipState
+	drawioRels  map[string]RelationshipState
+	visibleRels map[string]bool
+}
+
 // relKey returns a canonical key for a relationship.
 // The index disambiguates multiple relationships between the same pair.
 func relKey(from, to string, index int) string {
@@ -530,7 +556,12 @@ func detectElementChangeForID(
 	lastElem, inLast := lastState.Elements[id]
 
 	detectModelElementChange(cs, id, me, inModel, lastElem, inLast)
-	detectDrawioElementChange(cs, id, de, inDrawio, lastElem, inLast, lastState, visibleElems, newPageOnly)
+	detectDrawioElementChange(
+		elemScanContext{cs: cs, lastState: lastState, visibleElems: visibleElems, newPageOnly: newPageOnly},
+		id,
+		presence[drawioElemSnapshot]{value: de, found: inDrawio},
+		presence[ElementState]{value: lastElem, found: inLast},
+	)
 
 	// Conflicts: both sides modified the same field
 	if inModel && inDrawio && inLast {
@@ -561,26 +592,18 @@ func detectModelElementChange(cs *ChangeSet, id string, me *model.Element, inMod
 
 // detectDrawioElementChange appends the draw.io-side ElementChange for a
 // single element, comparing against last-sync state.
-func detectDrawioElementChange(
-	cs *ChangeSet,
-	id string,
-	de drawioElemSnapshot,
-	inDrawio bool,
-	lastElem ElementState,
-	inLast bool,
-	lastState *SyncState,
-	visibleElems map[string]bool,
-	newPageOnly map[string]bool,
-) {
+func detectDrawioElementChange(ctx elemScanContext, id string, drawio presence[drawioElemSnapshot], last presence[ElementState]) {
+	de, inDrawio := drawio.value, drawio.found
+	lastElem, inLast := last.value, last.found
 	switch {
 	case inDrawio && !inLast:
-		cs.DrawioElementChanges = append(cs.DrawioElementChanges, ElementChange{ID: id, Type: Added})
+		ctx.cs.DrawioElementChanges = append(ctx.cs.DrawioElementChanges, ElementChange{ID: id, Type: Added})
 	case !inDrawio && inLast:
-		appendDrawioDeletionIfVisible(cs, id, lastState, visibleElems, newPageOnly)
+		appendDrawioDeletionIfVisible(ctx.cs, id, ctx.lastState, ctx.visibleElems, ctx.newPageOnly)
 	case inDrawio && inLast:
-		appendIfChanged(id, fieldTitle, lastElem.Title, de.title, &cs.DrawioElementChanges)
-		appendIfChanged(id, fieldDescription, lastElem.Description, de.description, &cs.DrawioElementChanges)
-		appendIfChanged(id, fieldTechnology, lastElem.Technology, de.technology, &cs.DrawioElementChanges)
+		appendIfChanged(id, fieldTitle, lastElem.Title, de.title, &ctx.cs.DrawioElementChanges)
+		appendIfChanged(id, fieldDescription, lastElem.Description, de.description, &ctx.cs.DrawioElementChanges)
+		appendIfChanged(id, fieldTechnology, lastElem.Technology, de.technology, &ctx.cs.DrawioElementChanges)
 		// Note: kind is not compared on the draw.io side because scope
 		// boundary elements have a derived kind (e.g. "system_boundary")
 		// that legitimately differs from the model kind ("system").
@@ -804,21 +827,23 @@ func detectRelationshipChangeForKey(
 
 	from, to, index := resolveRelFromTo(mr, lr, dr)
 
-	detectModelRelationshipChange(cs, from, to, index, mr, inModel, lr, inLast)
-	detectDrawioRelationshipChange(cs, k, from, to, index, dr, inDrawio, lr, inLast, modelRels, drawioRels, visibleRels)
+	detectModelRelationshipChange(cs, from, to, index,
+		presence[RelationshipState]{value: mr, found: inModel},
+		presence[RelationshipState]{value: lr, found: inLast},
+	)
+	detectDrawioRelationshipChange(
+		relScanContext{cs: cs, modelRels: modelRels, drawioRels: drawioRels, visibleRels: visibleRels},
+		k, from, to, index,
+		presence[RelationshipState]{value: dr, found: inDrawio},
+		presence[RelationshipState]{value: lr, found: inLast},
+	)
 }
 
 // detectModelRelationshipChange appends the model-side RelationshipChange
 // for a single relationship, comparing against last-sync state.
-func detectModelRelationshipChange(
-	cs *ChangeSet,
-	from, to string,
-	index int,
-	mr RelationshipState,
-	inModel bool,
-	lr RelationshipState,
-	inLast bool,
-) {
+func detectModelRelationshipChange(cs *ChangeSet, from, to string, index int, model, last presence[RelationshipState]) {
+	mr, inModel := model.value, model.found
+	lr, inLast := last.value, last.found
 	switch {
 	case inModel && !inLast:
 		cs.ModelRelationshipChanges = append(cs.ModelRelationshipChanges, RelationshipChange{
@@ -838,26 +863,16 @@ func detectModelRelationshipChange(
 
 // detectDrawioRelationshipChange appends the draw.io-side RelationshipChange
 // for a single relationship, comparing against last-sync state.
-func detectDrawioRelationshipChange(
-	cs *ChangeSet,
-	k string,
-	from, to string,
-	index int,
-	dr RelationshipState,
-	inDrawio bool,
-	lr RelationshipState,
-	inLast bool,
-	modelRels map[string]RelationshipState,
-	drawioRels map[string]RelationshipState,
-	visibleRels map[string]bool,
-) {
+func detectDrawioRelationshipChange(ctx relScanContext, k string, from, to string, index int, drawio, last presence[RelationshipState]) {
+	dr, inDrawio := drawio.value, drawio.found
+	lr, inLast := last.value, last.found
 	switch {
 	case inDrawio && !inLast:
-		appendAddedDrawioRelationship(cs, from, to, index, dr, modelRels)
+		appendAddedDrawioRelationship(ctx.cs, from, to, index, dr, ctx.modelRels)
 	case !inDrawio && inLast:
-		appendDeletedDrawioRelationship(cs, k, from, to, index, drawioRels, visibleRels)
+		appendDeletedDrawioRelationship(ctx.cs, k, from, to, index, ctx.drawioRels, ctx.visibleRels)
 	case inDrawio && inLast && dr.Label != lr.Label:
-		cs.DrawioRelationshipChanges = append(cs.DrawioRelationshipChanges, RelationshipChange{
+		ctx.cs.DrawioRelationshipChanges = append(ctx.cs.DrawioRelationshipChanges, RelationshipChange{
 			From: from, To: to, Index: index, Type: Modified, Field: fieldLabel,
 			OldValue: lr.Label, NewValue: dr.Label,
 		})

--- a/internal/sync/forward.go
+++ b/internal/sync/forward.go
@@ -101,6 +101,23 @@ type ForwardResult struct {
 	Warnings          []string
 }
 
+// forwardRenderInputs bundles the read-only inputs threaded through the
+// forward-sync render pipeline below: the change set being built, the
+// target document/page, style templates, the flattened/full model, and the
+// result accumulator. Most S107 "too many parameters" findings in this file
+// were the same 4-6 of these values being passed individually through a
+// dozen-plus functions; page is unset (nil) above the point where a
+// specific view's page has been resolved.
+type forwardRenderInputs struct {
+	cs        *ChangeSet
+	doc       *drawio.Document
+	page      *drawio.Page
+	templates *drawio.TemplateSet
+	flat      map[string]*model.Element
+	model     *model.BausteinsichtModel
+	result    *ForwardResult
+}
+
 // ApplyForward applies ModelElementChanges and ModelRelationshipChanges from cs
 // to doc, using templates for styles and m for element data.
 // When the model defines views, elements and relationships are placed on their
@@ -121,55 +138,42 @@ func ApplyForward(
 		fwdOpts = opts[0]
 	}
 
+	in := forwardRenderInputs{cs: cs, doc: doc, templates: templates, flat: flat, model: m, result: result}
+
 	if len(m.Views) == 0 {
-		applyForwardToPage(cs, doc, templates, flat, nil, m, result)
+		applyForwardToPage(in, nil)
 		return result
 	}
 
-	applyForwardPerView(cs, doc, templates, flat, m, &fwdOpts, result)
+	applyForwardPerView(in, &fwdOpts)
 	return result
 }
 
 // applyForwardToPage applies all changes to a single page (legacy/no-views mode).
-func applyForwardToPage(
-	cs *ChangeSet,
-	doc *drawio.Document,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	elemFilter map[string]bool,
-	m *model.BausteinsichtModel,
-	result *ForwardResult,
-) {
-	page := firstPage(doc)
+func applyForwardToPage(in forwardRenderInputs, elemFilter map[string]bool) {
+	page := firstPage(in.doc)
 	if page == nil {
-		result.Warnings = append(result.Warnings, "no page found in document")
+		in.result.Warnings = append(in.result.Warnings, "no page found in document")
 		return
 	}
-	applyChangesToPage(cs, page, templates, flat, elemFilter, "", "", &m.Specification, result)
+	in.page = page
+	applyChangesToPage(in, elemFilter, "", "")
 
 	// Reconcile orphaned elements: remove any element on the page whose
 	// bausteinsicht_id is not present in the current model. This handles
 	// cases where the sync state is missing or the model was emptied. (#110)
-	reconcileOrphanedElements(page, flat, result)
+	reconcileOrphanedElements(page, in.flat, in.result)
 
 	// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
-	synchronizeDocLinkIcons(page, m)
+	synchronizeDocLinkIcons(page, in.model)
 }
 
 // applyForwardPerView iterates over model views and applies changes per page.
-func applyForwardPerView(
-	cs *ChangeSet,
-	doc *drawio.Document,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	m *model.BausteinsichtModel,
-	opts *ForwardOptions,
-	result *ForwardResult,
-) {
-	drillDownLinks := buildDrillDownLinks(m)
+func applyForwardPerView(in forwardRenderInputs, opts *ForwardOptions) {
+	drillDownLinks := buildDrillDownLinks(in.model)
 
-	for viewID, view := range m.Views {
-		applyForwardToView(cs, doc, templates, flat, m, opts, viewID, view, drillDownLinks, result)
+	for viewID, view := range in.model.Views {
+		applyForwardToView(in, opts, viewID, view, drillDownLinks)
 	}
 }
 
@@ -189,29 +193,20 @@ func buildDrillDownLinks(m *model.BausteinsichtModel) map[string]string {
 // applyForwardToView runs the full forward-sync pipeline for a single view's
 // page: placement of new elements, model changes, connectors, reconciliation,
 // drill-down links, back navigation, metadata/legend, and doc-link icons.
-func applyForwardToView(
-	cs *ChangeSet,
-	doc *drawio.Document,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	m *model.BausteinsichtModel,
-	opts *ForwardOptions,
-	viewID string,
-	view model.View,
-	drillDownLinks map[string]string,
-	result *ForwardResult,
-) {
+func applyForwardToView(in forwardRenderInputs, opts *ForwardOptions, viewID string, view model.View, drillDownLinks map[string]string) {
+	m := in.model
 	pageID := "view-" + viewID
-	page := doc.GetPage(pageID)
+	page := in.doc.GetPage(pageID)
 	if page == nil {
-		result.Warnings = append(result.Warnings, "no page found for view: "+viewID)
+		in.result.Warnings = append(in.result.Warnings, "no page found for view: "+viewID)
 		return
 	}
+	in.page = page
 
 	viewCopy := view
 	resolved, err := model.ResolveView(m, &viewCopy)
 	if err != nil {
-		result.Warnings = append(result.Warnings, "resolving view "+viewID+": "+err.Error())
+		in.result.Warnings = append(in.result.Warnings, "resolving view "+viewID+": "+err.Error())
 		return
 	}
 
@@ -229,7 +224,7 @@ func applyForwardToView(
 	}
 
 	if scopeID != "" {
-		createScopeBoundary(scopeID, viewID, page, templates, flat, &m.Specification, result)
+		createScopeBoundary(scopeID, viewID, page, in.templates, in.flat, &m.Specification, in.result)
 		// Include scope element in the filter so connectors targeting the
 		// boundary element are rendered (#217).
 		elemSet[scopeID] = true
@@ -240,22 +235,22 @@ func applyForwardToView(
 	// position elements on fresh pages. applyChangesToPage will then
 	// skip Added elements that are already placed. For existing pages,
 	// this handles elements newly included via view changes (#231).
-	populateNewPage(page, viewID, scopeID, templates, flat, elemSet, m, result)
+	populateNewPage(in, viewID, scopeID, elemSet)
 
-	applyChangesToPage(cs, page, templates, flat, elemSet, viewID, scopeID, &m.Specification, result)
+	applyChangesToPage(in, elemSet, viewID, scopeID)
 
 	// Populate connectors for relationships whose endpoints are both
 	// on the page but whose connector doesn't exist yet. This handles
 	// relationships involving newly populated elements (#231).
-	populateConnectors(page, viewID, scopeID, m, elemSet, templates, result)
+	populateConnectors(in, viewID, scopeID, elemSet)
 
 	// Reconciliation: remove elements on the page that are no longer
 	// in the resolved view (e.g., after exclude list changes). #102
-	reconcileViewPage(page, elemSet, flat, scopeID, viewID, result)
+	reconcileViewPage(page, elemSet, in.flat, scopeID, viewID, in.result)
 
 	// Set drill-down links on elements that have a detail view. (#198)
 	// Drill-down links take priority over user-defined element links (ADR-009).
-	result.Warnings = append(result.Warnings, applyDrillDownLinks(page, drillDownLinks)...)
+	in.result.Warnings = append(in.result.Warnings, applyDrillDownLinks(page, drillDownLinks)...)
 
 	// Create back-navigation button on detail views (views with scope). (#198)
 	if scopeID != "" {
@@ -263,7 +258,7 @@ func applyForwardToView(
 	}
 
 	// Create metadata and legend boxes on each view page. (#233)
-	applyViewMetadataAndLegend(page, viewID, view, m, opts, elemSet, flat, templates, result)
+	applyViewMetadataAndLegend(in, opts, viewID, view, elemSet)
 
 	// Synchronize documentation-link icons (element Link/Decisions/DocLinks) with the model. (#543)
 	synchronizeDocLinkIcons(page, m)
@@ -274,28 +269,19 @@ func applyForwardToView(
 
 // applyViewMetadataAndLegend creates the metadata and legend boxes on page,
 // if enabled by config. (#233)
-func applyViewMetadataAndLegend(
-	page *drawio.Page,
-	viewID string,
-	view model.View,
-	m *model.BausteinsichtModel,
-	opts *ForwardOptions,
-	elemSet map[string]bool,
-	flat map[string]*model.Element,
-	templates *drawio.TemplateSet,
-	result *ForwardResult,
-) {
+func applyViewMetadataAndLegend(in forwardRenderInputs, opts *ForwardOptions, viewID string, view model.View, elemSet map[string]bool) {
+	m := in.model
 	metadataEnabled := m.Config.Metadata == nil || *m.Config.Metadata
 	legendEnabled := m.Config.Legend == nil || *m.Config.Legend
 
 	if metadataEnabled && opts != nil {
-		if createMetadata(page, viewID, view, m.Config, opts.ModelPath, opts.SyncTime) {
-			result.MetadataUpdated++
+		if createMetadata(in.page, viewID, view, m.Config, opts.ModelPath, opts.SyncTime) {
+			in.result.MetadataUpdated++
 		}
 	}
 	if legendEnabled {
-		if createLegend(page, viewID, m.Specification, templates, elemSet, flat) {
-			result.MetadataUpdated++
+		if createLegend(in.page, viewID, m.Specification, in.templates, elemSet, in.flat) {
+			in.result.MetadataUpdated++
 		}
 	}
 }
@@ -304,26 +290,17 @@ func applyViewMetadataAndLegend(
 // the view's resolved set that aren't already present.
 // For new pages, this populates elements already in sync state (#184, #188).
 // For existing pages, this adds elements newly included via view changes (#231).
-func populateNewPage(
-	page *drawio.Page,
-	viewID string,
-	scopeID string,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	elemSet map[string]bool,
-	m *model.BausteinsichtModel,
-	result *ForwardResult,
-) {
-	toPlace := collectElementsToPlace(page, scopeID, elemSet)
+func populateNewPage(in forwardRenderInputs, viewID string, scopeID string, elemSet map[string]bool) {
+	toPlace := collectElementsToPlace(in.page, scopeID, elemSet)
 	if len(toPlace) == 0 {
 		return
 	}
 
-	if isFreshPage(page, scopeID) {
-		layoutMode := viewLayoutMode(m, page.ID())
-		placeElementsWithLayout(page, viewID, scopeID, templates, flat, m, toPlace, layoutMode, result)
+	if isFreshPage(in.page, scopeID) {
+		layoutMode := viewLayoutMode(in.model, in.page.ID())
+		placeElementsWithLayout(in, viewID, scopeID, toPlace, layoutMode)
 	} else {
-		placeElementsIncrementally(page, viewID, scopeID, templates, flat, m, toPlace, result)
+		placeElementsIncrementally(in, viewID, scopeID, toPlace)
 	}
 }
 
@@ -368,21 +345,12 @@ func viewLayoutMode(m *model.BausteinsichtModel, pageID string) string {
 // placeElementsWithLayout uses the layout engine to position toPlace on a
 // fresh page, resizing the scope boundary to fit if the engine computed
 // boundary dimensions.
-func placeElementsWithLayout(
-	page *drawio.Page,
-	viewID string,
-	scopeID string,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	m *model.BausteinsichtModel,
-	toPlace []string,
-	layoutMode string,
-	result *ForwardResult,
-) {
-	lr := computeLayout(toPlace, flat, templates, m.ElementOrder, scopeID, layoutMode, m.Relationships)
+func placeElementsWithLayout(in forwardRenderInputs, viewID string, scopeID string, toPlace []string, layoutMode string) {
+	m := in.model
+	lr := computeLayout(toPlace, in.flat, in.templates, m.ElementOrder, scopeID, layoutMode, m.Relationships)
 
 	if scopeID != "" && lr.BoundaryWidth > 0 && lr.BoundaryHeight > 0 {
-		resizeScopeBoundary(page, scopeID, lr.BoundaryX, lr.BoundaryY, lr.BoundaryWidth, lr.BoundaryHeight)
+		resizeScopeBoundary(in.page, scopeID, lr.BoundaryX, lr.BoundaryY, lr.BoundaryWidth, lr.BoundaryHeight)
 	}
 
 	sort.Strings(toPlace)
@@ -391,27 +359,19 @@ func placeElementsWithLayout(
 		if !ok {
 			continue
 		}
-		placeSingleElement(id, viewID, scopeID, page, templates, flat, &m.Specification, pos.X, pos.Y, false, result)
+		placeSingleElement(id, viewID, scopeID, in.page, in.templates, in.flat, &m.Specification, pos.X, pos.Y, false, in.result)
 	}
 }
 
 // placeElementsIncrementally falls back to cursor-based grid placement for
 // elements newly included on an existing (non-fresh) page.
-func placeElementsIncrementally(
-	page *drawio.Page,
-	viewID string,
-	scopeID string,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	m *model.BausteinsichtModel,
-	toPlace []string,
-	result *ForwardResult,
-) {
+func placeElementsIncrementally(in forwardRenderInputs, viewID string, scopeID string, toPlace []string) {
+	page := in.page
 	pl := computePlacement(page)
 	pl.childCount[scopeID] = countScopeChildren(page, viewID, scopeID)
 	initialChildCount := pl.childCount[scopeID]
 	for _, id := range toPlace {
-		applyElementAdded(id, viewID, scopeID, page, templates, flat, &m.Specification, &pl, result)
+		applyElementAdded(id, viewID, scopeID, page, in.templates, in.flat, &in.model.Specification, &pl, in.result)
 	}
 	// Expand only when new children were added in this pass (#330).
 	if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
@@ -433,15 +393,8 @@ func connectorStyle(baseStyle, kind string, spec *model.Specification) string {
 // populateConnectors creates connectors for all model relationships whose
 // (possibly lifted) endpoints are both on the page but no connector exists yet.
 // This ensures relationships involving newly populated elements are rendered (#231).
-func populateConnectors(
-	page *drawio.Page,
-	viewID string,
-	scopeID string,
-	m *model.BausteinsichtModel,
-	elemSet map[string]bool,
-	templates *drawio.TemplateSet,
-	result *ForwardResult,
-) {
+func populateConnectors(in forwardRenderInputs, viewID string, scopeID string, elemSet map[string]bool) {
+	m := in.model
 	dashedForPair := computeDashedPairs(m, elemSet, scopeID)
 
 	liftedSeen := make(map[string]bool)
@@ -454,7 +407,7 @@ func populateConnectors(
 		if isDuplicateLiftedRelationship(from, to, isLifted, liftedSeen) {
 			continue
 		}
-		createConnectorIfAbsent(page, viewID, from, to, i, rel.Label, dashedForPair[from+"->"+to], templates, result)
+		createConnectorIfAbsent(in, viewID, from, to, i, rel.Label, dashedForPair[from+"->"+to])
 	}
 }
 
@@ -503,22 +456,13 @@ func liftModelRelationshipEndpoints(rel model.Relationship, elemSet map[string]b
 
 // createConnectorIfAbsent creates the connector for a (possibly lifted)
 // relationship on page, unless a connector already exists at that index.
-func createConnectorIfAbsent(
-	page *drawio.Page,
-	viewID string,
-	from, to string,
-	index int,
-	label string,
-	dashed bool,
-	templates *drawio.TemplateSet,
-	result *ForwardResult,
-) {
+func createConnectorIfAbsent(in forwardRenderInputs, viewID string, from, to string, index int, label string, dashed bool) {
 	srcRef := scopedCellID(viewID, from)
 	tgtRef := scopedCellID(viewID, to)
-	if page.FindConnector(srcRef, tgtRef, index) != nil {
+	if in.page.FindConnector(srcRef, tgtRef, index) != nil {
 		return // Already exists.
 	}
-	style := templates.GetConnectorStyle()
+	style := in.templates.GetConnectorStyle()
 	if dashed {
 		style = mergeStyles(style, "dashed=1;")
 	}
@@ -530,8 +474,8 @@ func createConnectorIfAbsent(
 		TargetRef: tgtRef,
 		Index:     index,
 	}
-	page.CreateConnector(data, style)
-	result.ConnectorsCreated++
+	in.page.CreateConnector(data, style)
+	in.result.ConnectorsCreated++
 }
 
 // scopedCellID returns a page-scoped cell ID to ensure file-wide uniqueness.
@@ -653,23 +597,14 @@ func createScopeBoundary(
 // viewID is used to scope cell IDs for file-wide uniqueness (empty = legacy).
 // scopeID identifies the boundary element for parenting children (empty = no scope).
 // spec provides tag definitions for applying tag-based styles.
-func applyChangesToPage(
-	cs *ChangeSet,
-	page *drawio.Page,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	elemFilter map[string]bool,
-	viewID string,
-	scopeID string,
-	spec *model.Specification,
-	result *ForwardResult,
-) {
+func applyChangesToPage(in forwardRenderInputs, elemFilter map[string]bool, viewID string, scopeID string) {
+	page := in.page
 	pl := computePlacement(page)
 	pl.childCount[scopeID] = countScopeChildren(page, viewID, scopeID)
 	initialChildCount := pl.childCount[scopeID]
 
-	applyModelElementChanges(cs, page, templates, flat, elemFilter, viewID, scopeID, spec, &pl, result)
-	applyModelRelationshipChanges(cs, page, templates, elemFilter, viewID, scopeID, spec, result)
+	applyModelElementChanges(in, elemFilter, viewID, scopeID, &pl)
+	applyModelRelationshipChanges(in, elemFilter, viewID, scopeID)
 
 	// Expand scope boundary to fit any children added in this pass (#330).
 	if scopeID != "" && pl.childCount[scopeID] > initialChildCount {
@@ -678,32 +613,22 @@ func applyChangesToPage(
 }
 
 // applyModelElementChanges applies Added/Modified/Deleted element changes from cs to page.
-func applyModelElementChanges(
-	cs *ChangeSet,
-	page *drawio.Page,
-	templates *drawio.TemplateSet,
-	flat map[string]*model.Element,
-	elemFilter map[string]bool,
-	viewID string,
-	scopeID string,
-	spec *model.Specification,
-	pl *placement,
-	result *ForwardResult,
-) {
-	for _, ch := range cs.ModelElementChanges {
+func applyModelElementChanges(in forwardRenderInputs, elemFilter map[string]bool, viewID string, scopeID string, pl *placement) {
+	spec := &in.model.Specification
+	for _, ch := range in.cs.ModelElementChanges {
 		switch ch.Type {
 		case Added:
 			if elemFilter != nil && !elemFilter[ch.ID] {
 				continue
 			}
-			applyElementAdded(ch.ID, viewID, scopeID, page, templates, flat, spec, pl, result)
+			applyElementAdded(ch.ID, viewID, scopeID, in.page, in.templates, in.flat, spec, pl, in.result)
 		case Modified:
 			if elemFilter != nil && !elemFilter[ch.ID] && ch.ID != scopeID {
 				continue
 			}
-			applyElementModified(ch, page, templates, flat, result)
+			applyElementModified(ch, in.page, in.templates, in.flat, in.result)
 		case Deleted:
-			applyElementDeleted(ch, viewID, page, result)
+			applyElementDeleted(ch, viewID, in.page, in.result)
 		}
 	}
 }
@@ -730,26 +655,17 @@ func applyElementDeleted(ch ElementChange, viewID string, page *drawio.Page, res
 // (e.g., api→db) and a lifted relationship (e.g., api.catalog→db lifted to
 // api→db) map to the same pair, the direct one's label is used for the
 // connector.
-func applyModelRelationshipChanges(
-	cs *ChangeSet,
-	page *drawio.Page,
-	templates *drawio.TemplateSet,
-	elemFilter map[string]bool,
-	viewID string,
-	scopeID string,
-	spec *model.Specification,
-	result *ForwardResult,
-) {
+func applyModelRelationshipChanges(in forwardRenderInputs, elemFilter map[string]bool, viewID string, scopeID string) {
 	liftedSeen := make(map[string]bool)
 	for pass := 0; pass < 2; pass++ {
-		for _, ch := range cs.ModelRelationshipChanges {
+		for _, ch := range in.cs.ModelRelationshipChanges {
 			if ch.Type == Deleted {
 				if pass == 0 {
-					applyRelationshipDeleted(ch, viewID, page, result)
+					applyRelationshipDeleted(ch, viewID, in.page, in.result)
 				}
 				continue
 			}
-			applyRelationshipUpsert(ch, pass, elemFilter, viewID, scopeID, page, templates, spec, liftedSeen, result)
+			applyRelationshipUpsert(in, ch, pass, elemFilter, viewID, scopeID, liftedSeen)
 		}
 	}
 }
@@ -770,18 +686,7 @@ func applyRelationshipDeleted(ch RelationshipChange, viewID string, page *drawio
 // applyRelationshipUpsert applies a single Added/Modified relationship change
 // for one pass of the two-pass direct/lifted processing in
 // applyModelRelationshipChanges.
-func applyRelationshipUpsert(
-	ch RelationshipChange,
-	pass int,
-	elemFilter map[string]bool,
-	viewID string,
-	scopeID string,
-	page *drawio.Page,
-	templates *drawio.TemplateSet,
-	spec *model.Specification,
-	liftedSeen map[string]bool,
-	result *ForwardResult,
-) {
+func applyRelationshipUpsert(in forwardRenderInputs, ch RelationshipChange, pass int, elemFilter map[string]bool, viewID string, scopeID string, liftedSeen map[string]bool) {
 	from, to, ok := liftRelationshipEndpoints(ch, elemFilter, scopeID)
 	if !ok {
 		return
@@ -794,21 +699,23 @@ func applyRelationshipUpsert(
 		return // Second pass: only lifted relationships
 	}
 
+	page := in.page
+	spec := &in.model.Specification
 	switch ch.Type {
 	case Added:
 		if isDuplicateLiftedRelationship(from, to, isLifted, liftedSeen) {
 			return
 		}
 		lifted := RelationshipChange{From: from, To: to, Index: ch.Index, Type: ch.Type, NewValue: ch.NewValue, Kind: ch.Kind}
-		applyRelAdded(lifted, viewID, page, templates, spec, result)
+		applyRelAdded(lifted, viewID, page, in.templates, spec, in.result)
 	case Modified:
 		page.UpdateConnectorLabel(from, to, ch.Index, ch.NewValue)
 		// Recompute style from the template base rather than patching the
 		// existing style, so a kind change that flips dashed on or off is
 		// reflected either way (#518), mirroring UpdateElementKind's
 		// full-replacement approach.
-		page.SetConnectorStyle(from, to, ch.Index, connectorStyle(templates.GetConnectorStyle(), ch.Kind, spec))
-		result.ConnectorsUpdated++
+		page.SetConnectorStyle(from, to, ch.Index, connectorStyle(in.templates.GetConnectorStyle(), ch.Kind, spec))
+		in.result.ConnectorsUpdated++
 	}
 }
 

--- a/internal/sync/forward_test.go
+++ b/internal/sync/forward_test.go
@@ -359,7 +359,7 @@ func TestPopulateConnectors_LiftedDashedIsOrderIndependent(t *testing.T) {
 		{From: "api.sub1", To: "queue", Kind: "sync"},
 		{From: "api.sub2", To: "queue", Kind: "async"},
 	})
-	populateConnectors(page1, "", "", m1, elemSet, ts, &ForwardResult{})
+	populateConnectors(forwardRenderInputs{page: page1, templates: ts, model: m1, result: &ForwardResult{}}, "", "", elemSet)
 
 	// Dashed relationship first, non-dashed one second (reversed order).
 	doc2 := drawio.NewDocument()
@@ -368,7 +368,7 @@ func TestPopulateConnectors_LiftedDashedIsOrderIndependent(t *testing.T) {
 		{From: "api.sub2", To: "queue", Kind: "async"},
 		{From: "api.sub1", To: "queue", Kind: "sync"},
 	})
-	populateConnectors(page2, "", "", m2, elemSet, ts, &ForwardResult{})
+	populateConnectors(forwardRenderInputs{page: page2, templates: ts, model: m2, result: &ForwardResult{}}, "", "", elemSet)
 
 	for i, page := range []*drawio.Page{page1, page2} {
 		conn := page.FindConnector("api", "queue", 0)

--- a/internal/sync/layout.go
+++ b/internal/sync/layout.go
@@ -13,6 +13,15 @@ type position struct {
 	X, Y float64
 }
 
+// elemLayoutInputs bundles the read-only inputs shared by the row-placement
+// helpers below — the same three values threaded through unchanged whether
+// laying out tiers or BFS rows.
+type elemLayoutInputs struct {
+	flat      map[string]*model.Element
+	templates *drawio.TemplateSet
+	cfg       layoutConfig
+}
+
 type layoutConfig struct {
 	pageWidth  float64 // 1169 (A4 landscape)
 	elementGap float64 // 40
@@ -263,7 +272,7 @@ func placeLayered(
 ) (contentWidth, contentHeight float64) {
 	tiers, tierKeys := groupIntoTiers(ids, flat, kindTier, maxTier)
 
-	rows, maxRowWidth, endY := placeTierRows(tierKeys, tiers, flat, templates, cfg, originX, originY, positions)
+	rows, maxRowWidth, endY := placeTierRows(tierKeys, tiers, elemLayoutInputs{flat: flat, templates: templates, cfg: cfg}, position{X: originX, Y: originY}, positions)
 	centerRows(rows, maxRowWidth, positions)
 
 	contentWidth = maxRowWidth
@@ -311,23 +320,15 @@ func groupIntoTiers(ids []string, flat map[string]*model.Element, kindTier map[s
 // wrapping to a new row when the page width would be exceeded. Returns the
 // resulting rows (for later centering), the widest row's width, and the Y
 // position immediately after the last row.
-func placeTierRows(
-	tierKeys []int,
-	tiers map[int][]string,
-	flat map[string]*model.Element,
-	templates *drawio.TemplateSet,
-	cfg layoutConfig,
-	originX, originY float64,
-	positions map[string]position,
-) (rows []layeredRow, maxRowWidth float64, endY float64) {
-	curY := originY
+func placeTierRows(tierKeys []int, tiers map[int][]string, in elemLayoutInputs, origin position, positions map[string]position) (rows []layeredRow, maxRowWidth float64, endY float64) {
+	curY := origin.Y
 
 	for _, tier := range tierKeys {
 		elems := tiers[tier]
 		sort.Strings(elems)
 
 		var tierRows []layeredRow
-		tierRows, curY = placeOneTier(elems, flat, templates, cfg, originX, curY, positions)
+		tierRows, curY = placeOneTier(elems, in.flat, in.templates, in.cfg, origin.X, curY, positions)
 		for _, row := range tierRows {
 			rows = append(rows, row)
 			if row.width > maxRowWidth {
@@ -423,7 +424,7 @@ func placeBFS(
 ) (contentWidth, contentHeight float64) {
 	adj, connectedToActor := buildScopeAdjacency(ids, actorIDs, relationships)
 	rows := assignBFSRows(ids, adj, connectedToActor)
-	return placeBFSRows(rows, flat, templates, cfg, originX, originY, minRowWidth, positions)
+	return placeBFSRows(rows, elemLayoutInputs{flat: flat, templates: templates, cfg: cfg}, position{X: originX, Y: originY}, minRowWidth, positions)
 }
 
 // buildScopeAdjacency builds an adjacency map among ids (scope children)
@@ -575,15 +576,9 @@ func unplacedSorted(ids []string, placed map[string]bool) []string {
 // placeBFSRows places each BFS row left-aligned starting at (originX,
 // originY), wrapping to a new line when minRowWidth would be exceeded, and
 // returns the overall content width/height.
-func placeBFSRows(
-	rows [][]string,
-	flat map[string]*model.Element,
-	templates *drawio.TemplateSet,
-	cfg layoutConfig,
-	originX, originY float64,
-	minRowWidth float64,
-	positions map[string]position,
-) (contentWidth, contentHeight float64) {
+func placeBFSRows(rows [][]string, in elemLayoutInputs, origin position, minRowWidth float64, positions map[string]position) (contentWidth, contentHeight float64) {
+	flat, templates, cfg := in.flat, in.templates, in.cfg
+	originX, originY := origin.X, origin.Y
 	curY := originY
 	maxWidth := 0.0
 


### PR DESCRIPTION
## Description

Second PR working through #623. Fixes all 13 `go:S107` findings (>7 parameters) in `internal/sync/`.

## Changes

Rather than fixing each function in isolation, named the parameter clusters that were already being threaded unchanged through function after function — each flagged function had exactly one call site within its file, so this stayed contained:

- **`internal/sync/forward.go`** (8 findings): `forwardRenderInputs` bundles `cs *ChangeSet`, `doc`/`page`, `templates`, `flat`/`model`, and `result` — the same 4-6 values threaded through the whole forward-sync render pipeline. Also simplifies 5 unflagged-but-equally-bloated pass-through functions on the same call chain (`applyForwardPerView`, `applyForwardToPage`, `applyChangesToPage`, `populateNewPage`, `populateConnectors`) — they had to be touched anyway to pass the new type through, so fixing their own param count too was free.
- **`internal/sync/diff.go`** (3 findings): a generic `presence[T]{value T; found bool}` replaces the repeated "state T, found bool" pair each three-way (model/draw.io/last-sync) comparison function took per side.
- **`internal/sync/layout.go`** (2 findings): `elemLayoutInputs{flat, templates, cfg}` + the file's existing `position{X,Y}` type bundle the row-placement helpers' shared inputs.

Also documents the >7-params convention in `CLAUDE.md` so future code in this shape gets bundled the same way instead of re-accumulating params.

## Type of Change

- [x] Improvement/refactoring — behavior-preserving only, no new logic, no CLI/output change.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l`, `staticcheck ./internal/sync/...` all clean.
- `go test ./...` — all packages pass.
- `go test ./e2e/ -v` — full e2e suite passes (37s), including sync/view-heavy scenarios (`TestViewsWildcardsScopeLifting`'s 21 subtests, drill-down, structurizr/xmi/likec4 pipelines).
- Two direct test call sites in `forward_test.go` (`populateConnectors`) updated to the new signature — same assertions, no test logic changed.

This is the highest-risk PR in the #623 series (core forward-sync engine), so I ran the full test suite rather than just the touched packages before opening this.

## Documentation

`CLAUDE.md` — added the >7-params / bundle-into-a-struct convention this PR establishes.

Refs #623