### PR TITLE
refactor(sonar): reduce cognitive complexity in cmd/bausteinsicht/repl.go

### DIFF
--- a/cmd/bausteinsicht/repl.go
+++ b/cmd/bausteinsicht/repl.go
@@ -180,50 +180,60 @@ func (s *replState) listCommand(parts []string) {
 
 	switch parts[0] {
 	case "elements":
-		flat, _ := model.FlattenElements(s.model)
-		ids := make([]string, 0, len(flat))
-		for id := range flat {
-			ids = append(ids, id)
-		}
-		sort.Strings(ids)
-		fmt.Printf("\n%-30s %-15s %-40s\n", "ID", "Kind", "Title")
-		fmt.Println(strings.Repeat("-", 85))
-		for _, id := range ids {
-			elem := flat[id]
-			fmt.Printf("%-30s %-15s %-40s\n", id, elem.Kind, elem.Title)
-		}
-
+		s.listElements()
 	case "relationships":
-		fmt.Printf("\n%-20s → %-20s %-30s\n", "From", "To", "Label")
-		fmt.Println(strings.Repeat("-", 70))
-		rels := make([]model.Relationship, len(s.model.Relationships))
-		copy(rels, s.model.Relationships)
-		sort.Slice(rels, func(i, j int) bool {
-			if rels[i].From != rels[j].From {
-				return rels[i].From < rels[j].From
-			}
-			if rels[i].To != rels[j].To {
-				return rels[i].To < rels[j].To
-			}
-			return rels[i].Label < rels[j].Label
-		})
-		for _, rel := range rels {
-			fmt.Printf("%-20s → %-20s %-30s\n", rel.From, rel.To, rel.Label)
-		}
-
+		s.listRelationships()
 	case "views":
-		keys := make([]string, 0, len(s.model.Views))
-		for k := range s.model.Views {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		fmt.Printf("\n%-20s %-50s\n", "Key", "Title")
-		fmt.Println(strings.Repeat("-", 70))
-		for _, key := range keys {
-			fmt.Printf("%-20s %-50s\n", key, s.model.Views[key].Title)
-		}
+		s.listViews()
 	}
 	fmt.Println()
+}
+
+func (s *replState) listElements() {
+	flat, _ := model.FlattenElements(s.model)
+	ids := make([]string, 0, len(flat))
+	for id := range flat {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	fmt.Printf("\n%-30s %-15s %-40s\n", "ID", "Kind", "Title")
+	fmt.Println(strings.Repeat("-", 85))
+	for _, id := range ids {
+		elem := flat[id]
+		fmt.Printf("%-30s %-15s %-40s\n", id, elem.Kind, elem.Title)
+	}
+}
+
+func (s *replState) listRelationships() {
+	fmt.Printf("\n%-20s → %-20s %-30s\n", "From", "To", "Label")
+	fmt.Println(strings.Repeat("-", 70))
+	rels := make([]model.Relationship, len(s.model.Relationships))
+	copy(rels, s.model.Relationships)
+	sort.Slice(rels, func(i, j int) bool {
+		if rels[i].From != rels[j].From {
+			return rels[i].From < rels[j].From
+		}
+		if rels[i].To != rels[j].To {
+			return rels[i].To < rels[j].To
+		}
+		return rels[i].Label < rels[j].Label
+	})
+	for _, rel := range rels {
+		fmt.Printf("%-20s → %-20s %-30s\n", rel.From, rel.To, rel.Label)
+	}
+}
+
+func (s *replState) listViews() {
+	keys := make([]string, 0, len(s.model.Views))
+	for k := range s.model.Views {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	fmt.Printf("\n%-20s %-50s\n", "Key", "Title")
+	fmt.Println(strings.Repeat("-", 70))
+	for _, key := range keys {
+		fmt.Printf("%-20s %-50s\n", key, s.model.Views[key].Title)
+	}
 }
 
 func (s *replState) addCommand(parts []string) {
@@ -240,84 +250,28 @@ func (s *replState) addCommand(parts []string) {
 }
 
 func (s *replState) addElementInteractive() {
-	fmt.Print("Element ID: ")
-	s.scanner.Scan()
-	id := strings.TrimSpace(s.scanner.Text())
-	if id == "" {
-		fmt.Println("Aborted (empty ID)")
-		return
-	}
-	if !isValidKey(id) {
-		fmt.Printf("Invalid ID %q: must start with a letter and contain only letters, digits, hyphens, or underscores\n", id)
+	id, ok := s.promptElementID()
+	if !ok {
 		return
 	}
 
 	if existing, exists := s.model.Model[id]; exists {
-		fmt.Printf("Element '%s' already exists.\n", id)
-		fmt.Printf("  Updating:  kind, title, description\n")
-		preserved := []string{}
-		if len(existing.Children) > 0 {
-			preserved = append(preserved, fmt.Sprintf("%d child(ren)", len(existing.Children)))
-		}
-		if existing.Technology != "" {
-			preserved = append(preserved, "technology")
-		}
-		if len(existing.Tags) > 0 {
-			preserved = append(preserved, "tags")
-		}
-		if existing.Status != "" {
-			preserved = append(preserved, "status")
-		}
-		if len(existing.Decisions) > 0 {
-			preserved = append(preserved, "decisions")
-		}
-		if len(existing.Metadata) > 0 {
-			preserved = append(preserved, "metadata")
-		}
-		if len(preserved) > 0 {
-			fmt.Printf("  Preserving: %s\n", strings.Join(preserved, ", "))
-		}
-		fmt.Print("Overwrite? (yes/no): ")
-		s.scanner.Scan()
-		if strings.ToLower(strings.TrimSpace(s.scanner.Text())) != "yes" {
-			fmt.Println("Aborted")
+		if !s.confirmOverwriteExistingElement(id, existing) {
 			return
 		}
 	}
 
-	fmt.Print("Kind: ")
-	s.scanner.Scan()
-	kind := strings.TrimSpace(s.scanner.Text())
-	if kind == "" {
-		fmt.Println("Aborted (kind must not be empty)")
-		return
-	}
-	if len(s.model.Specification.Elements) > 0 {
-		if _, ok := s.model.Specification.Elements[kind]; !ok {
-			fmt.Printf("Unknown kind %q; valid kinds: %s\n", kind, validKinds(s.model))
-			return
-		}
-	}
-
-	fmt.Print("Title: ")
-	s.scanner.Scan()
-	title := strings.TrimSpace(s.scanner.Text())
-	if title == "" {
-		fmt.Println("Aborted (title must not be empty)")
+	kind, ok := s.promptElementKind()
+	if !ok {
 		return
 	}
 
-	existingDesc := s.model.Model[id].Description
-	if existingDesc != "" {
-		fmt.Printf("Description (optional) [%s]: ", existingDesc)
-	} else {
-		fmt.Print("Description (optional): ")
+	title, ok := s.promptElementTitle()
+	if !ok {
+		return
 	}
-	s.scanner.Scan()
-	desc := strings.TrimSpace(s.scanner.Text())
-	if desc == "" {
-		desc = existingDesc
-	}
+
+	desc := s.promptElementDescription(s.model.Model[id].Description)
 
 	if !s.saveUndo() {
 		fmt.Println("(warning: undo not available for this change)")
@@ -332,6 +286,113 @@ func (s *replState) addElementInteractive() {
 	s.model.Model[id] = updated
 	s.modified = true
 	fmt.Printf("✅ Added element '%s'\n", id)
+}
+
+// promptElementID prompts for and validates a new/existing element ID.
+func (s *replState) promptElementID() (string, bool) {
+	fmt.Print("Element ID: ")
+	s.scanner.Scan()
+	id := strings.TrimSpace(s.scanner.Text())
+	if id == "" {
+		fmt.Println("Aborted (empty ID)")
+		return "", false
+	}
+	if !isValidKey(id) {
+		fmt.Printf("Invalid ID %q: must start with a letter and contain only letters, digits, hyphens, or underscores\n", id)
+		return "", false
+	}
+	return id, true
+}
+
+// confirmOverwriteExistingElement tells the user which fields of an
+// existing element addElementInteractive will overwrite vs. preserve, and
+// asks for confirmation. Reports whether the user confirmed.
+func (s *replState) confirmOverwriteExistingElement(id string, existing model.Element) bool {
+	fmt.Printf("Element '%s' already exists.\n", id)
+	fmt.Printf("  Updating:  kind, title, description\n")
+	if preserved := describePreservedFields(existing); len(preserved) > 0 {
+		fmt.Printf("  Preserving: %s\n", strings.Join(preserved, ", "))
+	}
+	fmt.Print("Overwrite? (yes/no): ")
+	s.scanner.Scan()
+	if strings.ToLower(strings.TrimSpace(s.scanner.Text())) != "yes" {
+		fmt.Println("Aborted")
+		return false
+	}
+	return true
+}
+
+// describePreservedFields lists existing's non-empty fields that
+// addElementInteractive does not prompt for, so the user knows they will
+// survive an overwrite.
+func describePreservedFields(existing model.Element) []string {
+	var preserved []string
+	if len(existing.Children) > 0 {
+		preserved = append(preserved, fmt.Sprintf("%d child(ren)", len(existing.Children)))
+	}
+	if existing.Technology != "" {
+		preserved = append(preserved, "technology")
+	}
+	if len(existing.Tags) > 0 {
+		preserved = append(preserved, "tags")
+	}
+	if existing.Status != "" {
+		preserved = append(preserved, "status")
+	}
+	if len(existing.Decisions) > 0 {
+		preserved = append(preserved, "decisions")
+	}
+	if len(existing.Metadata) > 0 {
+		preserved = append(preserved, "metadata")
+	}
+	return preserved
+}
+
+// promptElementKind prompts for and validates a kind against the
+// specification (if one is defined).
+func (s *replState) promptElementKind() (string, bool) {
+	fmt.Print("Kind: ")
+	s.scanner.Scan()
+	kind := strings.TrimSpace(s.scanner.Text())
+	if kind == "" {
+		fmt.Println("Aborted (kind must not be empty)")
+		return "", false
+	}
+	if len(s.model.Specification.Elements) > 0 {
+		if _, ok := s.model.Specification.Elements[kind]; !ok {
+			fmt.Printf("Unknown kind %q; valid kinds: %s\n", kind, validKinds(s.model))
+			return "", false
+		}
+	}
+	return kind, true
+}
+
+// promptElementTitle prompts for a non-empty title.
+func (s *replState) promptElementTitle() (string, bool) {
+	fmt.Print("Title: ")
+	s.scanner.Scan()
+	title := strings.TrimSpace(s.scanner.Text())
+	if title == "" {
+		fmt.Println("Aborted (title must not be empty)")
+		return "", false
+	}
+	return title, true
+}
+
+// promptElementDescription prompts for an optional description, defaulting
+// to existingDesc (shown as the prompt's bracketed default) when left blank.
+func (s *replState) promptElementDescription(existingDesc string) string {
+	if existingDesc != "" {
+		fmt.Printf("Description (optional) [%s]: ", existingDesc)
+	} else {
+		fmt.Print("Description (optional): ")
+	}
+	s.scanner.Scan()
+	desc := strings.TrimSpace(s.scanner.Text())
+	if desc == "" {
+		desc = existingDesc
+	}
+	return desc
 }
 
 func (s *replState) addRelationshipInteractive() {
@@ -407,7 +468,6 @@ func (s *replState) removeCommand(parts []string) {
 	}
 
 	pushed := s.saveUndo()
-
 	popUndo := func() {
 		if pushed && len(s.undoStack) > 0 {
 			s.undoStack = s.undoStack[:len(s.undoStack)-1]
@@ -416,46 +476,58 @@ func (s *replState) removeCommand(parts []string) {
 
 	switch parts[0] {
 	case "element":
-		id := parts[1]
-		// Only top-level elements can be removed this way; nested children
-		// (dot-path IDs like "shop.api") must be edited in the JSONC directly.
-		if _, exists := s.model.Model[id]; !exists {
-			fmt.Printf("Element '%s' not found (nested elements must be edited in the model file)\n", id)
-			popUndo()
-			return
-		}
-		delete(s.model.Model, id)
-		s.modified = true
-		fmt.Printf("✅ Removed element '%s'\n", id)
-
+		s.removeElementCommand(parts[1], popUndo)
 	case "relationship":
-		if len(parts) < 3 {
-			fmt.Println("Usage: remove relationship <from> <to> [label]")
-			popUndo()
-			return
+		s.removeRelationshipCommand(parts[1:], popUndo)
+	}
+}
+
+// removeElementCommand removes a top-level element from the model. Only
+// top-level elements can be removed this way; nested children (dot-path IDs
+// like "shop.api") must be edited in the JSONC directly. popUndo rolls back
+// the undo-stack push removeCommand already made, if this ends up a no-op.
+func (s *replState) removeElementCommand(id string, popUndo func()) {
+	if _, exists := s.model.Model[id]; !exists {
+		fmt.Printf("Element '%s' not found (nested elements must be edited in the model file)\n", id)
+		popUndo()
+		return
+	}
+	delete(s.model.Model, id)
+	s.modified = true
+	fmt.Printf("✅ Removed element '%s'\n", id)
+}
+
+// removeRelationshipCommand removes the first relationship matching
+// args[0]->args[1] (and, if given, the label in args[2:]). popUndo rolls
+// back the undo-stack push removeCommand already made, if this ends up a
+// no-op (usage error or no match found).
+func (s *replState) removeRelationshipCommand(args []string, popUndo func()) {
+	if len(args) < 2 {
+		fmt.Println("Usage: remove relationship <from> <to> [label]")
+		popUndo()
+		return
+	}
+	from, to := args[0], args[1]
+	wantLabel := ""
+	if len(args) >= 3 {
+		wantLabel = strings.Join(args[2:], " ")
+	}
+	removed := false
+	rels := s.model.Relationships[:0]
+	for _, r := range s.model.Relationships {
+		if !removed && r.From == from && r.To == to && (wantLabel == "" || r.Label == wantLabel) {
+			removed = true
+			continue
 		}
-		from, to := parts[1], parts[2]
-		wantLabel := ""
-		if len(parts) >= 4 {
-			wantLabel = strings.Join(parts[3:], " ")
-		}
-		removed := false
-		rels := s.model.Relationships[:0]
-		for _, r := range s.model.Relationships {
-			if !removed && r.From == from && r.To == to && (wantLabel == "" || r.Label == wantLabel) {
-				removed = true
-				continue
-			}
-			rels = append(rels, r)
-		}
-		s.model.Relationships = rels
-		if removed {
-			s.modified = true
-			fmt.Printf("✅ Removed relationship %s → %s\n", from, to)
-		} else {
-			fmt.Printf("Relationship %s → %s not found\n", from, to)
-			popUndo()
-		}
+		rels = append(rels, r)
+	}
+	s.model.Relationships = rels
+	if removed {
+		s.modified = true
+		fmt.Printf("✅ Removed relationship %s → %s\n", from, to)
+	} else {
+		fmt.Printf("Relationship %s → %s not found\n", from, to)
+		popUndo()
 	}
 }
 

--- a/cmd/bausteinsicht/repl_test.go
+++ b/cmd/bausteinsicht/repl_test.go
@@ -461,3 +461,129 @@ func TestReplAddRelationship_ToNotFound(t *testing.T) {
 		t.Error("no relationship should have been added for unknown to")
 	}
 }
+
+// TestReplListCommand_EmptyArgs covers listCommand's own len(parts)==0
+// guard. Unreachable through executeCommand (which checks args length
+// first), but listCommand is a distinct unit that should not panic if
+// called directly with no subcommand.
+func TestReplListCommand_EmptyArgs(t *testing.T) {
+	s := newTestReplState("")
+	s.listCommand(nil) // should not panic
+}
+
+// TestReplAddCommand_EmptyArgs is addCommand's equivalent of
+// TestReplListCommand_EmptyArgs.
+func TestReplAddCommand_EmptyArgs(t *testing.T) {
+	s := newTestReplState("")
+	s.addCommand(nil) // should not panic
+}
+
+// TestReplRemoveRelationship_OnlyFromGiven covers
+// removeRelationshipCommand's own len(args)<2 guard specifically (distinct
+// from TestReplRemoveRelationship_InsufficientArgs, which supplies zero
+// args and never gets past removeCommand's own length check).
+func TestReplRemoveRelationship_OnlyFromGiven(t *testing.T) {
+	s := newTestReplState("")
+	s.removeCommand([]string{"relationship", "a"}) // missing <to>
+	if len(s.undoStack) != 0 {
+		t.Errorf("undo stack should be cleaned up, got len %d", len(s.undoStack))
+	}
+}
+
+// TestReplListRelationships_Sorted covers listRelationships' sort
+// comparator's tie-breaking branches (same From, different To; same
+// From+To, different Label) — a single-relationship model never exercises
+// the comparator body at all.
+func TestReplListRelationships_Sorted(t *testing.T) {
+	s := newTestReplState("")
+	s.model.Model["shop"] = model.Element{Kind: "system", Title: "Shop"}
+	s.model.Relationships = []model.Relationship{
+		{From: "customer", To: "shop", Label: "browses"},
+		{From: "customer", To: "webshop", Label: "uses"},
+		{From: "customer", To: "webshop", Label: "buys"},
+	}
+	s.listRelationships() // should not panic; ordering itself isn't asserted here
+}
+
+// TestReplListViews covers listViews' loop, never exercised by the default
+// test model (which has zero views).
+func TestReplListViews(t *testing.T) {
+	s := newTestReplState("")
+	s.model.Views = map[string]model.View{
+		"overview": {Title: "Overview"},
+	}
+	s.listViews() // should not panic
+}
+
+// TestReplRemoveRelationship_KeepsOthers covers the loop's "keep" branch in
+// removeRelationshipCommand: removing one relationship out of several must
+// leave the others in place, not just empty the whole slice.
+func TestReplRemoveRelationship_KeepsOthers(t *testing.T) {
+	s := newTestReplState("")
+	s.model.Relationships = []model.Relationship{
+		{From: "customer", To: "webshop", Label: "uses"},
+		{From: "webshop", To: "customer", Label: "notifies"},
+	}
+	s.removeCommand([]string{"relationship", "customer", "webshop"})
+	if len(s.model.Relationships) != 1 {
+		t.Fatalf("expected 1 relationship to remain, got %d", len(s.model.Relationships))
+	}
+	if s.model.Relationships[0].From != "webshop" {
+		t.Errorf("expected the unrelated relationship to survive, got %+v", s.model.Relationships[0])
+	}
+}
+
+// TestReplAddElement_HappyPath covers addElementInteractive's full
+// completion tail (undo save, Model-map init, final assignment) — every
+// other add-element test aborts partway through.
+func TestReplAddElement_HappyPath(t *testing.T) {
+	s := newTestReplState("newservice\nsystem\nNew Service\nA new service\n")
+	s.addElementInteractive()
+	elem, ok := s.model.Model["newservice"]
+	if !ok {
+		t.Fatal("expected element 'newservice' to be added")
+	}
+	if elem.Kind != "system" || elem.Title != "New Service" || elem.Description != "A new service" {
+		t.Errorf("unexpected element: %+v", elem)
+	}
+	if !s.modified {
+		t.Error("expected s.modified to be true")
+	}
+}
+
+// TestReplAddElement_UnknownKind covers promptElementKind's rejection
+// branch: a kind not present in the model's specification.
+func TestReplAddElement_UnknownKind(t *testing.T) {
+	s := newTestReplState("newservice\nbogus\n")
+	s.addElementInteractive()
+	if _, ok := s.model.Model["newservice"]; ok {
+		t.Error("element should not have been added (unknown kind)")
+	}
+}
+
+// TestDescribePreservedFields_AllFields covers every branch of
+// describePreservedFields — the existing overwrite test only ever exercises
+// an element with none of these fields set.
+func TestDescribePreservedFields_AllFields(t *testing.T) {
+	existing := model.Element{
+		Children:   map[string]model.Element{"child": {}},
+		Technology: "Go",
+		Tags:       []string{"core"},
+		Status:     "active",
+		Decisions:  []string{"ADR-001"},
+		Metadata:   map[string]string{"owner": "team-a"},
+	}
+	preserved := describePreservedFields(existing)
+	for _, want := range []string{"1 child(ren)", "technology", "tags", "status", "decisions", "metadata"} {
+		found := false
+		for _, p := range preserved {
+			if p == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in preserved fields, got: %v", want, preserved)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fourth PR working through #623. Fixes all 3 `go:S3776` findings in `cmd/bausteinsicht/repl.go`.

## Changes

Split each flagged function's switch/sequential-branch structure into named methods:

- `listCommand` (18 → low single digits): `elements`/`relationships`/`views` cases extracted as `listElements`/`listRelationships`/`listViews`.
- `addElementInteractive` (29 → 8): the sequential ID/existing-check/kind/title/description prompt logic split into `promptElementID`, `confirmOverwriteExistingElement` (+ `describePreservedFields`), `promptElementKind`, `promptElementTitle`, `promptElementDescription`.
- `removeCommand` (21 → 5): `element`/`relationship` cases extracted as `removeElementCommand`/`removeRelationshipCommand`.

Learned from PR #626's quality-gate failure last time: added coverage for the extracted functions' branches up front, before pushing, rather than in a follow-up commit — the existing test suite never exercised the empty-args guards (only reachable calling a method directly, since `executeCommand` already checks args length before dispatching), the multi-relationship sort comparator or multi-view list (the shared test model has 0 relationships/views), the unknown-kind rejection, the full add-element happy path (every existing add test aborts partway through), or most of `describePreservedFields`' branches (the existing overwrite test only sets one field).

## Type of Change

- [x] Improvement/refactoring — behavior-preserving only, no new logic, no CLI/output change.

## Testing

- Verified locally with `gocognit`: no touched function exceeds 9; CI's/SonarCloud's threshold is 15. (`runRepl` at 20 is a pre-existing, untouched violation outside this PR's diff and outside #623's flagged findings.)
- `go build ./...`, `go vet ./...`, `gofmt -l`, `staticcheck ./cmd/bausteinsicht/...` all clean.
- `go test ./...` — all packages pass.
- New-code coverage on every extracted function is 100% except `listRelationships`/`addElementInteractive` (91.7% each) — the remaining gaps are the same class of hard-to-trigger defensive branch (e.g. `saveUndo`'s JSON marshal failure) accepted in prior PRs in this series.

## Documentation

N/A — internal refactor, no user-visible or cross-command effect.

Refs #623