### PR TITLE
refactor(sonar): reduce cognitive complexity in internal/sync/reverse.go

### DIFF
--- a/internal/sync/reverse.go
+++ b/internal/sync/reverse.go
@@ -156,192 +156,244 @@ func applyRelSwap(newFrom, newTo string, m *model.BausteinsichtModel, result *Re
 func applyElementChange(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastElemMap map[string]bool, priorSync bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
-		// Reject empty title updates from draw.io (#150).
-		if ch.Field == "title" && strings.TrimSpace(ch.NewValue) == "" {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Element %q: ignoring empty title from draw.io", ch.ID))
-			return
-		}
-		err := modifyElement(m, ch.ID, func(e *model.Element) {
-			switch ch.Field {
-			case "title":
-				e.Title = ch.NewValue
-			case "description":
-				e.Description = ch.NewValue
-			case "technology":
-				e.Technology = ch.NewValue
-			}
-		})
-		if err != nil {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Element %q not found in model: %v", ch.ID, err))
-			return
-		}
-		result.ElementsUpdated++
-
+		applyReverseElementModified(ch, m, result)
 	case Deleted:
-		err := deleteElement(m, ch.ID)
-		if err != nil {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Element %q could not be deleted: %v", ch.ID, err))
-			return
-		}
-		result.ElementsDeleted++
-		// Clean orphaned relationships referencing the deleted element (#266).
-		prefix := ch.ID + "."
-		var kept []model.Relationship
-		for _, r := range m.Relationships {
-			if r.From == ch.ID || r.To == ch.ID ||
-				strings.HasPrefix(r.From, prefix) || strings.HasPrefix(r.To, prefix) {
-				result.RelationshipsDeleted++
-				continue
-			}
-			kept = append(kept, r)
-		}
-		m.Relationships = kept
-		// Clean stale references from view include/exclude lists.
-		for viewID, v := range m.Views {
-			v.Include = removeFromSlice(v.Include, ch.ID)
-			v.Exclude = removeFromSlice(v.Exclude, ch.ID)
-			m.Views[viewID] = v
-		}
-		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("Element %q was deleted in draw.io and removed from model", ch.ID))
-
+		applyReverseElementDeleted(ch, m, result)
 	case Added:
-		if m.Model == nil {
-			m.Model = make(map[string]model.Element)
+		applyReverseElementAdded(ch, m, flatModel, lastElemMap, priorSync, result)
+	}
+}
+
+// applyReverseElementModified writes a title/description/technology edit
+// made in draw.io back to the model.
+func applyReverseElementModified(ch ElementChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	// Reject empty title updates from draw.io (#150).
+	if ch.Field == "title" && strings.TrimSpace(ch.NewValue) == "" {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Element %q: ignoring empty title from draw.io", ch.ID))
+		return
+	}
+	err := modifyElement(m, ch.ID, func(e *model.Element) {
+		switch ch.Field {
+		case "title":
+			e.Title = ch.NewValue
+		case "description":
+			e.Description = ch.NewValue
+		case "technology":
+			e.Technology = ch.NewValue
 		}
-		// Use the pre-computed flat model to check existence across the full
-		// hierarchy. A naive m.Model[ch.ID] check misses nested elements whose
-		// IDs are dot-paths (e.g. "parent.child"), causing them to be
-		// re-created as spurious top-level entries with empty titles (#307).
-		if _, exists := flatModel[ch.ID]; exists {
-			// Check if this element was already synced from draw.io in a previous sync.
-			// If it was, it's on a different page now - that's normal, skip silently.
-			if lastElemMap[ch.ID] {
-				// Already synced before (possibly on another page) - no action needed.
-				return
-			}
-			// Element exists in model but wasn't synced from draw.io before - that's a
-			// genuine conflict. Only warn if a prior sync actually happened; on the
-			// very first sync the user legitimately has it in both places.
-			hasLastState := priorSync
-			if hasLastState {
-				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("Element %q from draw.io skipped: ID already exists in model (not synced from draw.io)", ch.ID))
-			}
+	})
+	if err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Element %q not found in model: %v", ch.ID, err))
+		return
+	}
+	result.ElementsUpdated++
+}
+
+// applyReverseElementDeleted removes an element deleted in draw.io from the
+// model, along with the relationships and view references it leaves behind.
+func applyReverseElementDeleted(ch ElementChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	err := deleteElement(m, ch.ID)
+	if err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Element %q could not be deleted: %v", ch.ID, err))
+		return
+	}
+	result.ElementsDeleted++
+	// Clean orphaned relationships referencing the deleted element (#266).
+	prefix := ch.ID + "."
+	var kept []model.Relationship
+	for _, r := range m.Relationships {
+		if r.From == ch.ID || r.To == ch.ID ||
+			strings.HasPrefix(r.From, prefix) || strings.HasPrefix(r.To, prefix) {
+			result.RelationshipsDeleted++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	m.Relationships = kept
+	// Clean stale references from view include/exclude lists.
+	for viewID, v := range m.Views {
+		v.Include = removeFromSlice(v.Include, ch.ID)
+		v.Exclude = removeFromSlice(v.Exclude, ch.ID)
+		m.Views[viewID] = v
+	}
+	result.Warnings = append(result.Warnings,
+		fmt.Sprintf("Element %q was deleted in draw.io and removed from model", ch.ID))
+}
+
+// applyReverseElementAdded imports an element that was created directly in
+// draw.io, unless it turns out to already exist in the model (either
+// already synced before, or a genuine model/draw.io ID collision).
+func applyReverseElementAdded(ch ElementChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastElemMap map[string]bool, priorSync bool, result *ReverseResult) {
+	if m.Model == nil {
+		m.Model = make(map[string]model.Element)
+	}
+	// Use the pre-computed flat model to check existence across the full
+	// hierarchy. A naive m.Model[ch.ID] check misses nested elements whose
+	// IDs are dot-paths (e.g. "parent.child"), causing them to be
+	// re-created as spurious top-level entries with empty titles (#307).
+	if _, exists := flatModel[ch.ID]; exists {
+		// Check if this element was already synced from draw.io in a previous sync.
+		// If it was, it's on a different page now - that's normal, skip silently.
+		if lastElemMap[ch.ID] {
+			// Already synced before (possibly on another page) - no action needed.
 			return
 		}
-		kind := firstSpecKind(m)
-		m.Model[ch.ID] = model.Element{
-			Kind:  kind,
-			Title: ch.NewValue,
+		// Element exists in model but wasn't synced from draw.io before - that's a
+		// genuine conflict. Only warn if a prior sync actually happened; on the
+		// very first sync the user legitimately has it in both places.
+		if priorSync {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Element %q from draw.io skipped: ID already exists in model (not synced from draw.io)", ch.ID))
 		}
-		result.ElementsCreated++
-		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("New element %q added from draw.io (kind=%q) — review and assign a meaningful ID and kind.", ch.ID, kind))
+		return
 	}
+	kind := firstSpecKind(m)
+	m.Model[ch.ID] = model.Element{
+		Kind:  kind,
+		Title: ch.NewValue,
+	}
+	result.ElementsCreated++
+	result.Warnings = append(result.Warnings,
+		fmt.Sprintf("New element %q added from draw.io (kind=%q) — review and assign a meaningful ID and kind.", ch.ID, kind))
 }
 
 func applyRelationshipChange(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastRelMap map[string]bool, modelRelMap map[string]RelationshipState, priorSync bool, result *ReverseResult) {
 	switch ch.Type {
 	case Modified:
-		updated := false
-		if ch.Index >= 0 && ch.Index < len(m.Relationships) {
-			r := m.Relationships[ch.Index]
-			if r.From == ch.From && r.To == ch.To {
-				if ch.Field == "label" {
-					m.Relationships[ch.Index].Label = ch.NewValue
-				}
-				updated = true
-			}
-		}
-		// Fallback: search by from/to if index does not match.
-		if !updated {
-			for i, r := range m.Relationships {
-				if r.From == ch.From && r.To == ch.To {
-					if ch.Field == "label" {
-						m.Relationships[i].Label = ch.NewValue
-					}
-					updated = true
-					break
-				}
-			}
-		}
-		if updated {
-			result.RelationshipsUpdated++
-		} else {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Relationship %q->%q not found in model", ch.From, ch.To))
-		}
-
+		applyReverseRelationshipModified(ch, m, result)
 	case Deleted:
-		before := len(m.Relationships)
-		if ch.Index >= 0 && ch.Index < len(m.Relationships) {
-			r := m.Relationships[ch.Index]
-			if r.From == ch.From && r.To == ch.To {
-				m.Relationships = append(m.Relationships[:ch.Index], m.Relationships[ch.Index+1:]...)
-			} else {
-				// Fallback: filter by from/to.
-				m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
-			}
+		applyReverseRelationshipDeleted(ch, m, result)
+	case Added:
+		applyReverseRelationshipAdded(ch, m, flatModel, lastRelMap, modelRelMap, priorSync, result)
+	}
+}
+
+// applyReverseRelationshipModified writes a label edit made in draw.io back
+// to the model, preferring the connector's index but falling back to a
+// from/to search if the index no longer lines up (e.g. after a reorder).
+func applyReverseRelationshipModified(ch RelationshipChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	updated := relabelRelationshipByIndex(ch, m)
+	if !updated {
+		// Fallback: search by from/to if index does not match.
+		updated = relabelRelationshipByFromTo(ch, m)
+	}
+	if updated {
+		result.RelationshipsUpdated++
+	} else {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Relationship %q->%q not found in model", ch.From, ch.To))
+	}
+}
+
+// relabelRelationshipByIndex applies ch's label edit to the relationship at
+// ch.Index, if that slot still holds the same from/to pair. Reports whether
+// a match was found (and updated, when ch.Field is "label").
+func relabelRelationshipByIndex(ch RelationshipChange, m *model.BausteinsichtModel) bool {
+	if ch.Index < 0 || ch.Index >= len(m.Relationships) {
+		return false
+	}
+	r := m.Relationships[ch.Index]
+	if r.From != ch.From || r.To != ch.To {
+		return false
+	}
+	if ch.Field == "label" {
+		m.Relationships[ch.Index].Label = ch.NewValue
+	}
+	return true
+}
+
+// relabelRelationshipByFromTo is relabelRelationshipByIndex's fallback for
+// when ch.Index no longer lines up (e.g. after a reorder): it searches for
+// the first relationship matching ch's from/to pair instead.
+func relabelRelationshipByFromTo(ch RelationshipChange, m *model.BausteinsichtModel) bool {
+	for i, r := range m.Relationships {
+		if r.From != ch.From || r.To != ch.To {
+			continue
+		}
+		if ch.Field == "label" {
+			m.Relationships[i].Label = ch.NewValue
+		}
+		return true
+	}
+	return false
+}
+
+// applyReverseRelationshipDeleted removes a relationship deleted in draw.io
+// from the model, preferring the connector's index but falling back to a
+// from/to filter if the index no longer lines up.
+func applyReverseRelationshipDeleted(ch RelationshipChange, m *model.BausteinsichtModel, result *ReverseResult) {
+	before := len(m.Relationships)
+	if ch.Index >= 0 && ch.Index < len(m.Relationships) {
+		r := m.Relationships[ch.Index]
+		if r.From == ch.From && r.To == ch.To {
+			m.Relationships = append(m.Relationships[:ch.Index], m.Relationships[ch.Index+1:]...)
 		} else {
+			// Fallback: filter by from/to.
 			m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
 		}
-		if len(m.Relationships) < before {
-			result.RelationshipsDeleted++
-		}
-
-	case Added:
-		// Validate that both endpoints exist in the model before adding (#329).
-		// Prevents stale relationships from old draw.io files being imported after model replacement.
-		if _, fromExists := flatModel[ch.From]; !fromExists {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Relationship %q->%q rejected: From element %q does not exist in model", ch.From, ch.To, ch.From))
-			return
-		}
-		if _, toExists := flatModel[ch.To]; !toExists {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("Relationship %q->%q rejected: To element %q does not exist in model", ch.From, ch.To, ch.To))
-			return
-		}
-		// Check if this relationship was already synced from draw.io in a previous
-		// sync. Match on the connector index (relKey) so a genuinely new second
-		// relationship between the same pair (#142) stays distinct from the
-		// already-synced first one. If synced before, it's on a different page
-		// now - skip silently. (Reading a nil map yields false.)
-		if lastRelMap[relKey(ch.From, ch.To, ch.Index)] {
-			// Already synced before (possibly on another page) - no action needed.
-			return
-		}
-		// Check whether the model already holds this exact relationship, keyed the
-		// same way as the connector and the last-sync state (relKey over the global
-		// relationship index). This answers "does the model already have this
-		// relationship" directly, regardless of how many others share the pair, so
-		// a genuinely new connector (whose key is absent) is always imported.
-		if _, present := modelRelMap[relKey(ch.From, ch.To, ch.Index)]; present {
-			// Present in the model but not synced from draw.io. On the very first
-			// sync (no prior sync) this is expected - the user added it to both
-			// places - so skip silently; once a prior sync exists it is a genuine
-			// conflict, so warn.
-			if priorSync {
-				pageInfo := ""
-				if ch.PageID != "" {
-					pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)
-				}
-				result.Warnings = append(result.Warnings,
-					fmt.Sprintf("Relationship %q->%q already exists in model (not synced from draw.io), skipping duplicate%s", ch.From, ch.To, pageInfo))
-			}
-			return
-		}
-		m.Relationships = append(m.Relationships, model.Relationship{
-			From:  ch.From,
-			To:    ch.To,
-			Label: ch.NewValue,
-		})
-		result.RelationshipsCreated++
+	} else {
+		m.Relationships = filterRelationships(m.Relationships, ch.From, ch.To)
 	}
+	if len(m.Relationships) < before {
+		result.RelationshipsDeleted++
+	}
+}
+
+// applyReverseRelationshipAdded imports a relationship (connector) created
+// directly in draw.io, unless its endpoints don't exist in the model (#329)
+// or it turns out to already exist (either already synced before, or a
+// genuine model/draw.io collision).
+func applyReverseRelationshipAdded(ch RelationshipChange, m *model.BausteinsichtModel, flatModel map[string]*model.Element, lastRelMap map[string]bool, modelRelMap map[string]RelationshipState, priorSync bool, result *ReverseResult) {
+	// Validate that both endpoints exist in the model before adding (#329).
+	// Prevents stale relationships from old draw.io files being imported after model replacement.
+	if _, fromExists := flatModel[ch.From]; !fromExists {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Relationship %q->%q rejected: From element %q does not exist in model", ch.From, ch.To, ch.From))
+		return
+	}
+	if _, toExists := flatModel[ch.To]; !toExists {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("Relationship %q->%q rejected: To element %q does not exist in model", ch.From, ch.To, ch.To))
+		return
+	}
+	// Check if this relationship was already synced from draw.io in a previous
+	// sync. Match on the connector index (relKey) so a genuinely new second
+	// relationship between the same pair (#142) stays distinct from the
+	// already-synced first one. If synced before, it's on a different page
+	// now - skip silently. (Reading a nil map yields false.)
+	if lastRelMap[relKey(ch.From, ch.To, ch.Index)] {
+		// Already synced before (possibly on another page) - no action needed.
+		return
+	}
+	// Check whether the model already holds this exact relationship, keyed the
+	// same way as the connector and the last-sync state (relKey over the global
+	// relationship index). This answers "does the model already have this
+	// relationship" directly, regardless of how many others share the pair, so
+	// a genuinely new connector (whose key is absent) is always imported.
+	if _, present := modelRelMap[relKey(ch.From, ch.To, ch.Index)]; present {
+		// Present in the model but not synced from draw.io. On the very first
+		// sync (no prior sync) this is expected - the user added it to both
+		// places - so skip silently; once a prior sync exists it is a genuine
+		// conflict, so warn.
+		if priorSync {
+			pageInfo := ""
+			if ch.PageID != "" {
+				pageInfo = fmt.Sprintf(" (on draw.io page %q)", ch.PageID)
+			}
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Relationship %q->%q already exists in model (not synced from draw.io), skipping duplicate%s", ch.From, ch.To, pageInfo))
+		}
+		return
+	}
+	m.Relationships = append(m.Relationships, model.Relationship{
+		From:  ch.From,
+		To:    ch.To,
+		Label: ch.NewValue,
+	})
+	result.RelationshipsCreated++
 }
 
 // filterRelationships returns all relationships except those matching from/to.

--- a/internal/sync/reverse_test.go
+++ b/internal/sync/reverse_test.go
@@ -893,3 +893,249 @@ func TestApplyReverse_DeletedElementCleansNestedRelationships(t *testing.T) {
 		t.Errorf("expected RelationshipsDeleted=2, got %d", r.RelationshipsDeleted)
 	}
 }
+
+// TestApplyReverse_RelationshipLabelUpdated_FallbackByFromTo covers
+// relabelRelationshipByFromTo: when ch.Index no longer lines up with the
+// model's current array position (e.g. after a reorder), the label update
+// must still find the relationship by from/to.
+func TestApplyReverse_RelationshipLabelUpdated_FallbackByFromTo(t *testing.T) {
+	m := modelWithRel("a", "b", "old label")
+	cs := relChangeSet("a", "b", Modified, "label", "old label", "new label")
+	cs.DrawioRelationshipChanges[0].Index = 5 // stale/mismatched index
+
+	r := ApplyReverse(cs, m, nil)
+
+	if m.Relationships[0].Label != "new label" {
+		t.Errorf("expected label %q via fallback, got %q", "new label", m.Relationships[0].Label)
+	}
+	if r.RelationshipsUpdated != 1 {
+		t.Errorf("expected RelationshipsUpdated=1, got %d", r.RelationshipsUpdated)
+	}
+}
+
+// TestApplyReverse_RelationshipDeleted_FallbackByFromTo covers
+// filterRelationships via applyReverseRelationshipDeleted's fallback path:
+// a stale ch.Index must not prevent the relationship from being found and
+// deleted by from/to.
+func TestApplyReverse_RelationshipDeleted_FallbackByFromTo(t *testing.T) {
+	m := modelWithRel("a", "b", "calls")
+	cs := relChangeSet("a", "b", Deleted, "", "", "")
+	cs.DrawioRelationshipChanges[0].Index = 5 // stale/mismatched index
+
+	r := ApplyReverse(cs, m, nil)
+
+	if len(m.Relationships) != 0 {
+		t.Errorf("expected relationship to be removed via fallback, got %d remaining", len(m.Relationships))
+	}
+	if r.RelationshipsDeleted != 1 {
+		t.Errorf("expected RelationshipsDeleted=1, got %d", r.RelationshipsDeleted)
+	}
+}
+
+// TestApplyReverse_RelationshipLabelUpdated_IndexMismatchFallsBack covers
+// relabelRelationshipByIndex's from/to-mismatch branch: ch.Index is within
+// bounds but points at a different relationship, so the update must still
+// find the right one via the from/to fallback (not just an out-of-range
+// index, which TestApplyReverse_RelationshipLabelUpdated_FallbackByFromTo
+// already covers).
+func TestApplyReverse_RelationshipLabelUpdated_IndexMismatchFallsBack(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "a"},
+			"b": {Kind: "container", Title: "b"},
+			"c": {Kind: "container", Title: "c"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "c", Label: "unrelated"},
+			{From: "a", To: "b", Label: "old label"},
+		},
+	}
+	cs := relChangeSet("a", "b", Modified, "label", "old label", "new label")
+	cs.DrawioRelationshipChanges[0].Index = 0 // in bounds, but that slot is a->c, not a->b
+
+	r := ApplyReverse(cs, m, nil)
+
+	if m.Relationships[1].Label != "new label" {
+		t.Errorf("expected label %q via fallback, got %q", "new label", m.Relationships[1].Label)
+	}
+	if r.RelationshipsUpdated != 1 {
+		t.Errorf("expected RelationshipsUpdated=1, got %d", r.RelationshipsUpdated)
+	}
+}
+
+// TestApplyReverse_RelationshipDeleted_IndexMismatchFallsBack is the delete
+// counterpart of the index-mismatch-fallback case above.
+func TestApplyReverse_RelationshipDeleted_IndexMismatchFallsBack(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "a"},
+			"b": {Kind: "container", Title: "b"},
+			"c": {Kind: "container", Title: "c"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "c", Label: "unrelated"},
+			{From: "a", To: "b", Label: "calls"},
+		},
+	}
+	cs := relChangeSet("a", "b", Deleted, "", "", "")
+	cs.DrawioRelationshipChanges[0].Index = 0 // in bounds, but that slot is a->c, not a->b
+
+	r := ApplyReverse(cs, m, nil)
+
+	if len(m.Relationships) != 1 || m.Relationships[0].To != "c" {
+		t.Errorf("expected only a->c to remain, got %+v", m.Relationships)
+	}
+	if r.RelationshipsDeleted != 1 {
+		t.Errorf("expected RelationshipsDeleted=1, got %d", r.RelationshipsDeleted)
+	}
+}
+
+// TestApplyReverse_RelationshipAddedToElementMissing is the "To" side
+// counterpart of TestApplyReverse_RelationshipAddedStaleElementsRejected
+// (which only covers a missing "From").
+func TestApplyReverse_RelationshipAddedToElementMissing(t *testing.T) {
+	m := modelWithRel("x", "y", "")
+	m.Relationships = []model.Relationship{}
+	cs := relChangeSet("x", "nonexistent", Added, "", "", "uses")
+
+	r := ApplyReverse(cs, m, nil)
+
+	if len(m.Relationships) != 0 {
+		t.Fatalf("expected 0 relationships (stale rejected), got %d", len(m.Relationships))
+	}
+	warnText := strings.Join(r.Warnings, "; ")
+	if !strings.Contains(warnText, "nonexistent") || !strings.Contains(warnText, "does not exist") {
+		t.Errorf("expected warning mentioning non-existent To element, got: %s", warnText)
+	}
+}
+
+// TestApplyReverse_ElementAddedAlreadySyncedSkipped covers the
+// "already synced from draw.io before" skip branch: the element exists in
+// the model AND was recorded in the last sync state, so a re-appearing
+// Added change (e.g. the element moved to another page) is a silent no-op.
+func TestApplyReverse_ElementAddedAlreadySyncedSkipped(t *testing.T) {
+	m := simpleModel("api", "API", "", "")
+	cs := elemChangeSet("api", Added, "", "", "API")
+	lastState := &SyncState{
+		Timestamp: "2026-01-01T00:00:00Z",
+		Elements:  map[string]ElementState{"api": {Title: "API", Kind: "container"}},
+	}
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if r.ElementsCreated != 0 {
+		t.Errorf("expected 0 elements created (already synced), got %d", r.ElementsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("expected no warnings for an element already synced before, got: %v", r.Warnings)
+	}
+}
+
+// TestApplyReverse_ElementDeletedNotFoundWarns covers deleteElement's error
+// path: a Deleted change for an ID that doesn't exist in the model at all.
+func TestApplyReverse_ElementDeletedNotFoundWarns(t *testing.T) {
+	m := simpleModel("api", "API", "", "")
+	cs := elemChangeSet("nonexistent", Deleted, "", "", "")
+
+	r := ApplyReverse(cs, m, nil)
+
+	if r.ElementsDeleted != 0 {
+		t.Errorf("expected 0 elements deleted, got %d", r.ElementsDeleted)
+	}
+	warnText := strings.Join(r.Warnings, "; ")
+	if !strings.Contains(warnText, "could not be deleted") {
+		t.Errorf("expected a \"could not be deleted\" warning, got: %s", warnText)
+	}
+}
+
+// TestApplyReverse_ElementAddedNilModelMap covers applyReverseElementAdded's
+// m.Model-is-nil initialization branch.
+func TestApplyReverse_ElementAddedNilModelMap(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Specification: model.Specification{
+			Elements: map[string]model.ElementKind{"container": {Notation: "box"}},
+		},
+	}
+	cs := elemChangeSet("newElem", Added, "", "", "New Element")
+
+	r := ApplyReverse(cs, m, nil)
+
+	if r.ElementsCreated != 1 {
+		t.Fatalf("expected 1 element created, got %d", r.ElementsCreated)
+	}
+	if _, ok := m.Model["newElem"]; !ok {
+		t.Error("expected new element to be present in the initialized Model map")
+	}
+}
+
+// TestApplyReverse_RelationshipAddedDuplicateWithPageID covers the
+// pageInfo-in-warning branch of applyReverseRelationshipAdded: a duplicate
+// relationship rejection where the incoming change carries a draw.io PageID.
+func TestApplyReverse_RelationshipAddedDuplicateWithPageID(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"}, // index 0, present in model but never synced from draw.io
+		},
+	}
+	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z", // a prior sync completed
+	}
+	cs := &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "uses", PageID: "view-context"},
+		},
+	}
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected the duplicate to be rejected, got %d relationships", len(m.Relationships))
+	}
+	warnText := strings.Join(r.Warnings, "; ")
+	if !strings.Contains(warnText, "view-context") {
+		t.Errorf("expected warning to mention the draw.io page, got: %s", warnText)
+	}
+}
+
+// TestApplyReverse_RelationshipAddedAlreadySyncedSkipped covers the
+// lastRelMap-hit branch: the relationship was already synced from draw.io
+// in a previous sync (e.g. it now appears on a different page), so a
+// re-appearing Added change is a silent no-op.
+func TestApplyReverse_RelationshipAddedAlreadySyncedSkipped(t *testing.T) {
+	m := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"a": {Kind: "container", Title: "A"},
+			"b": {Kind: "container", Title: "B"},
+		},
+		Relationships: []model.Relationship{
+			{From: "a", To: "b", Label: "uses"},
+		},
+	}
+	lastState := &SyncState{
+		Timestamp: "2026-07-26T00:00:00Z",
+		Relationships: []RelationshipState{
+			{From: "a", To: "b", Index: 0, Label: "uses"},
+		},
+	}
+	cs := &ChangeSet{
+		DrawioRelationshipChanges: []RelationshipChange{
+			{From: "a", To: "b", Index: 0, Type: Added, NewValue: "uses"},
+		},
+	}
+
+	r := ApplyReverse(cs, m, lastState)
+
+	if len(m.Relationships) != 1 {
+		t.Fatalf("expected no new relationship, got %d", len(m.Relationships))
+	}
+	if r.RelationshipsCreated != 0 {
+		t.Errorf("expected RelationshipsCreated=0, got %d", r.RelationshipsCreated)
+	}
+	if len(r.Warnings) != 0 {
+		t.Errorf("expected no warnings for an already-synced relationship, got: %v", r.Warnings)
+	}
+}


### PR DESCRIPTION
## Description

Third PR working through #623. Fixes both `go:S3776` findings in `internal/sync/reverse.go` — the worst single offender in the whole issue (`applyRelationshipChange`, 56 → 15 required).

## Changes

Split each `switch ch.Type` case (Modified/Deleted/Added) into its own named function:

- `applyElementChange` (was 25): now dispatches to `applyReverseElementModified`, `applyReverseElementDeleted`, `applyReverseElementAdded`.
- `applyRelationshipChange` (was 56): now dispatches to `applyReverseRelationshipModified`, `applyReverseRelationshipDeleted`, `applyReverseRelationshipAdded`.
- `applyReverseRelationshipModified` itself still measured 21 with `gocognit` after that first pass — its "try by index, fall back to from/to search" logic needed a second split into `relabelRelationshipByIndex`/`relabelRelationshipByFromTo`.

Named with a `Reverse` prefix specifically to avoid colliding with `forward.go`'s identically-shaped `apply{Element,Relationship}{Modified,Deleted,Added}` helpers, which apply changes in the opposite direction (model → draw.io, not draw.io → model).

No logic changed — this is purely "which function is this code physically inside of." One small drive-by simplification: dropped a redundant `hasLastState := priorSync` alias that was never anything but `priorSync` itself.

## Type of Change

- [x] Improvement/refactoring — behavior-preserving only, no new logic, no CLI/output change.

## Testing

- Verified locally with `gocognit` (not runnable against SonarCloud directly before pushing): no function in `reverse.go` now exceeds 12; CI's/SonarCloud's threshold is 15.
- `go build ./...`, `go vet ./...`, `gofmt -l`, `staticcheck ./internal/sync/...` all clean.
- `go test ./...` — all packages pass.
- `go test ./e2e/ -run "Reverse|Conflict|Label|Delete"` — reverse-sync-specific e2e scenarios pass.

## Documentation

N/A — internal refactor, no user-visible or cross-command effect.

Refs #623