### PR TITLE
refactor(sonar): reduce cognitive complexity in remaining #623 findings

### DIFF
--- a/cmd/bausteinsicht/repl_save.go
+++ b/cmd/bausteinsicht/repl_save.go
@@ -45,15 +45,34 @@ func (s *replState) saveCommand() error {
 // model using comment-preserving patch operations. Falls back by returning an error
 // whenever any existing element was modified or any relationship was removed or changed
 // (which require a full rewrite). Only pure inserts use the comment-preserving path.
+// relSig is a relationship's full-value identity, used to compare
+// relationships as a multiset (they have no stable ID like elements do).
+type relSig struct{ from, to, label, kind string }
+
 func (s *replState) patchSave() error {
 	onDisk, err := model.Load(s.modelPath)
 	if err != nil {
 		return fmt.Errorf("reading model: %w", err)
 	}
 
-	// Reject element deletions or modifications (value-based compare).
+	if err := rejectModifiedElements(onDisk, s.model); err != nil {
+		return err
+	}
+	if err := rejectModifiedRelationships(onDisk, s.model); err != nil {
+		return err
+	}
+	if err := s.insertNewElements(onDisk); err != nil {
+		return err
+	}
+	return s.appendNewRelationships(onDisk)
+}
+
+// rejectModifiedElements returns an error if any element present in onDisk
+// was deleted or value-modified in mem — patchSave only ever adds, never
+// edits, so any such change requires a full save instead.
+func rejectModifiedElements(onDisk, mem *model.BausteinsichtModel) error {
 	for id, onDiskElem := range onDisk.Model {
-		memElem, ok := s.model.Model[id]
+		memElem, ok := mem.Model[id]
 		if !ok {
 			return fmt.Errorf("element %q was deleted; full save required", id)
 		}
@@ -61,11 +80,14 @@ func (s *replState) patchSave() error {
 			return fmt.Errorf("element %q was modified; full save required", id)
 		}
 	}
+	return nil
+}
 
-	// Reject relationship deletions or modifications (multiset compare by full value).
-	type relSig struct{ from, to, label, kind string }
-	memRelMultiset := make(map[relSig]int, len(s.model.Relationships))
-	for _, r := range s.model.Relationships {
+// rejectModifiedRelationships returns an error if any relationship present
+// in onDisk is missing from mem (compared as a multiset by full value).
+func rejectModifiedRelationships(onDisk, mem *model.BausteinsichtModel) error {
+	memRelMultiset := make(map[relSig]int, len(mem.Relationships))
+	for _, r := range mem.Relationships {
 		memRelMultiset[relSig{r.From, r.To, r.Label, r.Kind}]++
 	}
 	for _, r := range onDisk.Relationships {
@@ -75,8 +97,12 @@ func (s *replState) patchSave() error {
 		}
 		memRelMultiset[sig]--
 	}
+	return nil
+}
 
-	// Insert new top-level elements.
+// insertNewElements patches onto disk every top-level element present in
+// s.model but not yet in onDisk.
+func (s *replState) insertNewElements(onDisk *model.BausteinsichtModel) error {
 	for id, elem := range s.model.Model {
 		if _, exists := onDisk.Model[id]; exists {
 			continue
@@ -93,8 +119,12 @@ func (s *replState) patchSave() error {
 			return fmt.Errorf("inserting element %s: %w", capturedID, perr)
 		}
 	}
+	return nil
+}
 
-	// Append only truly new relationships (those not already on disk).
+// appendNewRelationships patches onto disk every relationship in s.model
+// that isn't already present on disk (compared as a multiset by full value).
+func (s *replState) appendNewRelationships(onDisk *model.BausteinsichtModel) error {
 	onDiskRelMultiset := make(map[relSig]int, len(onDisk.Relationships))
 	for _, r := range onDisk.Relationships {
 		onDiskRelMultiset[relSig{r.From, r.To, r.Label, r.Kind}]++
@@ -116,7 +146,6 @@ func (s *replState) patchSave() error {
 			return fmt.Errorf("appending relationship: %w", perr)
 		}
 	}
-
 	return nil
 }
 

--- a/cmd/bausteinsicht/repl_save_test.go
+++ b/cmd/bausteinsicht/repl_save_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -425,6 +426,9 @@ func TestReplOverwrite_EmptyDescriptionKeepsExisting(t *testing.T) {
 // from TestReplPatchSave_InvalidModelPath, which fails at the initial
 // model.Load (read) step.
 func TestReplPatchSave_InsertFailsOnReadOnlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict directory write access on Windows (ACL-based, not POSIX mode bits)")
+	}
 	s, path := newFileReplState(t, "")
 	s.model.Model["newelement"] = model.Element{Kind: "actor", Title: "New"}
 
@@ -445,6 +449,9 @@ func TestReplPatchSave_InsertFailsOnReadOnlyDir(t *testing.T) {
 // (no new element, so insertNewElements is a no-op and never reaches its
 // own PatchInsert call).
 func TestReplPatchSave_AppendRelationshipFailsOnReadOnlyDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not restrict directory write access on Windows (ACL-based, not POSIX mode bits)")
+	}
 	s, path := newFileReplState(t, "")
 	s.model.Relationships = append(s.model.Relationships, model.Relationship{From: "customer", To: "webshop", Label: "uses"})
 

--- a/cmd/bausteinsicht/repl_save_test.go
+++ b/cmd/bausteinsicht/repl_save_test.go
@@ -416,3 +416,45 @@ func TestReplOverwrite_EmptyDescriptionKeepsExisting(t *testing.T) {
 		t.Errorf("empty input should keep existing description, got %q", got)
 	}
 }
+
+// TestReplPatchSave_InsertFailsOnReadOnlyDir covers insertNewElements' (and
+// transitively patchSave's) PatchInsert error branch: model.Load succeeds
+// (the file itself is readable), but the write fails because PatchInsert
+// writes atomically via a temp file in the same directory (model/patch.go),
+// which needs write permission on the *directory*, not the file — distinct
+// from TestReplPatchSave_InvalidModelPath, which fails at the initial
+// model.Load (read) step.
+func TestReplPatchSave_InsertFailsOnReadOnlyDir(t *testing.T) {
+	s, path := newFileReplState(t, "")
+	s.model.Model["newelement"] = model.Element{Kind: "actor", Title: "New"}
+
+	dir := filepath.Dir(path)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o700) }() // restore so t.TempDir() cleanup can remove it
+
+	if err := s.patchSave(); err == nil {
+		t.Fatal("expected an error writing to a model whose directory is read-only")
+	}
+}
+
+// TestReplPatchSave_AppendRelationshipFailsOnReadOnlyDir is
+// TestReplPatchSave_InsertFailsOnReadOnlyDir's relationship counterpart —
+// covers appendNewRelationships' own PatchInsert error branch specifically
+// (no new element, so insertNewElements is a no-op and never reaches its
+// own PatchInsert call).
+func TestReplPatchSave_AppendRelationshipFailsOnReadOnlyDir(t *testing.T) {
+	s, path := newFileReplState(t, "")
+	s.model.Relationships = append(s.model.Relationships, model.Relationship{From: "customer", To: "webshop", Label: "uses"})
+
+	dir := filepath.Dir(path)
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o700) }()
+
+	if err := s.patchSave(); err == nil {
+		t.Fatal("expected an error writing to a model whose directory is read-only")
+	}
+}

--- a/cmd/bausteinsicht/snapshot_diff.go
+++ b/cmd/bausteinsicht/snapshot_diff.go
@@ -25,57 +25,59 @@ func newSnapshotDiffCmd() *cobra.Command {
 }
 
 func runSnapshotDiff(cmd *cobra.Command, args []string) error {
-	snapshotID1 := args[0]
 	format, _ := cmd.Flags().GetString("format")
 	modelPath, _ := cmd.Flags().GetString("model")
 
 	manager := snapshot.NewManager(".")
 
-	// Load first snapshot
-	if !manager.Exists(snapshotID1) {
-		return exitWithCode(fmt.Errorf("snapshot not found: %s", snapshotID1), 2)
-	}
-
-	snap1, err := manager.Load(snapshotID1)
+	model1, err := loadSnapshotModel(manager, args[0])
 	if err != nil {
-		return exitWithCode(fmt.Errorf("loading snapshot %s: %w", snapshotID1, err), 2)
-	}
-	if snap1 == nil || snap1.Model == nil {
-		return exitWithCode(fmt.Errorf("snapshot %s contains no model data", snapshotID1), 1)
+		return err
 	}
 
-	var model2 *model.BausteinsichtModel
+	model2, err := resolveSecondModel(manager, args, modelPath)
+	if err != nil {
+		return err
+	}
 
-	// Load second snapshot or current state
+	diffs := diffModels(model1, model2)
+	return writeDiffOutput(cmd, diffs, format)
+}
+
+// loadSnapshotModel loads snapshot id and returns its model, failing if the
+// snapshot doesn't exist or carries no model data.
+func loadSnapshotModel(manager *snapshot.Manager, id string) (*model.BausteinsichtModel, error) {
+	if !manager.Exists(id) {
+		return nil, exitWithCode(fmt.Errorf("snapshot not found: %s", id), 2)
+	}
+	snap, err := manager.Load(id)
+	if err != nil {
+		return nil, exitWithCode(fmt.Errorf("loading snapshot %s: %w", id, err), 2)
+	}
+	if snap == nil || snap.Model == nil {
+		return nil, exitWithCode(fmt.Errorf("snapshot %s contains no model data", id), 1)
+	}
+	return snap.Model, nil
+}
+
+// resolveSecondModel returns the second comparand: a second snapshot's
+// model when args carries two IDs, otherwise the current on-disk model.
+func resolveSecondModel(manager *snapshot.Manager, args []string, modelPath string) (*model.BausteinsichtModel, error) {
 	if len(args) == 2 {
-		snapshotID2 := args[1]
-		if !manager.Exists(snapshotID2) {
-			return exitWithCode(fmt.Errorf("snapshot not found: %s", snapshotID2), 2)
-		}
-		snap2, err := manager.Load(snapshotID2)
-		if err != nil {
-			return exitWithCode(fmt.Errorf("loading snapshot %s: %w", snapshotID2, err), 2)
-		}
-		if snap2 == nil || snap2.Model == nil {
-			return exitWithCode(fmt.Errorf("snapshot %s contains no model data", snapshotID2), 1)
-		}
-		model2 = snap2.Model
-	} else {
-		// Load current model
-		if modelPath == "" {
-			modelPath = "architecture.jsonc"
-		}
-		m, err := model.Load(modelPath)
-		if err != nil {
-			return exitWithCode(fmt.Errorf("loading current model: %w", err), 2)
-		}
-		model2 = m
+		return loadSnapshotModel(manager, args[1])
 	}
+	if modelPath == "" {
+		modelPath = "architecture.jsonc"
+	}
+	m, err := model.Load(modelPath)
+	if err != nil {
+		return nil, exitWithCode(fmt.Errorf("loading current model: %w", err), 2)
+	}
+	return m, nil
+}
 
-	// Compare models
-	diffs := diffModels(snap1.Model, model2)
-
-	// Output results
+// writeDiffOutput renders diffs in the requested format to cmd's stdout.
+func writeDiffOutput(cmd *cobra.Command, diffs *ModelDiff, format string) error {
 	switch format {
 	case "json":
 		data, err := json.MarshalIndent(diffs, "", "  ")
@@ -88,7 +90,6 @@ func runSnapshotDiff(cmd *cobra.Command, args []string) error {
 	default:
 		return exitWithCode(fmt.Errorf("unknown format: %s", format), 2)
 	}
-
 	return nil
 }
 

--- a/cmd/bausteinsicht/snapshot_diff_test.go
+++ b/cmd/bausteinsicht/snapshot_diff_test.go
@@ -210,3 +210,92 @@ func TestSnapshotDiffCmdNotFound(t *testing.T) {
 		t.Fatal("expected error for nonexistent snapshot")
 	}
 }
+
+// TestSnapshotDiffCmd_AgainstCurrentModel covers resolveSecondModel's
+// "no second snapshot ID given" branch: diffing a single snapshot against
+// the current on-disk model instead of a second snapshot. Every other test
+// in this file passes two snapshot IDs.
+func TestSnapshotDiffCmd_AgainstCurrentModel(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	snap1Model := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"system": {Title: "System", Kind: "system"},
+		},
+		Relationships: []model.Relationship{},
+	}
+	currentModel := &model.BausteinsichtModel{
+		Model: map[string]model.Element{
+			"system": {Title: "System", Kind: "system"},
+			"new":    {Title: "New Element", Kind: "component"},
+		},
+		Relationships: []model.Relationship{},
+	}
+
+	manager := snapshot.NewManager(tmpDir)
+	snap1 := snapshot.NewSnapshot("first snapshot", snap1Model)
+	if err := manager.Save(snap1); err != nil {
+		t.Fatalf("failed to save snapshot: %v", err)
+	}
+	if err := model.Save(tmpDir+"/architecture.jsonc", currentModel); err != nil {
+		t.Fatalf("failed to write current model: %v", err)
+	}
+
+	cmd := newSnapshotDiffCmd()
+	cmd.SetArgs([]string{snap1.ID, "--format", "text"})
+
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalWd) }()
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("new")) {
+		t.Fatalf("expected diff output with 'new' element, got: %s", buf.String())
+	}
+}
+
+// TestSnapshotDiffCmd_UnknownFormat covers writeDiffOutput's default/unknown
+// format branch.
+func TestSnapshotDiffCmd_UnknownFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	m1 := &model.BausteinsichtModel{Model: map[string]model.Element{}, Relationships: []model.Relationship{}}
+	m2 := &model.BausteinsichtModel{Model: map[string]model.Element{}, Relationships: []model.Relationship{}}
+
+	manager := snapshot.NewManager(tmpDir)
+	snap1 := snapshot.NewSnapshot("first", m1)
+	if err := manager.Save(snap1); err != nil {
+		t.Fatalf("failed to save first snapshot: %v", err)
+	}
+	time.Sleep(1 * time.Second)
+	snap2 := snapshot.NewSnapshot("second", m2)
+	if err := manager.Save(snap2); err != nil {
+		t.Fatalf("failed to save second snapshot: %v", err)
+	}
+
+	cmd := newSnapshotDiffCmd()
+	cmd.SetArgs([]string{snap1.ID, snap2.ID, "--format", "bogus"})
+
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+	defer func() { _ = os.Chdir(originalWd) }()
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for an unknown --format value")
+	}
+}

--- a/internal/overlay/apply.go
+++ b/internal/overlay/apply.go
@@ -46,8 +46,18 @@ func Apply(drawioPath string, metrics *MetricsFile, metricKey string, scheme Col
 	normalized := Normalize(extracted, higherIsBetter)
 
 	root := doc.Root()
+	applyColorToMxCells(root, normalized, scheme)
+	applyColorToObjectWrappedCells(root, normalized, scheme)
 
-	// Bare mxCell children (hand-crafted or connector elements)
+	if err := doc.WriteToFile(drawioPath); err != nil {
+		return fmt.Errorf("writing draw.io file: %w", err)
+	}
+	return nil
+}
+
+// applyColorToMxCells colors bare mxCell children (hand-crafted or
+// connector elements), keyed by their own "id" attribute.
+func applyColorToMxCells(root *etree.Element, normalized map[string]float64, scheme ColorScheme) {
 	for _, cell := range root.FindElements(".//mxGraphModel/root/mxCell") {
 		elementID := cell.SelectAttrValue("id", "")
 		if elementID == "" || elementID == "0" || elementID == "1" {
@@ -57,9 +67,12 @@ func Apply(drawioPath string, metrics *MetricsFile, metricKey string, scheme Col
 			applyColor(cell, normVal, scheme)
 		}
 	}
+}
 
-	// <object>-wrapped elements (bausteinsicht sync output).
-	// Match on bausteinsicht_id so metrics.json uses model IDs, not page-scoped draw.io IDs.
+// applyColorToObjectWrappedCells colors <object>-wrapped elements
+// (bausteinsicht sync output). Matches on bausteinsicht_id so metrics.json
+// uses model IDs, not page-scoped draw.io IDs.
+func applyColorToObjectWrappedCells(root *etree.Element, normalized map[string]float64, scheme ColorScheme) {
 	for _, obj := range root.FindElements(".//mxGraphModel/root/object") {
 		bsID := obj.SelectAttrValue("bausteinsicht_id", "")
 		if bsID == "" {
@@ -72,11 +85,6 @@ func Apply(drawioPath string, metrics *MetricsFile, metricKey string, scheme Col
 			}
 		}
 	}
-
-	if err := doc.WriteToFile(drawioPath); err != nil {
-		return fmt.Errorf("writing draw.io file: %w", err)
-	}
-	return nil
 }
 
 func Remove(drawioPath string) error {

--- a/internal/overlay/apply_test.go
+++ b/internal/overlay/apply_test.go
@@ -426,3 +426,31 @@ func TestApply_InvalidMetricKey(t *testing.T) {
 		t.Error("expected error for unknown metric key, got nil")
 	}
 }
+
+// TestApply_FileNotFound covers Apply's ReadFromFile error branch.
+func TestApply_FileNotFound(t *testing.T) {
+	metrics := metricsFor(map[string]float64{"a": 50})
+	err := Apply("/nonexistent/path.drawio", metrics, "coverage", DefaultColorScheme)
+	if err == nil {
+		t.Error("expected error for a nonexistent draw.io file, got nil")
+	}
+}
+
+// TestApply_ObjectWithoutBausteinsichtID covers
+// applyColorToObjectWrappedCells' bsID=="" skip branch: an <object> element
+// with no bausteinsicht_id attribute at all (unlike drawioWithObjects,
+// which always sets one).
+func TestApply_ObjectWithoutBausteinsichtID(t *testing.T) {
+	xml := `<?xml version="1.0"?><mxfile><diagram><mxGraphModel><root>` +
+		`<mxCell id="0"/><mxCell id="1" parent="0"/>` +
+		`<object id="stray-obj"><mxCell style="fillColor=#ffffff;" vertex="1" parent="1"/></object>` +
+		`</root></mxGraphModel></diagram></mxfile>`
+	path := writeTempDrawio(t, xml)
+	metrics := metricsFor(map[string]float64{"stray-obj": 50})
+
+	if err := Apply(path, metrics, "coverage", DefaultColorScheme); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// No assertion beyond "did not panic/error" — the object has no
+	// bausteinsicht_id, so it must simply be skipped, not matched.
+}

--- a/internal/stale/drawio.go
+++ b/internal/stale/drawio.go
@@ -30,31 +30,37 @@ func MarkInDrawio(staleElements []StaleElement, drawioPath string) error {
 	}
 
 	for _, page := range pages {
-		root := page.Root()
-		if root == nil {
-			continue
-		}
-
-		idMap := make(map[string]*etree.Element)
-		for _, obj := range root.SelectElements("object") {
-			if bausteinsichtID := obj.SelectAttr("bausteinsicht_id"); bausteinsichtID != nil {
-				idMap[bausteinsichtID.Value] = obj
-			}
-		}
-
-		for _, staleElem := range staleElements {
-			obj, exists := idMap[staleElem.ID]
-			if !exists {
-				continue
-			}
-			markStaleElement(obj, staleElem)
-		}
+		markPageStaleElements(page, staleElements)
 	}
 
 	if err := drawio.SaveDocument(drawioPath, doc); err != nil {
 		return fmt.Errorf("saving draw.io document: %w", err)
 	}
 	return nil
+}
+
+// markPageStaleElements marks the stale elements present on page, matching
+// by bausteinsicht_id.
+func markPageStaleElements(page *drawio.Page, staleElements []StaleElement) {
+	root := page.Root()
+	if root == nil {
+		return
+	}
+
+	idMap := make(map[string]*etree.Element)
+	for _, obj := range root.SelectElements("object") {
+		if bausteinsichtID := obj.SelectAttr("bausteinsicht_id"); bausteinsichtID != nil {
+			idMap[bausteinsichtID.Value] = obj
+		}
+	}
+
+	for _, staleElem := range staleElements {
+		obj, exists := idMap[staleElem.ID]
+		if !exists {
+			continue
+		}
+		markStaleElement(obj, staleElem)
+	}
 }
 
 // UnmarkInDrawio removes stale visual indicators from all diagram pages,
@@ -73,51 +79,9 @@ func UnmarkInDrawio(drawioPath string) (int, error) {
 			continue
 		}
 		for _, obj := range root.SelectElements("object") {
-			cell := obj.FindElement("mxCell")
-			if cell == nil {
-				continue
+			if unmarkStaleElement(obj) {
+				count++
 			}
-			originalFillAttr := cell.SelectAttr(overlay.OriginalFillAttr)
-			if originalFillAttr == nil {
-				continue
-			}
-			style := cell.SelectAttrValue("style", "")
-			if originalFillAttr.Value == "" {
-				// fillColor was originally absent — remove it instead of restoring a value.
-				style = removeStyleProperties(style, []string{"fillColor"})
-			} else {
-				style = setStyleProperty(style, "fillColor", originalFillAttr.Value)
-			}
-
-			// Restore original stroke color: if it was absent originally, remove the key.
-			originalStroke := cell.SelectAttrValue(originalStrokeColorAttr, "")
-			if originalStroke != "" {
-				style = setStyleProperty(style, "strokeColor", originalStroke)
-			} else {
-				style = removeStyleProperties(style, []string{"strokeColor"})
-			}
-
-			// Restore original stroke width: if it was absent originally, remove the key.
-			originalWidth := cell.SelectAttrValue(originalStrokeWidthAttr, "")
-			if originalWidth != "" {
-				style = setStyleProperty(style, "strokeWidth", originalWidth)
-			} else {
-				style = removeStyleProperties(style, []string{"strokeWidth"})
-			}
-
-			cell.CreateAttr("style", style)
-			cell.RemoveAttr(overlay.OriginalFillAttr)
-			cell.RemoveAttr(originalStrokeColorAttr)
-			cell.RemoveAttr(originalStrokeWidthAttr)
-
-			// Restore original tooltip (remove the stale tooltip if none was set before).
-			originalTooltip := obj.SelectAttrValue(originalTooltipAttr, "")
-			obj.RemoveAttr("tooltip")
-			obj.RemoveAttr(originalTooltipAttr)
-			if originalTooltip != "" {
-				obj.CreateAttr("tooltip", originalTooltip)
-			}
-			count++
 		}
 	}
 
@@ -125,6 +89,67 @@ func UnmarkInDrawio(drawioPath string) (int, error) {
 		return 0, fmt.Errorf("saving draw.io document: %w", err)
 	}
 	return count, nil
+}
+
+// unmarkStaleElement restores obj's original fill/stroke/tooltip from the
+// data-original-* attributes markStaleElement recorded, and removes those
+// attributes. Reports whether obj actually was marked (had a saved fill).
+func unmarkStaleElement(obj *etree.Element) bool {
+	cell := obj.FindElement("mxCell")
+	if cell == nil {
+		return false
+	}
+	originalFillAttr := cell.SelectAttr(overlay.OriginalFillAttr)
+	if originalFillAttr == nil {
+		return false
+	}
+
+	restoreCellStyle(cell, originalFillAttr.Value)
+	restoreTooltip(obj)
+	return true
+}
+
+// restoreCellStyle rewrites cell's style attribute, restoring (or removing,
+// if it was originally absent) fillColor/strokeColor/strokeWidth from the
+// data-original-* attributes, then removes those attributes.
+func restoreCellStyle(cell *etree.Element, originalFill string) {
+	style := cell.SelectAttrValue("style", "")
+	if originalFill == "" {
+		// fillColor was originally absent — remove it instead of restoring a value.
+		style = removeStyleProperties(style, []string{"fillColor"})
+	} else {
+		style = setStyleProperty(style, "fillColor", originalFill)
+	}
+
+	// Restore original stroke color: if it was absent originally, remove the key.
+	if originalStroke := cell.SelectAttrValue(originalStrokeColorAttr, ""); originalStroke != "" {
+		style = setStyleProperty(style, "strokeColor", originalStroke)
+	} else {
+		style = removeStyleProperties(style, []string{"strokeColor"})
+	}
+
+	// Restore original stroke width: if it was absent originally, remove the key.
+	if originalWidth := cell.SelectAttrValue(originalStrokeWidthAttr, ""); originalWidth != "" {
+		style = setStyleProperty(style, "strokeWidth", originalWidth)
+	} else {
+		style = removeStyleProperties(style, []string{"strokeWidth"})
+	}
+
+	cell.CreateAttr("style", style)
+	cell.RemoveAttr(overlay.OriginalFillAttr)
+	cell.RemoveAttr(originalStrokeColorAttr)
+	cell.RemoveAttr(originalStrokeWidthAttr)
+}
+
+// restoreTooltip restores obj's original tooltip, removing the stale
+// tooltip if none was set before.
+func restoreTooltip(obj *etree.Element) {
+	originalTooltip := obj.SelectAttrValue(originalTooltipAttr, "")
+	obj.RemoveAttr("tooltip")
+	obj.RemoveAttr(originalTooltipAttr)
+	if originalTooltip != "" {
+		obj.CreateAttr("tooltip", originalTooltip)
+	}
 }
 
 // markStaleElement applies a risk-color fill to the mxCell of an <object> element.

--- a/internal/stale/drawio_test.go
+++ b/internal/stale/drawio_test.go
@@ -318,3 +318,68 @@ func TestRemoveStyleProperties_EmptyStyle(t *testing.T) {
 		t.Errorf("expected empty string, got: %s", got)
 	}
 }
+
+// TestMarkInDrawio_NoPages covers MarkInDrawio's "no diagram page found"
+// branch: a syntactically valid draw.io document with zero <diagram> pages.
+func TestMarkInDrawio_NoPages(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?><mxfile></mxfile>`
+	path := writeTempDrawio(t, xml)
+
+	err := MarkInDrawio([]StaleElement{{ID: "shop.api"}}, path)
+	if err == nil {
+		t.Fatal("expected an error for a document with no pages")
+	}
+}
+
+// TestUnmarkStaleElement_NoCell covers unmarkStaleElement's cell==nil
+// branch: an <object> with no mxCell child.
+func TestUnmarkStaleElement_NoCell(t *testing.T) {
+	obj := etree.NewElement("object")
+	obj.CreateAttr("bausteinsicht_id", "shop.api")
+	if unmarkStaleElement(obj) {
+		t.Error("expected unmarkStaleElement to report false for an object with no mxCell")
+	}
+}
+
+// TestUnmarkInDrawio_RestoresOriginalStrokeAndTooltip covers the
+// "restore a non-empty original value" branches of restoreCellStyle
+// (strokeColor/strokeWidth) and restoreTooltip, which
+// TestUnmarkInDrawio_RestoresOriginalFill's fixture leaves unset (only
+// exercising the "was absent, remove it" branches).
+func TestUnmarkInDrawio_RestoresOriginalStrokeAndTooltip(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>` +
+		`<mxfile><diagram id="d1" name="Page"><mxGraphModel><root>` +
+		`<mxCell id="0"/><mxCell id="1" parent="0"/>` +
+		`<object bausteinsicht_id="shop.api" tooltip="⚠ STALE" data-original-tooltip="Original tooltip">` +
+		`<mxCell id="cell1" style="fillColor=#FF6666;strokeColor=#FF6666;strokeWidth=2;" ` +
+		`data-original-fill="#dae8fc" data-original-stroke-color="#000000" data-original-stroke-width="1" ` +
+		`vertex="1" parent="1"/>` +
+		`</object>` +
+		`</root></mxGraphModel></diagram></mxfile>`
+	path := writeTempDrawio(t, xml)
+
+	count, err := UnmarkInDrawio(path)
+	if err != nil {
+		t.Fatalf("UnmarkInDrawio: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 unmarked element, got %d", count)
+	}
+
+	tree := etree.NewDocument()
+	if err := tree.ReadFromFile(path); err != nil {
+		t.Fatalf("reading saved file: %v", err)
+	}
+	obj := tree.FindElement("//object[@bausteinsicht_id='shop.api']")
+	cell := obj.FindElement("mxCell")
+	style := cell.SelectAttrValue("style", "")
+	if !strings.Contains(style, "strokeColor=#000000") {
+		t.Errorf("expected original strokeColor restored, got style: %s", style)
+	}
+	if !strings.Contains(style, "strokeWidth=1") {
+		t.Errorf("expected original strokeWidth restored, got style: %s", style)
+	}
+	if obj.SelectAttrValue("tooltip", "") != "Original tooltip" {
+		t.Errorf("expected original tooltip restored, got: %q", obj.SelectAttrValue("tooltip", ""))
+	}
+}


### PR DESCRIPTION
## Description

Fifth and final PR working through #623. Fixes the last 5 flagged `go:S3776` findings.

## Changes

- `internal/overlay/apply.go`: `Apply` (17 → 4) splits its two element-loops into `applyColorToMxCells`/`applyColorToObjectWrappedCells`.
- `cmd/bausteinsicht/repl_save.go`: `patchSave` (21 → 4) splits into `rejectModifiedElements`, `rejectModifiedRelationships`, `insertNewElements`, `appendNewRelationships` (`relSig` moved to package scope so the reject/append helpers can share it).
- `cmd/bausteinsicht/snapshot_diff.go`: `runSnapshotDiff` (18 → 2) splits into `loadSnapshotModel` (also deduplicates the original's two near-identical snapshot-loading blocks), `resolveSecondModel`, `writeDiffOutput`.
- `internal/stale/drawio.go`: `MarkInDrawio` (16 → 4) splits off `markPageStaleElements`; `UnmarkInDrawio` (28 → 10) splits off `unmarkStaleElement`/`restoreCellStyle`/`restoreTooltip`.

Learned from #626's gate failure and #627's near-miss: added coverage for every extracted function's previously-untested branches before pushing this time. One notable snag: the read-only-**file** trick that worked for #621's `os.WriteFile` branch does *not* trigger `PatchInsert`'s failure mode here, since it writes atomically via a temp file in the same directory (`os.CreateTemp`) rather than writing the target file directly — needed a read-only **directory** instead.

## Type of Change

- [x] Improvement/refactoring — behavior-preserving only, no new logic, no CLI/output change.

## Testing

- Verified locally with `gocognit`: no touched function exceeds 10; CI's/SonarCloud's threshold is 15. (`formatDiffText`/`diffModels` in `snapshot_diff.go` are pre-existing, untouched violations outside this PR's diff and outside #623's flagged findings — same pattern as `runRepl` in #627 and `populateNewPage` in #625.)
- `go build ./...`, `go vet ./...`, `gofmt -l`, `staticcheck` all clean.
- `go test ./...` — all packages pass.
- New-code coverage on every extracted function is 87–100%; remaining gaps are the same class of hard-to-trigger defensive I/O-failure branch (`SaveDocument`/`json.Marshal` errors) accepted in prior PRs in this series.

## Closes out #623

Verified live against the SonarCloud API as each PR merged: **26 → 8 → 5 → 0** open findings (#624 → #625 → #626 → #627, this PR closes the last 5). The `add_specification.go` duplication (100% density, the one clear fix candidate from the original duplication survey) is also gone since #624. The remaining `internal/diagram/{html,dot,d2}.go` 3-way duplication cluster was assessed in #623 and deliberately left as-is — legitimate structural similarity across sibling exporters, not a defect.

## Documentation

N/A — internal refactor, no user-visible or cross-command effect.

Closes #623